### PR TITLE
docs(trustgate): add Actions API section

### DIFF
--- a/api-reference/endpoint/actions/create-policy.mdx
+++ b/api-reference/endpoint/actions/create-policy.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Create Policy'
+openapi: 'POST /v1/policies'
+---

--- a/api-reference/endpoint/actions/execute.mdx
+++ b/api-reference/endpoint/actions/execute.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Execute Actions'
+openapi: 'POST /v1/actions'
+---

--- a/api-reference/endpoint/apikey/create.mdx
+++ b/api-reference/endpoint/apikey/create.mdx
@@ -1,4 +1,4 @@
 ---
 title: 'Create Api Key'
-openapi: 'POST /api/v1/gateways/{gateway_id}/keys'
+openapi: 'POST /api/v1/iam/api-key'
 ---

--- a/api-reference/endpoint/apikey/delete.mdx
+++ b/api-reference/endpoint/apikey/delete.mdx
@@ -1,4 +1,4 @@
 ---
 title: 'Delete Api Key'
-openapi: 'DELETE /api/v1/gateways/{gateway_id}/keys/{key_id}'
+openapi: 'DELETE /api/v1/iam/api-key/{key_id}'
 ---

--- a/api-reference/endpoint/apikey/list.mdx
+++ b/api-reference/endpoint/apikey/list.mdx
@@ -1,4 +1,4 @@
 ---
 title: 'List Api Keys'
-openapi: 'GET /api/v1/gateways/{gateway_id}/keys'
+openapi: 'GET /api/v1/iam/api-key/public'
 ---

--- a/api-reference/endpoint/apikey/retrieve.mdx
+++ b/api-reference/endpoint/apikey/retrieve.mdx
@@ -1,4 +1,4 @@
 ---
 title: 'Retrieve Api Key'
-openapi: 'GET /api/v1/gateways/{gateway_id}/keys/{key_id}'
+openapi: 'GET /api/v1/iam/api-key/public'
 ---

