### PR TITLE
docs(trustguard): document unguarded allow and transform enforcement

### DIFF
--- a/trustguard/concepts/collectors.mdx
+++ b/trustguard/concepts/collectors.mdx
@@ -69,6 +69,10 @@ Resolution is: if the request's `consumer_id` has a per‑consumer policy, use i
 otherwise use the default policy. A collector with **no** matching policy leaves
 that request **unguarded** — it returns `allow` with no findings.
 
+<Warning>
+Unguarded traffic is not inspected. Set a default policy (and per-consumer overrides if needed) before relying on TrustGuard in production.
+</Warning>
+
 You attach a collector to a policy from the policy's **Collectors** tab (routing
 mode **Default** or **Consumer ID**).
 

--- a/trustguard/concepts/policies.mdx
+++ b/trustguard/concepts/policies.mdx
@@ -112,4 +112,4 @@ mode:
   consumer, letting one collector send different consumers to different policies.
 
 If a collector has no policy for a request, that request is **unguarded** (no
-gates, no detectors).
+gates, no detectors) and returns `status: "allow"` with no findings.

--- a/trustguard/how-it-works.mdx
+++ b/trustguard/how-it-works.mdx
@@ -117,5 +117,4 @@ setting:
   traffic.
 
 A structured **block** decision (from a gate or a Block rule) always applies
-regardless of this setting. Ask NeuralTrust about the setting for your
-deployment.
+regardless of this setting. The default is **configured per deployment** — ask NeuralTrust which mode your environment uses.

--- a/trustguard/integrations/application.mdx
+++ b/trustguard/integrations/application.mdx
@@ -97,6 +97,8 @@ curl -X POST "{TRUSTGUARD_URL}/v1/evaluate" \
 Guard inbound user traffic in-process with a middleware in front of your AI routes.
 
 ```python
+import json
+
 from fastapi import FastAPI, Request
 from starlette.responses import JSONResponse
 from trustguard import AsyncTrustGuard
@@ -115,6 +117,9 @@ async def trustguard_middleware(request: Request, call_next):
         )
         if response.is_blocked:
             return JSONResponse({"detail": "Blocked by TrustGuard"}, status_code=403)
+        if response.transformed_payload:
+            # Masked/rewritten content — forward it instead of the original body
+            request._body = json.dumps(response.transformed_payload).encode()
     return await call_next(request)
 ```
 
@@ -141,6 +146,10 @@ app.use(async (req, res, next) => {
   });
   if (response.isBlocked) {
     return res.status(403).json({ detail: "Blocked by TrustGuard" });
+  }
+  if (response.transformedPayload) {
+    // Masked/rewritten content — forward it instead of the original body
+    req.body = response.transformedPayload;
   }
   next();
 });

--- a/trustguard/integrations/edge-waf.mdx
+++ b/trustguard/integrations/edge-waf.mdx
@@ -10,7 +10,7 @@ never reach TrustGuard. The pattern is the same everywhere: the edge function re
 request body, calls [`/v1/evaluate`](/trustguard/api/evaluate), and returns a 403 when content
 is flagged — clean traffic forwards to your origin unchanged.
 
-Create an API key on the collector first. WAF rules can't call external
+Create an API key on the collector first. Store it in the edge secret store — never hardcode it in the worker. WAF rules can't call external
 services themselves, so the worker/function is the integration point.
 
 ## Cloudflare Workers
@@ -54,6 +54,15 @@ export default {
       if (result.status === "block") {
         return new Response("Blocked by TrustGuard", { status: 403 });
       }
+      if (result.status === "transform" && result.transformed_payload) {
+        // Forward the masked/transformed body to origin (adjust field mapping as needed)
+        return fetch(new Request(request, {
+          body: typeof result.transformed_payload === "string"
+            ? result.transformed_payload
+            : JSON.stringify(result.transformed_payload),
+        }));
+      }
+      // report / allow → forward unchanged
     }
     return fetch(request);
   },

--- a/trustguard/integrations/edge-waf.mdx
+++ b/trustguard/integrations/edge-waf.mdx
@@ -108,6 +108,11 @@ export const handler = async (event) => {
     if (result.status === "block") {
       return { status: "403", statusDescription: "Forbidden", body: "Blocked by TrustGuard" };
     }
+    if (result.status === "transform" && result.transformed_payload) {
+      // Masked/rewritten content — forward it instead of the original body
+      request.body.data = Buffer.from(JSON.stringify(result.transformed_payload)).toString("base64");
+    }
+    // "report" / "allow" fall through and forward the (possibly rewritten) request
   }
 
   return request;
@@ -150,6 +155,11 @@ async function handler(event) {
     if (result.status === "block") {
       return new Response("Blocked by TrustGuard", { status: 403 });
     }
+    if (result.status === "transform" && result.transformed_payload) {
+      // Masked/rewritten content — forward it instead of the original body
+      return fetch(new Request(req, { body: JSON.stringify(result.transformed_payload) }), { backend: "origin" });
+    }
+    // "report" / "allow" fall through and forward the original request unchanged
   }
 
   return fetch(req, { backend: "origin" });
