### PR TITLE
docs(security): soften privacy/security claims; fix broken anchors

### DIFF
--- a/neuraltrust/data-privacy/overview.mdx
+++ b/neuraltrust/data-privacy/overview.mdx
@@ -11,15 +11,15 @@ NeuralTrust ensures complete data privacy and regulatory compliance for AI monit
 
 ### Data Sovereignty Model
 
-NeuralTrust's data sovereignty model ensures that your most sensitive information never leaves your cloud environment. All data processing occurs within your own infrastructure, giving you complete control over your data while still benefiting from advanced AI monitoring capabilities.
+Where data lives depends on how you deploy. NeuralTrust offers **SaaS** and **Hybrid** — see [Deployment models](/neuraltrust/deployment/deployment-models).
 
-Our architecture separates sensitive data processing from control plane management. Your personal data, proprietary information, and confidential AI models remain in your environment, while only privacy-safe metadata is shared with our Control Plane for system management and compliance analytics.
+| | **SaaS** | **Hybrid** |
+|---|---|---|
+| Raw payloads | NeuralTrust | Your PostgreSQL (data plane in your environment) |
+| Metadata / analytics | NeuralTrust | Exported to NeuralTrust (OTLP) |
+| Control plane | NeuralTrust | NeuralTrust |
 
-Key sovereignty features include:
-- **Your Environment**: All data processing occurs within your cloud environment
-- **Zero Data Export**: No sensitive data leaves your infrastructure
-- **Encrypted Communication**: Only privacy-safe metadata shared with Control Plane
-- **Customer Keys**: You control all encryption keys and data access
+On Hybrid, sensitive payloads stay in your infrastructure; privacy-safe metadata is shared with the control plane over encrypted channels. Encryption key options can be configured for your environment.
 
 ### Privacy-by-Design Features
 
@@ -91,7 +91,7 @@ Advanced anonymization techniques remove identifying information while preservin
 
 Protection controls include:
 - **End-to-End Encryption**: AES-256 encryption for all data at rest and in transit
-- **Zero-Knowledge Architecture**: NeuralTrust cannot access your raw data
+- **Data isolation**: On Hybrid, raw payloads stay in your environment; NeuralTrust receives privacy-safe metadata
 - **Anonymization**: Advanced techniques to remove identifying information
 - **Synthetic Data**: Generate artificial datasets for testing and development
 

--- a/neuraltrust/data-privacy/overview.mdx
+++ b/neuraltrust/data-privacy/overview.mdx
@@ -11,6 +11,10 @@ NeuralTrust ensures complete data privacy and regulatory compliance for AI monit
 
 ### Data Sovereignty Model
 
+NeuralTrust's data sovereignty model ensures that your most sensitive information never leaves your cloud environment. All data processing occurs within your own infrastructure, giving you complete control over your data while still benefiting from advanced AI monitoring capabilities.
+
+Our architecture separates sensitive data processing from control plane management. Your personal data, proprietary information, and confidential AI models remain in your environment, while only privacy-safe metadata is shared with our Control Plane for system management and compliance analytics.
+
 Where data lives depends on how you deploy. NeuralTrust offers **SaaS** and **Hybrid** — see [Deployment models](/neuraltrust/deployment/deployment-models).
 
 | | **SaaS** | **Hybrid** |

--- a/neuraltrust/data-privacy/overview.mdx
+++ b/neuraltrust/data-privacy/overview.mdx
@@ -11,6 +11,8 @@ NeuralTrust ensures complete data privacy and regulatory compliance for AI monit
 
 ### Data Sovereignty Model
 
+NeuralTrust's data sovereignty model ensures that your most sensitive information never leaves your cloud environment. All data processing occurs within your own infrastructure, giving you complete control over your data while still benefiting from advanced AI monitoring capabilities.
+
 Where data lives depends on how you deploy. NeuralTrust offers **SaaS** and **Hybrid** — see [Deployment models](/neuraltrust/deployment/deployment-models).
 
 | | **SaaS** | **Hybrid** |
@@ -91,7 +93,7 @@ Advanced anonymization techniques remove identifying information while preservin
 
 Protection controls include:
 - **End-to-End Encryption**: AES-256 encryption for all data at rest and in transit