--- a/api-reference/openapi-actions.json
+++ b/api-reference/openapi-actions.json
@@ -1,0 +1,993 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "TrustGate-EE",
+        "contact": {
+            "name": "NeuralTrust",
+            "url": "https://neuraltrust.ai/contact",
+            "email": "support@neuraltrust.ai"
+        },
+        "version": "v1.7.53"
+    },
+    "paths": {
+        "/api/v1/gateways/{gateway_id}/consumer-groups": {
+            "get": {
+                "description": "Retrieves all consumer groups for a given gateway",
+                "tags": [
+                    "Consumer Groups"
+                ],
+                "summary": "List Consumer Groups",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of consumer groups",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a consumer group for a given gateway",
+                "tags": [
+                    "Consumer Groups"
+                ],
+                "summary": "Create a new Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/ConsumerGroup"
+                },
+                "responses": {
+                    "201": {
+                        "description": "Consumer group created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/gateways/{gateway_id}/consumer-groups/{group_id}": {
+            "get": {
+                "description": "Retrieves a consumer group by its ID within a gateway",
+                "tags": [
+                    "Consumer Groups"
+                ],
+                "summary": "Get Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Consumer Group ID",
+                        "name": "group_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Consumer group details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Consumer group not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates a consumer group by its ID within a gateway",
+                "tags": [
+                    "Consumer Groups"
+                ],
+                "summary": "Update Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Consumer Group ID",
+                        "name": "group_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/ConsumerGroup"
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated consumer group",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Consumer group not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Deletes a consumer group by its ID within a gateway",
+                "tags": [
+                    "Consumer Groups"
+                ],
+                "summary": "Delete Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Consumer Group ID",
+                        "name": "group_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Consumer group not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/gateways/{gateway_id}/consumer-groups/{group_id}/keys": {
+            "get": {
+                "description": "Retrieves all API keys assigned to a consumer group",
+                "tags": [
+                    "Consumer Groups",
+                    "API Keys"
+                ],
+                "summary": "List API Keys of Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Consumer Group ID",
+                        "name": "group_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of consumer group API keys",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Assigns an existing API key to a consumer group",
+                "tags": [
+                    "Consumer Groups",
+                    "API Keys"
+                ],
+                "summary": "Assign API Key to Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Consumer Group ID",
+                        "name": "group_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.AssignConsumerGroupApiKeyRequest"
+                            }
+                        }
+                    },
+                    "description": "API Key assignment body",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Consumer group API key created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/gateways/{gateway_id}/consumer-groups/{group_id}/keys/{key_id}": {
+            "delete": {
+                "description": "Deletes an API key assignment from a consumer group",
+                "tags": [
+                    "Consumer Groups",
+                    "API Keys"
+                ],
+                "summary": "Delete API Key from Consumer Group",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Consumer Group ID",
+                        "name": "group_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "API Key ID",
+                        "name": "key_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/actions": {
+            "post": {
+                "description": "Executes a set of actions defined by a policy",
+                "tags": [
+                    "Actions"
+                ],
+                "summary": "Execute Actions",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.ExecuteActionsRequest"
+                            }
+                        }
+                    },
+                    "description": "Execute actions request",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Execution result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/actions.ExecuteActionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Policy not allowed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/policies": {
+            "post": {
+                "description": "Creates a new policy with actions, telemetry and TrustLens configuration",
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "Create Policy",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.CreatePoliciesRequest"
+                            }
+                        }
+                    },
+                    "description": "Create policy request",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Policy created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/http.createPolicyResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "requestBodies": {
+            "ConsumerGroup": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                },
+                "description": "Consumer Group body",
+                "required": true
+            }
+        },
+        "schemas": {
+            "action.Action": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "parallel": {
+                        "type": "boolean"
+                    },
+                    "priority": {
+                        "type": "integer"
+                    },
+                    "settings": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                }
+            },
+            "actions.ActionResult": {
+                "type": "object",
+                "properties": {
+                    "data": {},
+                    "plugin_name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "actions.ExecuteActionsResponse": {
+                "type": "object",
+                "properties": {
+                    "error": {},
+                    "metadata": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/actions.ActionResult"
+                        }
+                    },
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    },
+                    "status": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "http.createPolicyResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.AssignConsumerGroupApiKeyRequest": {
+                "type": "object",
+                "required": [
+                    "api_key_id",
+                    "group_id",
+                    "name"
+                ],
+                "properties": {
+                    "api_key_id": {
+                        "type": "string"
+                    },
+                    "expires_at": {
+                        "type": "string"
+                    },
+                    "group_id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.CreatePoliciesRequest": {
+                "type": "object",
+                "properties": {
+                    "actions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/action.Action"
+                        }
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "telemetry": {
+                        "$ref": "#/components/schemas/request.TelemetryRequest"
+                    },
+                    "trustlens": {
+                        "$ref": "#/components/schemas/request.TrustLensConfigRequest"
+                    }
+                }
+            },
+            "request.ExecuteActionsRequest": {
+                "type": "object",
+                "required": [
+                    "payload"
+                ],
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    },
+                    "policy_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.ExporterRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "settings": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                }
+            },
+            "request.TelemetryRequest": {
+                "type": "object",
+                "properties": {
+                    "enable_plugin_traces": {
+                        "type": "boolean"
+                    },
+                    "enable_request_traces": {
+                        "type": "boolean"
+                    },
+                    "exporters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/request.ExporterRequest"
+                        }
+                    },
+                    "extra_params": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "header_mapping": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "request.TrustLensConfigRequest": {
+                "type": "object",
+                "properties": {
+                    "app_id": {
+                        "type": "string"
+                    },
+                    "mapping": {
+                        "$ref": "#/components/schemas/request.TrustLensMappingRequest"
+                    },
+                    "team_id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.TrustLensMappingDataRequest": {
+                "type": "object",
+                "properties": {
+                    "data_projection": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "extract_fields": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "request.TrustLensMappingRequest": {
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "$ref": "#/components/schemas/request.TrustLensMappingDataRequest"
+                    },
+                    "output": {
+                        "$ref": "#/components/schemas/request.TrustLensMappingDataRequest"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -252,186 +252,6 @@
                 }
             }
         },
-        "/api/v1/gateways/{gateway_id}/keys": {
-            "post": {
-                "description": "Generates a new API key for the specified gateway",
-                "tags": [
-                    "API Keys"
-                ],
-                "parameters": [
-                    {
-                        "description": "Authorization token",
-                        "name": "Authorization",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Gateway ID",
-                        "name": "gateway_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.CreateAPIKeyRequest"
-                            }
-                        }
-                    },
-                    "description": "API Key request body",
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "API Key created successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/apikey.APIKey"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request data",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/gateways/{gateway_id}/keys/{key_id}": {
-            "delete": {
-                "description": "Removes an API key from a gateway",
-                "tags": [
-                    "API Keys"
-                ],
-                "parameters": [
-                    {
-                        "description": "Authorization token",
-                        "name": "Authorization",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Gateway ID",
-                        "name": "gateway_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "API Key ID",
-                        "name": "key_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "API Key deleted successfully"
-                    },
-                    "404": {
-                        "description": "API Key not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/gateways/{gateway_id}/public-keys": {
-            "get": {
-                "description": "Returns a list of all API keys for a gateway with obfuscated key values",
-                "tags": [
-                    "API Keys"
-                ],
-                "parameters": [
-                    {
-                        "description": "Authorization token",
-                        "name": "Authorization",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Gateway ID",
-                        "name": "gateway_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of API Keys with obfuscated keys",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/apikey.APIKey"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Gateway not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/gateways/{gateway_id}/rules": {
             "get": {
                 "description": "Returns a list of all rules for a gateway",
@@ -1235,6 +1055,293 @@
                 }
             }
         },
+        "/api/v1/iam/api-key": {
+            "post": {
+                "description": "Generates a new API key for the specified gateway",
+                "tags": [
+                    "API Keys"
+                ],
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.CreateAPIKeyRequest"
+                            }
+                        }
+                    },
+                    "description": "API Key request body",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "API Key created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/apikey.APIKey"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/iam/api-key/public": {
+            "get": {
+                "description": "Returns a list of all API keys for a gateway with obfuscated key values",
+                "tags": [
+                    "API Keys"
+                ],
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of API Keys with obfuscated keys",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/apikey.APIKey"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Gateway not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/iam/api-key/{key_id}": {
+            "delete": {
+                "description": "Removes an API key. If the key is scoped to a gateway (GatewayType), provide ?subject_id=<gateway_uuid>.",
+                "tags": [
+                    "API Keys"
+                ],
+                "summary": "Delete an API Key",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "API Key ID",
+                        "name": "key_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/iam/api-key/{key_id}/policies": {
+            "put": {
+                "description": "Updates the set of allowed rule IDs (policies) for an API key",
+                "tags": [
+                    "API Keys"
+                ],
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Gateway ID",
+                        "name": "gateway_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "API Key ID",
+                        "name": "key_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/http.updateAPIKeyPoliciesRequest"
+                            }
+                        }
+                    },
+                    "description": "Policies update payload",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "API Key updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/apikey.APIKey"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "API key not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/plugins": {
             "get": {
                 "description": "Returns the list of available plugins",
@@ -1251,6 +1358,61 @@
                                     "items": {
                                         "$ref": "#/components/schemas/plugins.PluginDefinition"
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates the plugin chain for a given gateway or rule with granular add/edit/delete operations",
+                "tags": [
+                    "Plugins"
+                ],
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.UpdatePluginsRequest"
+                            }
+                        }
+                    },
+                    "description": "Update plugins payload",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "Plugins updated successfully"
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Entity not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
                                 }
                             }
                         }
@@ -1278,6 +1440,146 @@
                     }
                 }
             }
+        },
+        "/v1/actions": {
+            "post": {
+                "description": "Executes a set of actions defined by a policy",
+                "tags": [
+                    "Actions"
+                ],
+                "summary": "Execute Actions",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.ExecuteActionsRequest"
+                            }
+                        }
+                    },
+                    "description": "Execute actions request",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Execution result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/actions.ExecuteActionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Policy not allowed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/policies": {
+            "post": {
+                "description": "Creates a new policy with actions, telemetry and TrustLens configuration",
+                "tags": [
+                    "Policies"
+                ],
+                "summary": "Create Policy",
+                "parameters": [
+                    {
+                        "description": "Authorization token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/request.CreatePoliciesRequest"
+                            }
+                        }
+                    },
+                    "description": "Create policy request",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Policy created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/http.createPolicyResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -1291,13 +1593,7 @@
                     "created_at": {
                         "type": "string"
                     },
-                    "deleted_at": {
-                        "type": "string"
-                    },
                     "expires_at": {
-                        "type": "string"
-                    },
-                    "gateway_id": {
                         "type": "string"
                     },
                     "id": {
@@ -1308,8 +1604,31 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "policies": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subject": {
+                        "type": "string"
+                    },
+                    "subject_type": {
+                        "$ref": "#/components/schemas/apikey.SubjectType"
                     }
                 }
+            },
+            "apikey.SubjectType": {
+                "type": "string",
+                "enum": [
+                    "policy",
+                    "gateway"
+                ],
+                "x-enum-varnames": [
+                    "PolicyType",
+                    "GatewayType"
+                ]
             },
             "domain.ClientTLSConfig": {
                 "type": "object",
@@ -1320,10 +1639,6 @@
             "domain.CredentialsJSON": {
                 "type": "object",
                 "properties": {
-                    "allow_override": {
-                        "description": "General settings",
-                        "type": "boolean"
-                    },
                     "api_key": {
                         "description": "Api Key",
                         "type": "string"
@@ -1351,6 +1666,12 @@
                         "type": "string"
                     },
                     "azure_client_secret": {
+                        "type": "string"
+                    },
+                    "azure_endpoint": {
+                        "type": "string"
+                    },
+                    "azure_eversion": {
                         "type": "string"
                     },
                     "azure_tenant_id": {
@@ -1552,9 +1873,6 @@
                     "status": {
                         "type": "string"
                     },
-                    "subdomain": {
-                        "type": "string"
-                    },
                     "telemetry": {
                         "$ref": "#/components/schemas/telemetry.Telemetry"
                     },
@@ -1583,6 +1901,17 @@
                     }
                 }
             },
+            "http.updateAPIKeyPoliciesRequest": {
+                "type": "object",
+                "properties": {
+                    "policies": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "plugins.PluginDefinition": {
                 "type": "object",
                 "properties": {
@@ -1608,6 +1937,15 @@
                         "type": "string"
                     }
                 }
+            },
+            "request.AuthType": {
+                "type": "string",
+                "enum": [
+                    "oauth2"
+                ],
+                "x-enum-varnames": [
+                    "AuthTypeOAuth2"
+                ]
             },
             "request.ClientTLSCertRequest": {
                 "type": "object",
@@ -1655,6 +1993,32 @@
                     }
                 }
             },