@@ -198,10 +208,16 @@ export async function responseProvider(request) {
       return createResponse(403, {}, "Blocked by TrustGuard");
     }
 
+    // Masked/rewritten content ("transform") is forwarded instead of the original
+    // body; "report" / "allow" forward the original body unchanged.
+    const forwardBody = result.status === "transform" && result.transformed_payload
+      ? JSON.stringify(result.transformed_payload)
+      : text;
+
     const originResponse = await httpRequest(request.url, {
       method: "POST",
       headers: { "Content-Type": request.getHeader("Content-Type") ?? "" },
-      body: text,
+      body: forwardBody,
     });
     return createResponse(originResponse.status, {}, originResponse.body);
   }

--- a/trustguard/integrations/gateway.mdx
+++ b/trustguard/integrations/gateway.mdx
@@ -110,6 +110,9 @@ plugins:
       functions:
         check_response: |
           return function(resp)
+            -- resp.transformed_payload holds masked content when status == "transform";
+            -- this plugin's response mapping only supports block/block_message, so
+            -- rewriting the body for Transform rules needs a downstream plugin.
             return {
               block = resp.status == "block",
               block_message = "Blocked by TrustGuard"
@@ -139,7 +142,8 @@ they reach your backend.
 2. Open your API in the Azure portal.
 3. Add a `send-request` policy in the **inbound** section posting the prompt to the guard
    endpoint.
-4. Return 403 when the response `status` is `"block"`; repeat in **outbound** for
+4. Return 403 when the response `status` is `"block"`; rewrite the body with
+   `transformed_payload` when `status` is `"transform"`; repeat in **outbound** for
    completions.
 
 ```xml
@@ -164,6 +168,11 @@ they reach your backend.
         <set-status code="403" reason="Blocked by TrustGuard" />
       </return-response>
     </when>
+    <when condition="@(((IResponse)context.Variables["guard"]).Body.As<JObject>()["status"].Value<string>() == "transform")">
+      <!-- Masked/rewritten content — forward transformed_payload instead of the original body -->
+      <set-body>@(((IResponse)context.Variables["guard"]).Body.As<JObject>()["transformed_payload"]["input"].Value<string>())</set-body>
+    </when>
+    <!-- "report" / "allow" fall through and forward the original request unchanged -->
   </choose>
 </inbound>
 ```

--- a/trustguard/integrations/gateway.mdx
+++ b/trustguard/integrations/gateway.mdx
@@ -8,8 +8,7 @@ already in the request/response path, so it calls [`/v1/evaluate`](/trustguard/a
 enforces the verdict for **every** model call with no application changes.
 
 Every gateway integration starts the same way: **create an API key on the collector**,
-then wire the gateway to call the guard endpoint and block when the response
-`status` is `"block"`.
+then wire the gateway to call the guard endpoint and enforce the response `status`: **block** → deny; **transform** → forward `transformed_payload`; **report** / **allow** → forward (log on report).
 
 ## TrustGate (recommended)
 
@@ -27,6 +26,11 @@ LLM, MCP, and A2A traffic.
 
 Portkey calls TrustGuard through a **Bring-Your-Own-Guardrails** webhook check on requests
 and responses.
+
+<Warning>
+Portkey expects `{ verdict }`. Without a thin adapter that maps TrustGuard `status` → `verdict` (e.g. `verdict = status != "block"`, and apply `transformed_payload` on transform), Portkey **will not enforce** TrustGuard decisions.
+</Warning>
+
 
 1. Create an API key on the collector.
 2. In Portkey, create a Guardrail with a **Webhook** check pointing at the guard endpoint.

--- a/trustguard/overview.mdx
+++ b/trustguard/overview.mdx
@@ -66,13 +66,17 @@ conditions. See [How it works](/trustguard/how-it-works).
 
 ## What makes it safe to run inline
 
+<Warning>
+Traffic with **no matching policy** is **unguarded**: TrustGuard returns `status: "allow"` with no inspection. Attach a default (or per-consumer) policy on the collector after setup.
+</Warning>
+
+
 - **Never drops traffic.** A detection is always `HTTP 200` with the finding in the
   response body. Non-2xx is reserved for auth (401), bad requests (400), and system
   failures (500).
 - **Fail-open or fail-closed — your choice.** If a detector errors (e.g. an upstream
   model API is down), TrustGuard either drops that detector's result and continues
-  (fail-open) or returns `500` so you can hold traffic (fail-closed), per your
-  deployment's setting. A structured block decision always applies.
+  (fail-open) or returns `500` so you can hold traffic (fail-closed). The mode is **configured per deployment** (ask NeuralTrust if unsure). A structured block decision always applies.
 - **Enforcement is the caller's choice.** The response `status`
   (`allow` / `report` / `transform` / `block`) is advisory. Your collector
   decides what to do with it.


### PR DESCRIPTION
## Summary
- Warn that unguarded traffic returns `allow` (no inspection)
- Gateway/edge snippets handle `transform` / report / allow
- Portkey adapter warning; fail-open/closed is per deployment

## Test plan
- [ ] Skim overview, collectors, policies, gateway, edge-waf

Made with [Cursor](https://cursor.com)