### PR TITLE
docs(platform): fix Roles action permissions table on Users page

### DIFF
--- a/platform/users.mdx
+++ b/platform/users.mdx
@@ -144,8 +144,7 @@ Create and manage **custom** roles, or view predefined templates.
 |---|---|
 | Create custom role | IAM Admin+ |
 | View permissions | Anyone with Identity & Access visibility |
-| Duplicate / edit / delete | Custom roles only |
-| View Global Admin / Break the Glass | Yes (edit/duplicate blocked) |
+| Duplicate / edit / delete | IAM Admin+ |
 
 When inviting or editing a user, picking a role applies its template in one step. SSO [group mappings](/platform/user-sync) can also target platform roles.
 


### PR DESCRIPTION
## Summary
- Correct **Duplicate / edit / delete** to **IAM Admin+** (same bar as Create custom role). The previous “Custom roles only” wording described the target object, not who may act.
- Remove **View Global Admin / Break the Glass** — that visibility is already covered by **View permissions**. Structural templates remain view-only as stated in the Roles prose above the table.

## Test plan
- [ ] Confirm the Roles table on `/platform/users` matches product IAM behavior
- [ ] Spot-check that surrounding Roles prose still explains Global Admin / Break the Glass templates are not editable


Made with [Cursor](https://cursor.com)