+            "request.CreateAPIKeyRequest": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "expires_at": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "policies": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subject": {
+                        "type": "string"
+                    },
+                    "subject_type": {
+                        "type": "string"
+                    }
+                }
+            },
             "request.CreateGatewayRequest": {
                 "type": "object",
                 "properties": {
@@ -1684,10 +2048,6 @@
                         "$ref": "#/components/schemas/request.SessionConfigRequest"
                     },
                     "status": {
-                        "type": "string"
-                    },
-                    "subdomain": {
-                        "description": "@required",
                         "type": "string"
                     },
                     "telemetry": {
@@ -1749,6 +2109,38 @@
                     }
                 }
             },
+            "request.PluginOperation": {
+                "type": "string",
+                "enum": [
+                    "add",
+                    "edit",
+                    "delete"
+                ],
+                "x-enum-varnames": [
+                    "PluginOperationAdd",
+                    "PluginOperationEdit",
+                    "PluginOperationDelete"
+                ]
+            },
+            "request.PluginUpdate": {
+                "type": "object",
+                "properties": {
+                    "old_plugin_name": {
+                        "description": "For edit operation, we can optionally specify which plugin to update by name\nif the name itself is being changed",
+                        "type": "string"
+                    },
+                    "operation": {
+                        "$ref": "#/components/schemas/request.PluginOperation"
+                    },
+                    "plugin": {
+                        "$ref": "#/components/schemas/types.PluginConfig"
+                    },
+                    "plugin_name": {
+                        "description": "For delete operation, we only need the plugin name",
+                        "type": "string"
+                    }
+                }
+            },
             "request.ProxyConfigRequest": {
                 "type": "object",
                 "properties": {
@@ -1756,6 +2148,9 @@
                         "type": "string"
                     },
                     "port": {
+                        "type": "string"
+                    },
+                    "protocol": {
                         "type": "string"
                     }
                 }
