### PR TITLE
docs(trustguard): cross-link policy Input/Output phases to runtime direction

### DIFF
--- a/trustguard/api/evaluate.mdx
+++ b/trustguard/api/evaluate.mdx
@@ -43,7 +43,7 @@ gateway authenticates and calls this endpoint for you.)
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `payload` | object | ✅ | The content to inspect. Accepts a minimal `{ "input": "…" }` or a full provider body (OpenAI, Anthropic, Gemini, MCP). `payload.attachments` is extracted separately (not sent to text detectors). |
-| `direction` | enum | — | `input` (default) or `output`. Selects which detector rules run. |
+| `direction` | enum | — | `input` (default) or `output`. Selects which [policy](/trustguard/concepts/policies) detector phase runs. [TrustGate](/trustguard/integrations/gateway) sets this for you; other collectors must send it on every call (usually twice per turn). |
 | `protocol` | enum | — | `all` (default) · `llm` · `mcp` · `a2a`. Available as the `protocol` gate/rule condition. |
 | `session_id` | string | — | Conversation key for multi‑turn analysis when enabled. Synthesised if omitted (treated as single‑turn). |
 | `consumer_id` | string | — | Actor identifier — drives per‑consumer policy routing and behavioral detectors when enabled. |
@@ -51,6 +51,13 @@ gateway authenticates and calls this endpoint for you.)
 
 Unknown top‑level fields are rejected with `400` (strict decoding). Do **not**
 send `input`, `metadata`, `collector_id`, or `detector_id` at the top level.
+
+<Note>
+`direction` chooses which policy **Detectors** phase runs (`Input` vs `Output`).
+If you only ever send `input` (or omit the field), Output-phase rules never
+evaluate. Details and SDK examples:
+[Application integrations](/trustguard/integrations/application).
+</Note>
 
 <Note>
 Callers that authenticate with a **service token** instead of an API key must

--- a/trustguard/concepts/collectors.mdx
+++ b/trustguard/concepts/collectors.mdx
@@ -34,9 +34,11 @@ instructions and a ready‑to‑paste snippet for the chosen integration. See
 
 <Note>
 **TrustGate is the first‑class collector.** When TrustGuard runs behind the
-gateway, the gateway calls `/v1/evaluate` for you and enforces the verdict
-natively. Other collectors call the same API directly and enforce the verdict
-themselves.
+gateway, the gateway calls `/v1/evaluate` for you, sets `direction`
+(`input` / `output`) from the request and response path, and enforces the
+verdict natively. Other collectors call the same API directly, must send
+`direction` themselves, and enforce the verdict themselves — see
+[Application integrations](/trustguard/integrations/application).
 </Note>
 
 ## Authentication & API keys

--- a/trustguard/concepts/detectors.mdx
+++ b/trustguard/concepts/detectors.mdx
@@ -27,8 +27,11 @@ one well-tuned detector across many policies with different enforcement.
 | **Enabled** | on / off | A disabled detector is skipped everywhere it's referenced. |
 
 A detector does **not** carry a mode, a direction, or a protocol. Those belong
-to the policy rule that puts the detector to work — see
-[Policies](/trustguard/concepts/policies).
+to the [policy](/trustguard/concepts/policies) rule that puts the detector to
+work (the **Input** / **Output** phase). At request time the collector must send
+matching `direction` on `/v1/evaluate` — [TrustGate](/trustguard/integrations/gateway)
+sets it automatically; [application](/trustguard/integrations/application) and
+other collectors must set it themselves.
 
 ## Settings
 

--- a/trustguard/concepts/policies.mdx
+++ b/trustguard/concepts/policies.mdx
@@ -69,6 +69,26 @@ phase**:
 - **Input** — evaluate the prompt/request.
 - **Output** — evaluate the completion/response.
 