-- **Data isolation**: On Hybrid, raw payloads stay in your environment; NeuralTrust receives privacy-safe metadata
+- **Zero-Knowledge Architecture**: NeuralTrust cannot access your raw data
 - **Anonymization**: Advanced techniques to remove identifying information
 - **Synthetic Data**: Generate artificial datasets for testing and development
 

--- a/neuraltrust/data-privacy/overview.mdx
+++ b/neuraltrust/data-privacy/overview.mdx
@@ -11,8 +11,6 @@ NeuralTrust ensures complete data privacy and regulatory compliance for AI monit
 
 ### Data Sovereignty Model
 
-NeuralTrust's data sovereignty model ensures that your most sensitive information never leaves your cloud environment. All data processing occurs within your own infrastructure, giving you complete control over your data while still benefiting from advanced AI monitoring capabilities.
-
 Where data lives depends on how you deploy. NeuralTrust offers **SaaS** and **Hybrid** — see [Deployment models](/neuraltrust/deployment/deployment-models).
 
 | | **SaaS** | **Hybrid** |

--- a/neuraltrust/security/overview.mdx
+++ b/neuraltrust/security/overview.mdx
@@ -47,7 +47,7 @@ Security-minded customers sometimes voice a concern that NeuralTrust itself migh
 **Data security and encryption features:**
 - **Customer-Managed Keys**: Full control over encryption keys through cloud KMS
 - **End-to-End Encryption**: AES-256 encryption for data at rest and TLS 1.3 for data in transit
-- **Data isolation**: Options that can keep raw payloads out of NeuralTrust operator access
+- **Zero-Knowledge Architecture**: NeuralTrust cannot access your raw data
 - **Data Classification**: Automatic identification and protection of sensitive data
 - **Secure Deletion**: Cryptographic erasure with verification
 - **Backup Encryption**: Separate encryption keys with automatic rotation
@@ -58,7 +58,7 @@ See [Data security and encryption](/neuraltrust/data-privacy/overview).
 
 NeuralTrust provides auditing features to enable admins to monitor user activities to detect security anomalies. For example, you can monitor account takeovers by alerting on unusual time of logins or simultaneous remote logins.
 
-NeuralTrust provides controls that can help meet common security and compliance requirements (for example SOC 2, ISO 27001, GDPR), depending on your contract and configuration.
+NeuralTrust also provides controls that help meet security requirements for many compliance standards, such as HIPAA, PCI DSS, SOC 2, and FedRAMP.
 
 **Auditing and compliance features:**
 - **Comprehensive Audit Logs**: Complete tracking of all user and system activities
@@ -88,14 +88,14 @@ NeuralTrust maintains a comprehensive vulnerability management program that incl
 
 **Vulnerability management capabilities:**
 - **Continuous Scanning**: Automated daily vulnerability assessments
-- **Patch Management**: Prioritized response to critical vulnerabilities
+- **Patch Management**: Immediate response to critical vulnerabilities
 - **Third-Party Testing**: Quarterly penetration testing by independent firms
 - **Dependency Monitoring**: Real-time tracking of third-party component vulnerabilities
 - **Zero-Day Response**: Rapid response procedures for newly discovered threats
 
 ## Security certifications and compliance
 
-NeuralTrust maintains security certifications and compliance attestations appropriate to the platform.
+NeuralTrust maintains industry-leading security certifications and compliance attestations to ensure our platform meets the highest security standards.
 
 **Current certifications and compliance:**
 - **SOC 2 Type II**: Annual independent security and availability audits
@@ -104,4 +104,4 @@ NeuralTrust maintains security certifications and compliance attestations approp
 
 ---
 
-> **Security commitment**: NeuralTrust provides enterprise security controls — authentication, access control, encryption, monitoring, and compliance support — that can be configured to your risk profile. 
+> **🔒 Security Commitment**: NeuralTrust provides enterprise-grade security with comprehensive threat detection, automated compliance, and zero-trust architecture that protects your AI monitoring environment while maintaining operational excellence. 