@@ -1833,9 +2228,23 @@
                     }
                 }
             },
+            "request.TargetAuthRequest": {
+                "type": "object",
+                "properties": {
+                    "oauth": {
+                        "$ref": "#/components/schemas/request.UpstreamOAuthRequest"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/request.AuthType"
+                    }
+                }
+            },
             "request.TargetRequest": {
                 "type": "object",
                 "properties": {
+                    "auth": {
+                        "$ref": "#/components/schemas/request.TargetAuthRequest"
+                    },
                     "credentials": {
                         "$ref": "#/components/schemas/types.Credentials"
                     },
@@ -1872,14 +2281,15 @@
                     "port": {
                         "type": "integer"
                     },
-                    "priority": {
-                        "type": "integer"
-                    },
                     "protocol": {
                         "type": "string"
                     },
                     "provider": {
                         "type": "string"
+                    },
+                    "provider_options": {
+                        "type": "object",
+                        "additionalProperties": {}
                     },
                     "stream": {
                         "type": "boolean"
@@ -1956,11 +2366,96 @@
                     }
                 }
             },
+            "request.UpdatePluginsRequest": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "updates": {
+                        "description": "Granular updates for add/edit/delete operations",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/request.PluginUpdate"
+                        }
+                    }
+                }
+            },
+            "request.UpstreamAuthRequest": {
+                "type": "object",
+                "properties": {
+                    "oauth": {
+                        "$ref": "#/components/schemas/request.UpstreamOAuthRequest"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/request.AuthType"
+                    }
+                }
+            },
+            "request.UpstreamOAuthRequest": {
+                "type": "object",
+                "properties": {
+                    "audience": {
+                        "type": "string"
+                    },
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    },
+                    "code_verifier": {
+                        "type": "string"
+                    },
+                    "extra": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "grant_type": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "redirect_uri": {
+                        "type": "string"
+                    },
+                    "refresh_token": {
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "token_url": {
+                        "type": "string"
+                    },
+                    "use_basic_auth": {
+                        "type": "boolean"
+                    },
+                    "username": {
+                        "type": "string"
+                    }
+                }
+            },
             "request.UpstreamRequest": {
                 "type": "object",
                 "properties": {
                     "algorithm": {
                         "type": "string"
+                    },
+                    "auth": {
+                        "$ref": "#/components/schemas/request.UpstreamAuthRequest"
                     },
                     "embedding": {
                         "$ref": "#/components/schemas/request.EmbeddingRequest"
@@ -2056,8 +2551,17 @@
                             "$ref": "#/components/schemas/types.PluginConfig"
                         }
                     },
+                    "preserve_host": {
+                        "type": "boolean"
+                    },
+                    "retry_attempts": {
+                        "type": "integer"
+                    },
                     "service_id": {
                         "type": "string"
+                    },
+                    "strip_path": {
+                        "type": "boolean"
                     },
                     "trustlens": {
                         "$ref": "#/components/schemas/domain.TrustLensJSON"
@@ -2164,11 +2668,8 @@
                     "protocol": {
                         "type": "string"
                     },
-                    "retries": {
-                        "description": "Common settings",
-                        "type": "integer"
-                    },
                     "stream": {
+                        "description": "Common settings",
                         "type": "boolean"
                     },
                     "tags": {
@@ -2280,20 +2781,6 @@
                     }
                 }
             },