+At runtime TrustGuard only runs the rules for the phase that matches the
+request's **`direction`** (`input` or `output`). The phase you configure here
+and the `direction` on each `/v1/evaluate` call must line up — otherwise those
+detectors never fire.
+
+<Note>
+**Who sets `direction`?**
+
+- **[TrustGate](/trustguard/integrations/gateway)** sets it for you (`input` on
+  the request path, `output` on the response path).
+- **Any other collector** (SDK, REST, browser, edge/WAF) must send `direction`
+  explicitly on each call — typically **two** evaluates per turn (prompt then
+  completion). Omitting it defaults to `input`, so Output-phase rules never run.
+
+See [Application integrations](/trustguard/integrations/application) for SDK/REST
+examples, [Integrations overview](/trustguard/integrations/overview) for the
+shared call shape, and [How it works](/trustguard/how-it-works) for how rules are
+filtered by direction.
+</Note>
+
 Each rule references one [detector](/trustguard/concepts/detectors), an
 **action**, and optional **conditions** (same attribute model as gates):
 

--- a/trustguard/how-it-works.mdx
+++ b/trustguard/how-it-works.mdx
@@ -45,8 +45,14 @@ All gates are evaluated and the most restrictive outcome wins.
 ## 4. Run the detector rules
 
 For the request's `direction` (`input` or `output`), TrustGuard runs the
-policy's matching **detector rules**. Rules are filtered by direction and by
-their optional conditions, then split by capability:
+policy's matching **detector rules** — the same **Input** / **Output** phases
+you configure on the [policy](/trustguard/concepts/policies). Rules are filtered
+by direction and by their optional conditions, then split by capability:
+
+The caller supplies `direction` on `/v1/evaluate`.
+[TrustGate](/trustguard/integrations/gateway) sets it from the request/response
+stage; [application](/trustguard/integrations/application) and other collectors
+must set it explicitly (default `input` if omitted).
 
 | Phase | Detectors | Execution |
 |---|---|---|

--- a/trustguard/integrations/overview.mdx
+++ b/trustguard/integrations/overview.mdx
@@ -50,10 +50,15 @@ elif status == "transform"  → forward transformed_payload instead
 else                        → forward unchanged
 ```
 
-Inspect **input** before calling the model and **output** before returning it — usually
-two calls per interaction. See the full contract in the [Evaluate API](/trustguard/api/evaluate).
+Inspect **input** before calling the model and **output** before returning it —
+usually **two** calls per interaction, each with the matching `direction`. That
+`direction` selects which [policy](/trustguard/concepts/policies) **Detectors**
+phase runs. **Exception:** [TrustGate](/trustguard/integrations/gateway) sets
+`direction` for you on the request and response path. See the full contract in
+the [Evaluate API](/trustguard/api/evaluate) and the SDK walkthrough in
+[Application integrations](/trustguard/integrations/application).
 
-## Two rules for every integration
+## Rules for every integration
 
 1. **Create the API key on the collector** and pass it as
    `Authorization: Bearer <key>`.
@@ -61,6 +66,8 @@ two calls per interaction. See the full contract in the [Evaluate API](/trustgua
    findings to the right user and conversation in **Activity** and power the multi-turn
    and behavioral detectors. Each snippet shows the natural source on its platform
    (auth context, headers, cookies).
+3. **Send `direction`** (`input` / `output`) unless TrustGate is the collector —
+   otherwise Output-phase (or Input-phase) policy rules will not run.
 
 ## SDKs
 


### PR DESCRIPTION
## Summary
Closes a docs gap where [Policies → Detectors](https://docs.neuraltrust.ai/trustguard/concepts/policies) explained Input/Output phases without saying how runtime traffic selects them.

- **Policies**: Note under Detectors — TrustGate sets `direction`; other collectors must send it; links to application / integrations / how-it-works.
- **Detectors / Collectors / How it works / Evaluate API / Integrations overview**: Same mental model (phase ↔ `direction`, TrustGate vs manual, default `input`).
- Renamed “Two rules” → “Rules for every integration” and added the `direction` rule.

Pairs with #111 (application page examples). Merge either order; no file overlap.

## Test plan
- [ ] Read Policies → Detectors Note; links resolve
- [ ] Spot-check Evaluate API `direction` row + Note
- [ ] Confirm Integrations overview lists three rules and TrustGate exception


Made with [Cursor](https://cursor.com)