### PR TITLE
docs(trustgate): clarify LLM vs MCP consumer auth types

### DIFF
--- a/trustgate/concepts/auth.mdx
+++ b/trustgate/concepts/auth.mdx
@@ -20,8 +20,12 @@ which is how TrustGate authenticates to the **upstream provider**.
 | **`oidc`** | `Authorization: Bearer <jwt>` from your IdP; claims select a [role](/trustgate/concepts/roles) | inline or role_based |
 | **`mtls`** | Client certificate (or a trusted `X-Forwarded-Client-Cert` header) | inline |
 
-MCP consumers accept `api_key`, `oauth2`, and `mtls` (not `oidc`). A `role_based` consumer
-carries exactly one identity credential — `oauth2` or `oidc`.
+| Plane | Consumer auth types |
+|---|---|
+| **LLM** | `api_key`, `oauth2`, `oidc` |
+| **MCP** | `oauth2` |
+
+A `role_based` LLM consumer carries exactly one identity credential — `oauth2` or `oidc`.
 
 ## API keys
 

--- a/trustgate/concepts/authorization/overview.mdx
+++ b/trustgate/concepts/authorization/overview.mdx
@@ -38,7 +38,7 @@ the gateway to run the interactive OAuth login.
 
 <Note>
 An Identity-based LLM consumer carries **exactly one** identity auth (**OIDC** or
-**OAuth2**). MCP consumers use **OAuth2** (or API key / mTLS) — **not** OIDC.
+**OAuth2**). LLM consumers can also use **API key**. MCP consumers use **OAuth2** only — **not** OIDC or API key.
 </Note>
 
 ## Where to configure in the app

--- a/trustgate/concepts/consumers.mdx
+++ b/trustgate/concepts/consumers.mdx
@@ -25,7 +25,7 @@ A consumer routes in one of two modes:
 
 | Mode | Routing config lives on | Auth |
 |---|---|---|
-| **`inline`** (default) | The consumer directly — `registry_ids`, `lb_config`, `fallback`, `model_policies`. | `api_key`, `oauth2`, `oidc`, or `mtls`. |
+| **`inline`** (default) | The consumer directly — `registry_ids`, `lb_config`, `fallback`, `model_policies`. | LLM: `api_key`, `oauth2`, or `oidc`. MCP: `oauth2`. |
 | **`role_based`** | The consumer's [roles](/trustgate/concepts/roles); roles are selected from OIDC token claims. | A single `oauth2` or `oidc` credential. |
 
 ### Inline routing

--- a/trustgate/overview.mdx
+++ b/trustgate/overview.mdx
@@ -30,7 +30,7 @@ Putting TrustGate between your apps and your model providers gives you one contr
 - **Guardrails** — built-in [TrustGuard](/trustguard/overview), OpenAI Moderation, Azure
   Content Safety, and AWS Bedrock guardrail policies to inspect prompts and responses inline.
 - **Multi-tenancy & auth** — per-gateway consumers authenticated by API key, OAuth2, OIDC,
-  or mTLS, with policies scoped globally or per consumer.
+  or mTLS (see Auth). LLM consumers use API key, OAuth2, or OIDC; MCP consumers use OAuth2.
 - **Observability** — rich per-request telemetry (model, tokens, cost, latency breakdown,
   routing attempts, policy chain) exported through OpenTelemetry (OTLP) and forwarded to
   TrustLens, where it powers
@@ -48,7 +48,7 @@ then send traffic to the proxy. Six objects make up a gateway:
 | **[Gateway](/trustgate/concepts/gateways)** | The top-level tenant, addressed by a `slug`. Owns everything below. |
 | **[Registry](/trustgate/concepts/registries)** | An upstream backend — an LLM provider endpoint or an MCP server. |
 | **[Consumer](/trustgate/concepts/consumers)** | The calling application's identity. Owns routing and credentials, addressed by a `slug` in the URL. |
-| **[Auth](/trustgate/concepts/auth)** | A credential (API key, OAuth2, OIDC, mTLS) that authenticates as a consumer. |
+| **[Auth](/trustgate/concepts/auth)** | A credential that authenticates as a consumer — LLM: API key / OAuth2 / OIDC; MCP: OAuth2. |
 | **[Policy](/trustgate/policies/overview)** | A governance rule that runs at request/response stages — rate limiting, budgets, caching, tool governance, guardrails, CORS, and more. |
 | **[Role](/trustgate/concepts/roles)** | Routing config selected from OIDC token claims, for identity-based routing. |
 


### PR DESCRIPTION
## Summary
- LLM consumers: `api_key` / `oauth2` / `oidc`
- MCP consumers: `oauth2` only
- Keep auth type docs including mTLS; update plane matrix + Note (not removed)

## Test plan
- [ ] Review Auth, Consumers, Authorization overview, TrustGate overview

Made with [Cursor](https://cursor.com)