-            "types.CreateAPIKeyRequest": {
-                "type": "object",
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "expires_at": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                }
-            },
             "types.CreateRuleRequest": {
                 "type": "object",
                 "required": [
@@ -2346,10 +2833,6 @@
             "types.Credentials": {
                 "type": "object",
                 "properties": {
-                    "allow_override": {
-                        "description": "General settings",
-                        "type": "boolean"
-                    },
                     "api_key": {
                         "description": "Api Key",
                         "type": "string"
@@ -2377,6 +2860,12 @@
                         "type": "string"
                     },
                     "azure_client_secret": {
+                        "type": "string"
+                    },
+                    "azure_endpoint": {
+                        "type": "string"
+                    },
+                    "azure_eversion": {
                         "type": "string"
                     },
                     "azure_tenant_id": {
@@ -2622,6 +3111,15 @@
                     }
                 }
             },
+            "upstream.AuthType": {
+                "type": "string",
+                "enum": [
+                    "oauth2"
+                ],
+                "x-enum-varnames": [
+                    "AuthTypeOAuth2"
+                ]
+            },
             "upstream.EmbeddingConfig": {
                 "type": "object",
                 "properties": {
@@ -2666,12 +3164,18 @@
                     },
                     "port": {
                         "type": "string"
+                    },
+                    "protocol": {
+                        "type": "string"
                     }
                 }
             },
             "upstream.Target": {
                 "type": "object",
                 "properties": {
+                    "auth": {
+                        "$ref": "#/components/schemas/upstream.TargetAuth"
+                    },
                     "credentials": {
                         "$ref": "#/components/schemas/domain.CredentialsJSON"
                     },
@@ -2705,14 +3209,15 @@
                     "port": {
                         "type": "integer"
                     },
-                    "priority": {
-                        "type": "integer"
-                    },
                     "protocol": {
                         "type": "string"
                     },
                     "provider": {
                         "type": "string"
+                    },
+                    "provider_options": {
+                        "type": "object",
+                        "additionalProperties": {}
                     },
                     "stream": {
                         "type": "boolean"
@@ -2725,6 +3230,70 @@
                     },
                     "weight": {
                         "type": "integer"
+                    }
+                }
+            },
+            "upstream.TargetAuth": {
+                "type": "object",
+                "properties": {
+                    "oauth": {
+                        "$ref": "#/components/schemas/upstream.TargetOAuthConfig"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/upstream.AuthType"
+                    }
+                }
+            },
+            "upstream.TargetOAuthConfig": {
+                "type": "object",
+                "properties": {
+                    "audience": {
+                        "type": "string"
+                    },
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    },
+                    "code_verifier": {
+                        "type": "string"
+                    },
+                    "extra": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "grant_type": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "redirect_uri": {
+                        "type": "string"
+                    },
+                    "refresh_token": {
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "token_url": {
+                        "type": "string"
+                    },
+                    "use_basic_auth": {
+                        "type": "boolean"
+                    },
+                    "username": {
+                        "type": "string"
                     }
                 }
             },
@@ -2798,6 +3367,141 @@
                     },
                     "write_buffer_size": {
                         "type": "integer"
+                    }
+                }
+            }
+            ,
+            "action.Action": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "parallel": {
+                        "type": "boolean"
+                    },
+                    "priority": {
+                        "type": "integer"
+                    },
+                    "settings": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                }
+            },
+            "actions.ActionResult": {
+                "type": "object",
+                "properties": {
+                    "data": {},
+                    "plugin_name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "actions.ExecuteActionsResponse": {
+                "type": "object",
+                "properties": {
+                    "error": {},
+                    "metadata": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/actions.ActionResult"
+                        }
+                    },
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    },
+                    "status": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "http.createPolicyResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.CreatePoliciesRequest": {
+                "type": "object",
+                "properties": {
+                    "actions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/action.Action"
+                        }
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "telemetry": {
+                        "$ref": "#/components/schemas/request.TelemetryRequest"
+                    },
+                    "trustlens": {
+                        "$ref": "#/components/schemas/request.TrustLensConfigRequest"
+                    }
+                }
+            },
+            "request.ExecuteActionsRequest": {
+                "type": "object",
+                "required": [
+                    "payload"
+                ],
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    },
+                    "policy_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.TrustLensConfigRequest": {
+                "type": "object",
+                "properties": {
+                    "app_id": {
+                        "type": "string"
+                    },
+                    "mapping": {
+                        "$ref": "#/components/schemas/request.TrustLensMappingRequest"
+                    },
+                    "team_id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "request.TrustLensMappingDataRequest": {
+                "type": "object",
+                "properties": {
+                    "data_projection": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "extract_fields": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "request.TrustLensMappingRequest": {
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "$ref": "#/components/schemas/request.TrustLensMappingDataRequest"
+                    },
+                    "output": {
+                        "$ref": "#/components/schemas/request.TrustLensMappingDataRequest"
                     }
                 }
             }

--- a/docs.json
+++ b/docs.json
@@ -22,7 +22,7 @@
   "navigation": {
     "dropdowns": [
       {
-        "dropdown": "TrustGate",
+        "dropdown": "trustgate",
         "description": "AI gateway to protect and scale your GenAI apps",
         "icon": "block-brick-fire",
         "groups": [
@@ -206,6 +206,14 @@
             ]
           },
           {
+            "group": "Actions API",
+            "icon": "bolt",
+            "pages": [
+              "trustgate/actions-api/overview",
+              "trustgate/actions-api/examples"
+            ]
+          },
+          {
             "group": "API Reference",
             "icon": "file",
             "pages": [
@@ -255,6 +263,13 @@
                   "api-reference/endpoint/rule/list",
                   "api-reference/endpoint/rule/update",
                   "api-reference/endpoint/rule/delete"
+                ]
+              },
+              {
+                "group": "Actions",
+                "pages": [
+                  "api-reference/endpoint/actions/execute",
+                  "api-reference/endpoint/actions/create-policy"
                 ]
               }
             ]

--- a/trustgate/actions-api/examples.mdx
+++ b/trustgate/actions-api/examples.mdx
@@ -1,0 +1,134 @@
+---
+title: API Examples
+---
+
+## Execute actions (`POST /v1/actions`)
+
+### Request example
+```bash
+curl -X POST \
+  https://<host>/v1/actions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -d '{
+    "policy_id": "1d9d3ad5-3d7a-4f0a-b1b5-5c2f9d6a1234",
+    "payload": {
+      "input_text": "Hello world",
+      "user_id": "u-123"
+    }
+  }'
+```
+
+### Successful response example (representative)
+```json
+{
+  "status": 200,
+  "headers": {
+    "Content-Type": ["application/json"]
+  },
+  "payload": {
+    "result": "...result of the action chain...",
+    "metadata": {"latency_ms": 42}
+  }
+}
+```
+
+### Error example: policy not allowed
+```json
+{
+  "error": "policy not allowed"
+}
+```
+
+### Validation error example
+```json
+{
+  "error": "invalid policy_id"
+}
+```
+
+---
+
+## Create policy (`POST /v1/policies`)
+
+### Request example
+```bash
+curl -X POST \
+  https://<host>/v1/policies \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <ADMIN_API_KEY>" \
+  -d '{
+    "name": "policy-textops",
+    "actions": [
+      {
+        "name": "sanitize",
+        "priority": 1,
+        "parallel": false,
+        "settings": {"level": "standard"}
+      },
+      {
+        "name": "classify",
+        "priority": 2,
+        "parallel": false,
+        "settings": {"labels": ["spam", "ham"]}
+      }
+    ],
+    "telemetry": {
+      "exporters": [
+        {"name": "otlp", "settings": {"endpoint": "https://otel.example"}}
+      ],
+      "extra_params": {"tenant": "acme"},
+      "enable_plugin_traces": true,
+      "enable_request_traces": false,
+      "header_mapping": {"x-request-id": "trace_id"}
+    },
+    "trustlens": {
+      "app_id": "app-123",
+      "team_id": "team-xyz",
+      "type": "sync",
+      "mapping": {
+        "input": {
+          "extract_fields": {"text": "$.payload.input_text"},
+          "data_projection": {"user": "$.payload.user_id"}
+        },
+        "output": {
+          "extract_fields": {"result": "$.payload.result"},
+          "data_projection": {}
+        }
+      }
+    }
+  }'
+```
+
+### Successful response
+```json
+{ "id": "7d1a02e1-8b17-4a28-8f8a-6f8b6c9b8e52" }
+```
+
+---
+
+## API Keys management (admin) (`/v1/iam/api-keys`)
+
+### Create example
+```bash
+curl -X POST \
+  https://<host>/v1/iam/api-keys \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <ADMIN_API_KEY>" \
+  -d '{
+    "name": "ci-bot",
+    "expires_at": "2025-12-31T23:59:59Z",
+    "scopes": ["actions:execute", "policies:write"],
+    "policies": ["1d9d3ad5-3d7a-4f0a-b1b5-5c2f9d6a1234"]
+  }'
+```
+
+---
+
+## End-to-end example
+
+1) Create a policy → save the `id`.
+2) Execute actions with that `policy_id` and a `payload`.
+3) Observe exported metrics (based on your `telemetry` configuration).
+
+

