### PR TITLE
docs(trustguard): clarify input/output direction in application integrations

### DIFF
--- a/trustguard/integrations/application.mdx
+++ b/trustguard/integrations/application.mdx
@@ -20,11 +20,41 @@ The response carries a `status` (`allow` / `report` / `transform` / `block`); th
 expose `is_blocked` / `isBlocked` (true when `status == "block"`) and the
 `transformed_payload` for masked content.
 
+## Input vs output (`direction`)
+
+TrustGuard does **not** infer whether a payload is a prompt or a completion. Every
+`guard()` / `/v1/evaluate` call must set **`direction`**:
+
+| `direction` | When to call | Policy rules that run |
+|---|---|---|
+| **`input`** | Before the model call (user prompt / request) | Detector rules configured for the **Input** phase |
+| **`output`** | After the model responds (completion / response) | Detector rules configured for the **Output** phase |
+
+A [policy](/trustguard/concepts/policies) can attach different detectors (and actions) to
+each phase — for example jailbreak / prompt injection on **input**, and PII or toxicity
+on **output**. Only rules whose phase matches the request's `direction` run; the other
+phase is skipped for that call.
+
+To cover both sides of a turn you call TrustGuard **twice**:
+
+```text
+user → guard(direction="input") → model → guard(direction="output") → user
+```
+
+If you only send `input`, output-phase detectors never evaluate. If you omit
+`direction`, it defaults to **`input`**.
+
+When traffic goes through [TrustGate](/trustguard/integrations/gateway) instead of your
+app, the gateway sets `direction` for you (`input` on the request path, `output` on the
+response path). Application integrations must set it explicitly.
+
+See [How it works](/trustguard/how-it-works) for how rules are filtered by direction.
+
 ## Python SDK
 
 1. `pip install neuraltrust-trustguard`
-2. Call `client.guard()` with `direction="input"` (prompt) or `direction="output"`
-   (completion).
+2. Call `client.guard()` with `direction="input"` before the model and
+   `direction="output"` on the completion.
 3. Pass `consumer_id` and `session_id` for attribution.
 4. Block when `is_blocked` is true; forward `transformed_payload` when present.
 
@@ -33,22 +63,36 @@ from trustguard import TrustGuard
 
 client = TrustGuard("<your-trustguard-url>", "<collector-api-key>")
 
-response = client.guard(
+# 1) Prompt — runs Input-phase detector rules
+inbound = client.guard(
     {"input": user_input},
-    direction="input",            # "output" for completions
+    direction="input",            # required for prompt / request evaluation
     consumer_id="alex@acme.com",  # who: user id, email, or device fingerprint
     session_id="sess-123",        # which conversation the message belongs to
 )
+if inbound.is_blocked:
+    raise PermissionError("Blocked by TrustGuard (input)")
+prompt = inbound.transformed_payload or {"input": user_input}
 
-if response.is_blocked:
-    raise PermissionError("Blocked by TrustGuard")
-# response.transformed_payload carries masked content when a Transform rule ran
+# … call your model with prompt …
+
+# 2) Completion — runs Output-phase detector rules
+outbound = client.guard(
+    {"input": model_completion},
+    direction="output",           # required for completion / response evaluation
+    consumer_id="alex@acme.com",
+    session_id="sess-123",
+)
+if outbound.is_blocked:
+    raise PermissionError("Blocked by TrustGuard (output)")
+# outbound.transformed_payload carries masked content when a Transform rule ran
 ```
 
 ## Node.js SDK
 
 1. `npm install @neuraltrust/trustguard-sdk`
-2. Call `client.guard()` with `direction` `"input"` / `"output"`.
+2. Call `client.guard()` with `direction: "input"` before the model and
+   `direction: "output"` on the completion.
 3. Pass `consumerId` and `sessionId`.
 4. Block when `isBlocked` is true; forward `transformedPayload` when present.
 
@@ -60,21 +104,36 @@ const client = new TrustGuard({
   apiKey: "<collector-api-key>",
 });
 
-const response = await client.guard({
+// 1) Prompt — runs Input-phase detector rules
+const inbound = await client.guard({
   payload: { input: userInput },
-  direction: "input",          // "output" for completions
+  direction: "input",          // required for prompt / request evaluation
   consumerId: user.id,         // who: user id, email, or device fingerprint
   sessionId: conversationId,   // which conversation the message belongs to
 });
+if (inbound.isBlocked) throw new Error("Blocked by TrustGuard (input)");
+const prompt = inbound.transformedPayload ?? { input: userInput };
 
-if (response.isBlocked) throw new Error("Blocked by TrustGuard");
-// response.transformedPayload carries masked content when a Transform rule ran
+// … call your model with prompt …
+
+// 2) Completion — runs Output-phase detector rules
+const outbound = await client.guard({
+  payload: { input: modelCompletion },
+  direction: "output",         // required for completion / response evaluation
+  consumerId: user.id,
+  sessionId: conversationId,
+});
+if (outbound.isBlocked) throw new Error("Blocked by TrustGuard (output)");
+// outbound.transformedPayload carries masked content when a Transform rule ran
 ```
 
 ## REST API
 
 Any language can call the guard endpoint directly (Go users: use the Go SDK instead of
-hand-rolling).
+hand-rolling). Set **`direction`** on every request — `"input"` for the prompt,
+`"output"` for the completion — so TrustGuard applies the matching policy phase.
+
+**Input (before the model):**
 
 ```bash
 curl -X POST "{TRUSTGUARD_URL}/v1/evaluate" \
@@ -87,14 +146,33 @@ curl -X POST "{TRUSTGUARD_URL}/v1/evaluate" \
     "session_id": "sess-123",
     "consumer_id": "alex@acme.com"
   }'
+```
 
