### PR TITLE
docs(trustgate): document MCP reachability and SaaS vs Private OAuth

### DIFF
--- a/trustgate/concepts/authorization/entra-id.mdx
+++ b/trustgate/concepts/authorization/entra-id.mdx
@@ -28,6 +28,10 @@ the Entra `oid` claim as the stable subject. Use the values below exactly.
 - For Cursor / agent MCP login: the public MCP base URL of your gateway (e.g.
   `https://{gateway_slug}.mcp.neuraltrust.ai`), so you can register the OAuth redirect URI.
 
+<Note>
+**SaaS vs Private `mcp_base_url`:** SaaS uses `{slug}.mcp.neuraltrust.ai`. Private/Hybrid uses the Dataplane MCP URL from **Settings → Agent Gateway → General**. Register `{mcp_base_url}/oauth/callback` on the IdP **before** testing agent login.
+</Note>
+
 ## The values you will collect
 
 | Placeholder | Where it comes from |

--- a/trustgate/concepts/authorization/okta.mdx
+++ b/trustgate/concepts/authorization/okta.mdx
@@ -27,6 +27,10 @@ authorization server feature is the **API Access Management** product.
 - For Cursor / agent MCP login: the public MCP base URL of your gateway (e.g.
   `https://default-xxxxxxxx.mcp.neuraltrust.ai`), so you can register the OAuth redirect URI.
 
+<Note>
+**SaaS vs Private `mcp_base_url`:** SaaS uses `{slug}.mcp.neuraltrust.ai`. Private/Hybrid uses the Dataplane MCP URL from **Settings → Agent Gateway → General**. Register `{mcp_base_url}/oauth/callback` on the IdP **before** testing agent login.
+</Note>
+
 ## The values you will collect
 
 | Placeholder | Where it comes from |

--- a/trustgate/concepts/registries.mdx
+++ b/trustgate/concepts/registries.mdx
@@ -82,3 +82,6 @@ before saving (`POST …/registries/test-connection`) and **list an MCP registry
 (`GET …/registries/{id}/tools`, which calls the live MCP server). See the
 [Registries API](/trustgate/api/overview).
 
+<Note>
+For MCP registries, the data plane must reach the upstream `url`. Private VPC MCPs need [Hybrid](/neuraltrust/deployment/deployment-models).
+</Note>

--- a/trustgate/mcp/overview.mdx
+++ b/trustgate/mcp/overview.mdx
@@ -9,6 +9,10 @@ agent to each MCP server directly, TrustGate **aggregates** several servers into
 MCP endpoint — composing their tools, prompts, and resources — and applies the same tenancy,
 access control, auth, and observability as LLM traffic.
 
+<Note>
+The TrustGate **data plane must reach** each MCP registry `url`. SaaS cannot call private VPC endpoints unless you expose them. Use [Hybrid](/neuraltrust/deployment/deployment-models) for internal MCPs.
+</Note>
+
 ## One endpoint, many servers
 
 An agent connects to one TrustGate MCP endpoint and sees a unified surface. TrustGate speaks

--- a/trustgate/operate/deployment.mdx
+++ b/trustgate/operate/deployment.mdx
@@ -23,7 +23,7 @@ The published image runs one plane per container:
 ```dockerfile
 # Builder: golang (CGO_ENABLED=1) — CGO is required by confluent-kafka-go
 # Runtime: distroless nonroot
-EXPOSE 8080 8081
+EXPOSE 8080 8081 8082
 ENTRYPOINT ["/app/trustgate"]
 CMD ["proxy"]
 ```
@@ -31,6 +31,10 @@ CMD ["proxy"]
 Compose files: `docker-compose.yaml` (infra only — Postgres, Redis, Kafka), plus
 `docker-compose.api.yaml` (admin + proxy) and `docker-compose.frontend.yaml`. `make up`
 brings up the full stack. The image is `linux/amd64` (librdkafka).
+
+<Note>
+The Compose quick path focuses on admin + proxy (`8080`/`8081`). For MCP (`8082`), run the `mcp` plane (Kubernetes/chart) or add an MCP service yourself.
+</Note>
 
 ## Kubernetes
 

--- a/trustgate/overview.mdx
+++ b/trustgate/overview.mdx
@@ -7,7 +7,7 @@ description: "TrustGate is NeuralTrust's open-source, high-performance data-plan
 Apache-2.0) is a purpose-built reverse proxy for **LLM and agent traffic**. Point any
 OpenAI-, Anthropic-, or Responses-API client at it and TrustGate normalizes, routes,
 load-balances, governs, and observes every call — without changing your application code
-beyond its base URL and consumer credentials.
+beyond its base URL and consumer credentials. SaaS gateways are reached by subdomain; Private/Hybrid also accepts `X-AG-Gateway-Slug`.
 
 It is built from scratch in **Go** on top of [Fiber](https://gofiber.io), tuned for low
 latency and high concurrency, and ships as a single static binary, a Docker image, and
@@ -56,8 +56,8 @@ then send traffic to the proxy. Six objects make up a gateway:
 
 ```text
 client ──▶ /{consumer_slug}/v1/chat/completions
-              │  X-AG-API-Key
-              │  X-AG-Gateway-Slug (Private only)
+              │  X-AG-API-Key  or  Authorization: Bearer (OAuth2/OIDC)
+              │  X-AG-Gateway-Slug (Private only; SaaS uses subdomain)
               ├─ resolve gateway + consumer + policies
               ├─ apply policies (rate limit, cache, CORS, …)
               ├─ load-balance across the consumer's registries (+ fallback)


### PR DESCRIPTION
## Summary
- Note data plane must reach MCP URLs; Hybrid for private VPC
- SaaS vs Private `mcp_base_url` + register `/oauth/callback` (Okta/Entra)
- Expose 8082 / Compose MCP note; overview auth diagram tweak

## Test plan
- [ ] MCP overview, Okta/Entra MCP prereqs, deployment, TrustGate overview

Made with [Cursor](https://cursor.com)