--- a/trustgate/actions-api/overview.mdx
+++ b/trustgate/actions-api/overview.mdx
@@ -1,0 +1,101 @@
+---
+title: Overview
+---
+
+## Actions API overview
+
+This page explains what the Actions API is, what it does, how it is accessed, and where to find practical examples.
+
+---
+
+## Summary and purpose
+
+The Actions API lets you:
+- Execute action chains defined in policies (`/v1/actions`).
+- Manage policies (create policies with actions, telemetry, and TrustLens) via admin endpoints (`/v1/policies`).
+- Manage administrative API keys (`/v1/iam/api-keys`).
+
+It is designed to run action flows with high performance and report execution telemetry and metrics.
+
+---
+
+## Authentication and access control
+
+- Execution (`/v1/actions`): requires an API key that is allowed to use the requested policy (allowed policies list).
+- Administration (`/v1/policies`, `/v1/iam/api-keys`): requires an API key with admin privileges.
+
+Notes:
+- If the requested policy is not allowed for the API key, the service returns 403 Forbidden.
+
+---
+
+## Endpoints
+
+### 1) Execute actions
+- Method and path: `POST /v1/actions`
+- Authentication: execution API key.
+- Body: `policy_id` and `payload` with the data to be processed by the policy.
+- Typical responses:
+  - `200 OK` with the result of the action chain.
+  - `400 Bad Request` if the input is invalid or the policy does not exist.
+  - `403 Forbidden` if the policy is not allowed for the API key.
+  - `5xx` for internal errors.
+
+How it works (high level): the policy defines the sequence of actions (including order and optional parallelization). The service runs the flow over your `payload` and emits metrics/telemetry if enabled.
+
+See examples on the [Examples](/trustgate/actions-api/examples) page.
+
+### 2) Create policy
+- Method and path: `POST /v1/policies`
+- Authentication: admin API key.
+- Body: optional name, one or more actions (with order and configuration), and optional telemetry and TrustLens settings.
+- Typical responses:
+  - `201 Created` with the policy identifier.
+  - `400 Bad Request` if the request is invalid.
+  - `500 Internal Server Error` if a storage error occurs.
+
+See examples on the [Examples](/trustgate/actions-api/examples) page.
+
+### 3) API keys management (admin)
+- Group: `/v1/iam/api-keys`
+- Authentication: admin API key.
+- Endpoints:
+  - `POST /v1/iam/api-keys` to create keys.
+  - `DELETE /v1/iam/api-keys` to delete keys.
+
+Note: requests usually include key metadata (name, expiration, and restrictions such as allowed policies). See the [Examples](/trustgate/actions-api/examples) page.
+
+---
+
+## Actions and policies model (high level)
+
+- A policy contains a list of actions and optional telemetry and TrustLens configuration.
+- Each action includes at least:
+  - `name`: the action or plugin to run.
+  - `priority`: relative order (integer).
+  - `parallel`: whether it may run in parallel when applicable.
+  - `settings`: action-specific configuration.
+- The execution endpoint applies the policy’s actions to your request payload and returns the result.
+
+---
+
+## Errors and status codes
+
+- `400 Bad Request`: the request is invalid (for example, malformed or unknown `policy_id`).
+- `403 Forbidden`: the API key is not authorized for the requested policy.
+- `5xx`: internal service errors.
+
+---
+
+## Best practices
+
+- Create the policy first (`/v1/policies`), keep its `id`, then call `/v1/actions` with that `policy_id`.
+- Limit access using API keys with allowed policies to scope execution.
+- Configure telemetry to match your observability needs; enable plugin-level traces when diagnosing performance.
+- Validate and sanitize your `payload` client-side; the server enforces basic validation.
+
+---
+
+For a complete creation-and-execution flow, see the end-to-end example on the [Examples](/trustgate/actions-api/examples) page.
+
+