-# Response:
+**Output (after the model):**
+
+```bash
+curl -X POST "{TRUSTGUARD_URL}/v1/evaluate" \
+  -H "Authorization: Bearer <collector-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "protocol": "llm",
+    "direction": "output",
+    "payload": { "input": "Here is a summary of the customer call…" },
+    "session_id": "sess-123",
+    "consumer_id": "alex@acme.com"
+  }'
+```
+
+```text
+# Response shape (both directions):
 # { "status": "allow", "findings": [], "transformed_payload": null, "trace_id": "…", "request_id": "…" }
 ```
 
 ## Python middleware (FastAPI / Django / Flask)
 
 Guard inbound user traffic in-process with a middleware in front of your AI routes.
+Middleware typically covers the **request** path — set `direction="input"`. Guard the
+model **response** in the route or service layer with `direction="output"`.
 
 ```python
 from fastapi import FastAPI, Request
@@ -110,6 +188,7 @@ async def trustguard_middleware(request: Request, call_next):
         body = await request.body()
         response = await client.guard(
             {"input": body.decode()},
+            direction="input",  # Input-phase detectors only
             consumer_id=request.headers.get("x-user-id", ""),
             session_id=request.cookies.get("session_id", ""),
         )
@@ -119,6 +198,9 @@ async def trustguard_middleware(request: Request, call_next):
 ```
 
 ## Node.js middleware (Express / Next.js)
+
+Same pattern: middleware for **input**; call `guard` again with `direction: "output"`
+after the model returns.
 
 ```ts
 import express from "express";
@@ -136,6 +218,7 @@ app.use(async (req, res, next) => {
   if (req.method !== "POST") return next();
   const response = await client.guard({
     payload: { input: JSON.stringify(req.body) },
+    direction: "input", // Input-phase detectors only
     consumerId: req.get("x-user-id") ?? "",
     sessionId: req.cookies?.session_id ?? "",
   });
@@ -148,8 +231,6 @@ app.use(async (req, res, next) => {
 
 ## Tips
 
-- Inspect both sides: `direction:"input"` before the model call, `direction:"output"`
-  on the completion.
 - Send documents/links via the `attachments` argument (folded into
   `payload.attachments`) to engage the
   [document and URL analyzers](/trustguard/detectors/content-security) — see the


### PR DESCRIPTION
## Summary
- Add an **Input vs output (`direction`)** section explaining that TrustGuard does not infer prompt vs completion, that policy Input/Output phases only run when `direction` matches, and that app integrations must call guard twice per turn.
- Expand Python/Node SDK examples to show both `input` and `output` calls with comments.
- Document REST with separate input and output curl examples (previously only input, uncommented).
- Middleware samples now set `direction: "input"` and note that output must be guarded in the route/service layer.
- Link to How it works / policies; trim redundant tip that duplicated the new section.

## Test plan
- [ ] Preview the page in Mintlify (`mintlify dev`) and confirm the new section reads clearly near the top
- [ ] Spot-check links: policies, how-it-works, gateway integration
- [ ] Confirm code blocks render for Python, TS, and both curl examples


Made with [Cursor](https://cursor.com)