--- a/neuraltrust/security/overview.mdx
+++ b/neuraltrust/security/overview.mdx
@@ -42,7 +42,7 @@ To learn more about network security, see [Networking](/neuraltrust/deployment/o
 
 ## Data security and encryption
 
-Security-minded customers sometimes voice a concern that NeuralTrust itself might be compromised, which could result in the compromise of their environment. NeuralTrust has an security program designed to manage the risk of such an incident. That said, no company can completely eliminate all risk, and NeuralTrust provides encryption features for additional control of your data.
+Security-minded customers sometimes voice a concern that NeuralTrust itself might be compromised, which could result in the compromise of their environment. NeuralTrust has a security program designed to manage the risk of such an incident. That said, no company can completely eliminate all risk, and NeuralTrust provides encryption features for additional control of your data.
 
 **Data security and encryption features:**
 - **Customer-Managed Keys**: Full control over encryption keys through cloud KMS

--- a/neuraltrust/security/overview.mdx
+++ b/neuraltrust/security/overview.mdx
@@ -9,6 +9,8 @@ This section provides an overview of security features and capabilities that an 
 
 This section does not cover information about data governance and privacy. For that information, see [Data privacy and compliance](/neuraltrust/data-privacy/overview).
 
+NeuralTrust is available as **SaaS** and **Hybrid**. See [Deployment models](/neuraltrust/deployment/deployment-models).
+
 ## Authentication and access control
 
 In NeuralTrust, a _workspace_ is a NeuralTrust deployment in your cloud environment that functions as the unified environment for accessing all of your AI security and observability capabilities. Your organization can choose to have multiple workspaces or just one, depending on your needs. A NeuralTrust _account_ represents a single entity for purposes of billing, user management, and support. An account can include multiple workspaces across different cloud regions.
@@ -20,7 +22,7 @@ NeuralTrust provides security features, such as single sign-on, to configure str
 Access control lists determine who can view and perform operations on objects in NeuralTrust workspaces, such as AI models, monitoring dashboards, and security policies.
 
 **Key authentication and access control features:**
-- **Single Sign-On (SSO)**: SAML 2.0 and OpenID Connect integration with enterprise identity providers
+- **Single Sign-On (SSO)**: OpenID Connect and enterprise IdP integrations that can be configured
 - **Role-Based Access Control (RBAC)**: Granular permissions for different user types
 - **Service Principal Management**: Secure authentication for automated systems
 
@@ -30,33 +32,33 @@ NeuralTrust provides network protections that enable you to secure NeuralTrust w
 
 **Network security capabilities:**
 - **Zero-Trust Architecture**: Microsegmentation and service-level network isolation
-- **Customer-Managed VPC**: Complete control over network configuration and routing
+- **Customer-Managed VPC**: Network isolation options that can be configured (especially Hybrid)
 - **Private Endpoints**: Secure connectivity without internet exposure
 - **Network Access Control Lists**: Granular traffic filtering and monitoring
 - **VPN and Private Connectivity**: Secure remote access for administrators
 - **DDoS Protection**: Multi-layer protection against distributed attacks
 
-To learn more about network security, see [Networking](/neuraltrust/deployment/overview#cross-vpc-security-operations-privacy-safe-only).
+To learn more about network security, see [Networking](/neuraltrust/deployment/overview#network-requirements).
 
 ## Data security and encryption
 
-Security-minded customers sometimes voice a concern that NeuralTrust itself might be compromised, which could result in the compromise of their environment. NeuralTrust has an extremely strong security program which manages the risk of such an incident. That said, no company can completely eliminate all risk, and NeuralTrust provides encryption features for additional control of your data.
+Security-minded customers sometimes voice a concern that NeuralTrust itself might be compromised, which could result in the compromise of their environment. NeuralTrust has an security program designed to manage the risk of such an incident. That said, no company can completely eliminate all risk, and NeuralTrust provides encryption features for additional control of your data.
 
 **Data security and encryption features:**
 - **Customer-Managed Keys**: Full control over encryption keys through cloud KMS
 - **End-to-End Encryption**: AES-256 encryption for data at rest and TLS 1.3 for data in transit
-- **Zero-Knowledge Architecture**: NeuralTrust cannot access your raw data
+- **Data isolation**: Options that can keep raw payloads out of NeuralTrust operator access
 - **Data Classification**: Automatic identification and protection of sensitive data
 - **Secure Deletion**: Cryptographic erasure with verification
 - **Backup Encryption**: Separate encryption keys with automatic rotation
 
-See [Data security and encryption](/neuraltrust/deployment/overview#security-and-compliance).
+See [Data security and encryption](/neuraltrust/data-privacy/overview).
 
 ## Auditing, privacy, and compliance
 
 NeuralTrust provides auditing features to enable admins to monitor user activities to detect security anomalies. For example, you can monitor account takeovers by alerting on unusual time of logins or simultaneous remote logins.
 
-NeuralTrust also provides controls that help meet security requirements for many compliance standards, such as HIPAA, PCI DSS, SOC 2, and FedRAMP.
+NeuralTrust provides controls that can help meet common security and compliance requirements (for example SOC 2, ISO 27001, GDPR), depending on your contract and configuration.
 
 **Auditing and compliance features:**
 - **Comprehensive Audit Logs**: Complete tracking of all user and system activities
@@ -70,13 +72,13 @@ For more information about compliance, refer to the certifications listed in the
 
 ## Threat detection and response
 
-NeuralTrust employs advanced threat detection capabilities that use machine learning and behavioral analytics to identify potential security threats in real-time. Our Security Operations Center (SOC) provides 24/7 monitoring and incident response capabilities.
+NeuralTrust employs advanced threat detection capabilities that use machine learning and behavioral analytics to identify potential security threats in real-time. Monitoring and incident-response capabilities are available and can be configured to your operational model.
 
 **Threat detection features:**
 - **AI-Powered Detection**: Machine learning-based behavioral analytics
 - **Real-Time Monitoring**: Continuous threat detection across all infrastructure
-- **Automated Response**: Immediate containment of detected threats
-- **24/7 SOC**: Dedicated security professionals monitoring your environment
+- **Automated Response**: Containment workflows that can be configured
+- **Security operations**: Monitoring and response workflows that can be enabled
 - **Threat Intelligence**: Integration with global threat intelligence feeds
 - **Forensic Investigation**: Detailed analysis capabilities for security incidents
 
@@ -86,14 +88,14 @@ NeuralTrust maintains a comprehensive vulnerability management program that incl
 
 **Vulnerability management capabilities:**
 - **Continuous Scanning**: Automated daily vulnerability assessments
-- **Patch Management**: Immediate response to critical vulnerabilities
+- **Patch Management**: Prioritized response to critical vulnerabilities
 - **Third-Party Testing**: Quarterly penetration testing by independent firms
 - **Dependency Monitoring**: Real-time tracking of third-party component vulnerabilities
 - **Zero-Day Response**: Rapid response procedures for newly discovered threats
 
 ## Security certifications and compliance
 
-NeuralTrust maintains industry-leading security certifications and compliance attestations to ensure our platform meets the highest security standards.
+NeuralTrust maintains security certifications and compliance attestations appropriate to the platform.
 
 **Current certifications and compliance:**
 - **SOC 2 Type II**: Annual independent security and availability audits
@@ -102,4 +104,4 @@ NeuralTrust maintains industry-leading security certifications and compliance at
 
 ---
 
-> **🔒 Security Commitment**: NeuralTrust provides enterprise-grade security with comprehensive threat detection, automated compliance, and zero-trust architecture that protects your AI monitoring environment while maintaining operational excellence. 
+> **Security commitment**: NeuralTrust provides enterprise security controls — authentication, access control, encryption, monitoring, and compliance support — that can be configured to your risk profile. 

--- a/neuraltrust/security/overview.mdx
+++ b/neuraltrust/security/overview.mdx
@@ -22,7 +22,7 @@ NeuralTrust provides security features, such as single sign-on, to configure str
 Access control lists determine who can view and perform operations on objects in NeuralTrust workspaces, such as AI models, monitoring dashboards, and security policies.
 
 **Key authentication and access control features:**
-- **Single Sign-On (SSO)**: OpenID Connect and enterprise IdP integrations that can be configured
+- **Single Sign-On (SSO)**: SAML 2.0 and OpenID Connect integration with enterprise identity providers
 - **Role-Based Access Control (RBAC)**: Granular permissions for different user types
 - **Service Principal Management**: Secure authentication for automated systems
 


### PR DESCRIPTION
## Summary
- Soften absolute security/privacy marketing claims to configurable capability language
- Fix broken anchors on security overview
- Document SaaS vs Hybrid data residency in privacy overview (link to deployment models)

## Test plan
- [ ] Preview Mintlify pages for security + data-privacy
- [ ] Click fixed network / privacy links

Made with [Cursor](https://cursor.com)