--- a/trustgate/core-concepts/upstream-services-overview.mdx
+++ b/trustgate/core-concepts/upstream-services-overview.mdx
@@ -63,21 +63,117 @@ Targets represent the actual backend instances that handle incoming requests. Th
 
 ### 1. Target Properties
 
-The foundation of target management lies in properly configuring essential target properties. Each target requires a specific **host and port** configuration that defines its network location and access point. These basic connection parameters ensure the gateway can establish and maintain reliable connections to the backend service.
+Configure targets either as network endpoints (protocol/host/port) or as provider-based targets. Key properties include:
 
-The **weight for load balancing** property allows fine-grained control over traffic distribution. By assigning different weights to targets, administrators can influence how much traffic each target receives, enabling sophisticated load distribution strategies that account for varying server capacities and processing capabilities.
+1. Network endpoint (when not using a provider):
+   - **protocol**: Request protocol to upstream (e.g., `http`, `https`, `ws`, `wss`).
+   - **host** and **port**: Destination host and TCP port.
+   - **path**: Optional base path to prefix to all forwarded requests.
+   - **headers**: Static headers to append to every request sent to this target.
+   - **insecure_ssl**: Skip TLS certificate verification for `https`/`wss` when `true`.
 
-Targets can also be configured as **provider-based** instead of host/port endpoints. A provider-based target specifies a `provider`, `models`, and a `default_model` along with `credentials`. In this mode:
-- `host`/`port` must not be set
-- `credentials` are required
-- at least one entry in `models` is required
-- `default_model` is required and must be one of the `models`
+2. Provider-based (virtual) targets:
+   - **provider**: External AI provider identifier (e.g., `openai`, `anthropic`, etc.).
+   - **provider_options**: Free-form options required by the provider (JSON object).
+   - **models** and **default_model**: Allowed models and the default selection.
+   - **credentials**: Secret material used for provider authentication or templating.
+   - In this mode, do not set `host`/`port`.
 
-For host/port endpoints you may optionally configure **streaming** (`stream`) and **insecure SSL** (`insecure_ssl`) behavior where appropriate.
+3. Load balancing and behavior:
+   - **weight**: Relative weight for distributing requests to this target.
+   - **stream**: Enable streaming behavior to the upstream when supported.
+   - **tags** and **description**: Optional metadata for organizing and documenting targets.
 
-Comprehensive **health check settings** for each target enable customized monitoring approaches. These settings can be tailored to match the specific characteristics and requirements of each backend service, ensuring accurate health assessment and appropriate response to service degradation.
+4. Authentication:
+   - **auth**: Optional authentication block. See "Target Authentication (OAuth2)" below.
 
-### 2. Target States
+Comprehensive health check settings can be applied per target (see Health Checking above) to tailor monitoring and recovery behavior to each backend service.
+
+### 2. Target Authentication (OAuth2)
+
+Targets support OAuth2 for acquiring and attaching access tokens to upstream requests. Configure by setting `auth.type` to `oauth2` and providing the `oauth` options. Unless otherwise configured, tokens are added as `Authorization: Bearer <token>`.
+
+Required and optional fields:
+- **token_url** (required): OAuth2 token endpoint.
+- **grant_type** (required): One of `client_credentials`, `authorization_code`, `password`, or `refresh_token`.
+- **client_id**, **client_secret**: Client credentials as required by the grant.
+- **use_basic_auth**: When `true`, send client credentials via HTTP Basic Auth; otherwise send in the request body.
+- **scopes**: List of scopes to request.
+- **audience**: Audience parameter when required by the authorization server.
+- **code**, **redirect_uri**, **code_verifier**: Used for `authorization_code` grant (PKCE supported when `code_verifier` is present).
+- **username**, **password**: Used for `password` (Resource Owner Password) grant.
+- **refresh_token**: Used for `refresh_token` grant or to refresh expired tokens.
+- **extra**: Additional form parameters to include in the token request.
+
+Example: Client Credentials grant
+
+```json
+{
+  "targets": [
+    {
+      "protocol": "https",
+      "host": "api.example.com",
+      "port": 443,
+      "path": "/v1",
+      "auth": {
+        "type": "oauth2",
+        "oauth": {
+          "token_url": "https://auth.example.com/oauth/token",
+          "grant_type": "client_credentials",
+          "client_id": "your-client-id",
+          "client_secret": "your-client-secret",
+          "scopes": ["read", "write"],
+          "use_basic_auth": true
+        }
+      }
+    }
+  ]
+}
+```
+
+Example: Authorization Code with PKCE
+
+```json
+{
+  "auth": {
+    "type": "oauth2",
+    "oauth": {
+      "token_url": "https://auth.example.com/oauth/token",
+      "grant_type": "authorization_code",
+      "code": "<authorization_code>",
+      "redirect_uri": "https://your.app/callback",
+      "client_id": "your-client-id",
+      "code_verifier": "<pkce-code-verifier>",
+      "scopes": ["openid", "profile"]
+    }
+  }
+}
+```
+
+Example: Resource Owner Password Credentials
+
+```json
+{
+  "auth": {
+    "type": "oauth2",
+    "oauth": {
+      "token_url": "https://auth.example.com/oauth/token",
+      "grant_type": "password",
+      "client_id": "your-client-id",
+      "client_secret": "your-client-secret",
+      "username": "alice",
+      "password": "s3cret",
+      "scopes": ["read"]
+    }
+  }
+}
+```
+
+Notes:
+- When both `use_basic_auth=true` and client credentials are provided, the gateway sends them via the `Authorization` header to the token endpoint.
+- If `refresh_token` is provided or returned by the authorization server, it can be used to obtain new access tokens when previous ones expire.
+
+### 3. Target States
 
 Target states represent the operational status of backend instances and determine how they participate in request handling. A target in the **Healthy** state actively receives traffic and participates fully in the load balancing rotation. These targets have passed all health checks and are operating within expected parameters, making them eligible to handle incoming requests.
 

--- a/trustgate/getting-started/hello-gateway.mdx
+++ b/trustgate/getting-started/hello-gateway.mdx
@@ -61,20 +61,8 @@ curl http://localhost:8080/api/v1/gateways \
 ```
 </Accordion>
 
-<Accordion title="Step 2: Create an API Key" description="Generate an API key for authentication and access control">
-```bash
-# Create a test API key
-curl -X POST http://localhost:8080/api/v1/gateways/{gateway-id}/keys \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer jwt example" \
-  -d '{
-    "name": "test-key",
-    "expires_at": "2027-12-31T23:59:59Z"
-  }'
-```
-</Accordion>
 
-<Accordion title="Step 3: Create The Upstream" description="Configure upstream providers like OpenAI and Anthropic with load balancing">
+<Accordion title="Step 2: Create The Upstream" description="Configure upstream providers like OpenAI and Anthropic with load balancing">
 ```bash
 curl -X POST http://localhost:8080/api/v1/gateways/{gateway-id}/upstreams \
   -H "Content-Type: application/json" \
@@ -129,7 +117,7 @@ curl http://localhost:8080/api/v1/gateways/{gateway-id}/upstreams/{upstream-id} 
 ```
 </Accordion>
 
-<Accordion title="Step 4: Create the Service" description="Set up a service to handle routing and manage upstream connections">
+<Accordion title="Step 3: Create the Service" description="Set up a service to handle routing and manage upstream connections">
 Create your service using the Admin API:
 
 ```bash
@@ -154,7 +142,7 @@ curl http://localhost:8080/api/v1/gateways/{gateway-id}/services/{service-id} \
 ```
 </Accordion>
 
-<Accordion title="Step 5: Create a Rule" description="Define routing rules to direct traffic to your service">
+<Accordion title="Step 4: Create a Rule" description="Define routing rules to direct traffic to your service">
 Create your first rule using the Admin API:
 
 ```bash
@@ -181,10 +169,10 @@ curl http://localhost:8080/api/v1/gateways/{gateway-id}/rules \
 ```
 </Accordion>
 
-<Accordion title="Step 6: Test the Rules" description="Verify your configuration by making test requests to the gateway">
+<Accordion title="Step 5: Test the Rules" description="Verify your configuration by making test requests to the gateway">
 Test your rule configurations:
 
-**API Key:** You need to set the `x-api-key` header to the API key of your gateway, that you created in the Step 2.
+API Key (optional): If you plan to use API key authentication, create one in the Final Step below and set the `X-TG-API-Key` header to your key.
 
 ```bash
 # Test a route
@@ -200,6 +188,22 @@ curl -X POST http://localhost:8080/test \
       "include_usage": true
     },
     "max_tokens": 1024
+  }'
+```
+</Accordion>
+
+<Accordion title="Final Step: Create an API Key" description="Generate an API key for authentication and access control">
+```bash
+# Create an API key for your gateway and rule
+curl -X POST {{admin_host}}/api/v1/iam/api-keys \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer jwt example" \
+  -d '{
+    "name": "test-key",
+    "expires_at": "2026-01-01T00:00:00Z",
+    "subject_type": "gateway",
+    "subject": "{{gateway_id}}",
+    "policies": ["{{rule_id}}"]
   }'
 ```
 </Accordion>


### PR DESCRIPTION
- New Actions API category in navigation (docs.json)
- Add overview (product-focused, EN) and examples (EN) under trustgate/actions-api/
- Move examples out of overview and link accordingly
- Update Upstream targets docs with OAuth2 auth (TargetAuth, OAuth grants)
- Minor cleanup in getting-started and core concepts