### PR TITLE
docs(platform): clarify IAM roles, break-glass passwordless, SSO Owner mapping

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -154,7 +154,8 @@
             ]
           }
         ]
-      }, {
+      },
+      {
         "tab": "TrustGate",
         "icon": "door-open",
         "groups": [
@@ -561,12 +562,8 @@
       "destination": "/platform/event-schema"
     },
     {
-      "source": "/platform/password-policy",
-      "destination": "/platform/overview"
-    },
-    {
       "source": "/platform/feature-flags",
-      "destination": "/platform/overview"
+      "destination": "/neuraltrust/deployment/feature-flags"
     },
     {
       "source": "/platform/siem-integration",

--- a/platform/audit-logs.mdx
+++ b/platform/audit-logs.mdx
@@ -71,7 +71,7 @@ Audit Logs provide a comprehensive record of all security-related actions in you
 ### Step 1: Open Audit Logs
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Go to <a href="https://app.neuraltrust.ai/settings/audit-logs" target="_blank">**Settings** → **Audit Logs**</a>
+2. Open **Platform settings** (gear) → **Audit Logs** (or <a href="https://app.neuraltrust.ai/settings/audit-logs" target="_blank">Settings → Audit Logs</a>)
 
 ### Step 2: Apply Filters
 
@@ -275,7 +275,7 @@ Members cannot view audit logs to maintain separation of duties. If a member nee
 | Logs missing for date | Outside retention period | Contact support if needed |
 | Search returns nothing | Wrong search terms | Try partial matches or different filters |
 | SIEM not receiving events | Wrong credentials | Verify API key/token and endpoint URL |
-| SIEM connection failed | Firewall blocking | Ensure NeuralTrust IPs are whitelisted |
+| SIEM connection failed | Firewall blocking | Allow outbound HTTPS from NeuralTrust to your SIEM endpoint (contact support if you need source details) |
 
 ---
 

--- a/platform/audit-logs.mdx
+++ b/platform/audit-logs.mdx
@@ -71,8 +71,8 @@ Audit Logs provide a comprehensive record of all security-related actions in you
 
 ### Step 1: Open Audit Logs
 
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Open **Platform settings** (gear) → **Audit Logs** (or <a href="https://app.neuraltrust.ai/settings/audit-logs" target="_blank">Settings → Audit Logs</a>)
+1. Log in to NeuralTrust as Owner or Admin
+2. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available)
 
 ### Step 2: Apply Filters
 
@@ -199,7 +199,7 @@ Go to <a href="https://app.neuraltrust.ai/settings/siem" target="_blank">**Setti
 
 After connecting your SIEM, choose which events to forward:
 
-1. In **Settings** → **Audit Logs**, click the **SIEM Integration** button
+1. In **Audit Logs**, click the **SIEM Integration** button
 2. Toggle the categories you want to send (Authentication, User Management, SSO Security, etc.)
 3. Click **Save**
 

--- a/platform/audit-logs.mdx
+++ b/platform/audit-logs.mdx
@@ -26,11 +26,11 @@ Audit Logs provide a comprehensive record of all security-related actions in you
 
 | Event | Description | Details Captured |
 |-------|-------------|------------------|
-| `login.success` | User successfully signed in | Provider (Microsoft, GitHub, password), IP address |
-| `login.failure` | Failed login attempt | Failure reason, IP address |
-| `logout` | User signed out | Session duration |
-| `session.created` | New session started | Device info, IP address |
-| `session.expired` | Session timed out | Session duration |
+| `auth.login.success` | User successfully signed in | Provider (Microsoft, GitHub, password), IP address |
+| `auth.login.failure` | Failed login attempt | Failure reason, IP address |
+| `auth.logout` | User signed out | Session duration |
+| `auth.session.created` | New session started | Device info, IP address |
+| `auth.session.expired` | Session timed out | Session duration |
 
 ### User Management Events
 
@@ -51,10 +51,11 @@ Audit Logs provide a comprehensive record of all security-related actions in you
 | `sso.domain_added` | Email domain added | Domain name |
 | `sso.domain_verified` | Domain verification completed | Verification method |
 | `sso.enforced` | SSO-only mode enabled | Enabled by |
-| `scim.token_generated` | SCIM token created | Token expiration |
-| `scim.token_revoked` | SCIM token revoked | Revoked by |
-| `scim.user_provisioned` | User created via SCIM | Source system |
-| `scim.user_deprovisioned` | User removed via SCIM | Source system |
+| `scim.token.generated` | SCIM token created | Token expiration |
+| `scim.token.revoked` | SCIM token revoked | Revoked by |
+| `scim.user.provisioned` | User created via SCIM | Source system |
+| `scim.user.updated` | User attributes updated via SCIM | Source system |
+| `scim.user.deprovisioned` | User removed via SCIM | Source system |
 
 ### API Key Events
 

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -5,7 +5,12 @@ description: "Configure emergency access for administrators to bypass SSO enforc
 
 # Break the Glass (Emergency Access)
 
-Break the Glass is an emergency access feature that allows designated administrators to bypass SSO enforcement and log in with their password. This ensures you're never locked out of NeuralTrust if your identity provider experiences an outage.
+Two related mechanisms keep you from being locked out:
+
+1. **Break the Glass accounts** (org role) — emergency users with **Global Admin** permissions who sign in with a **password** (no MFA). Normal users are **passwordless** (magic link or SSO only).
+2. **SSO break-glass email list** (per IdP) — when SSO enforcement is on, listed emails may still use password login if they have a Break the Glass account/password.
+
+This page covers both. Max **5** break-glass users per SSO provider (recommended **2–3**).
 
 ## When to Use It
 
@@ -40,13 +45,13 @@ This means:
 3. All break-glass logins are recorded in Audit Logs for security tracking
 4. Maximum 5 break-glass users per provider (recommended: 2-3)
 
-### Normal User vs Break-Glass User
+### Normal user vs Break the Glass
 
-| Scenario | Normal User | Break-Glass User |
-|----------|-------------|------------------|
-| SSO Enforcement OFF | Can use password or SSO | Can use password or SSO |
-| SSO Enforcement ON | Must use SSO only | Can use password OR SSO |
-| IdP is down | Cannot log in | Can log in with password |
+| Scenario | Normal user | Break the Glass |
+|----------|-------------|-----------------|
+| Sign-in | Magic link or SSO (passwordless) | Password (and SSO if configured) |
+| SSO Enforcement ON | SSO (or magic link where allowed) | Password **or** SSO |
+| IdP is down | Cannot use SSO | Can log in with password |
 
 ---
 
@@ -57,14 +62,22 @@ Before adding someone to the break-glass list, they must:
 | Requirement | Why |
 |-------------|-----|
 | Have an existing NeuralTrust account | Must have signed up first |
-| Have a password configured | Cannot be SSO-only users |
-| Be a member of the team | Must belong to your team |
+| Be provisioned as Break the Glass (password ≥ 30 chars) | Only BtG accounts have passwords |
+| Be a member of the organization | Must belong to your org |
 
 <Warning>
-Break-glass users must have a password set. Users who only signed up via SSO or GitHub cannot be added to the break-glass list until they configure a password.
+Only Break the Glass accounts have passwords. Create/mark the user as Break the Glass in [User & Roles](/platform/users) before adding them to an SSO break-glass list.
 </Warning>
 
 ---
+
+
+## Hardening (recommended)
+
+- Keep **2–3** accounts (max 5 per provider) — not everyone.
+- Rotate BtG passwords periodically; store them in your secret manager.
+- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
+- Disable or remove BtG access when the emergency is over.
 
 ## Configuring Break-Glass Users
 

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -71,7 +71,6 @@ Only Break the Glass accounts have passwords. Create/mark the user as Break the 
 
 ---
 
-
 ## Hardening (recommended)
 
 - Keep **2–3** accounts (max 5 per provider) — not everyone.
@@ -105,7 +104,7 @@ Break-glass configuration only appears when SSO Enforcement is enabled for that 
 3. Enter the email address of a team administrator
 4. Click **Add** — the system validates the user meets requirements:
    - ✓ User exists in the system
-   - ✓ User has a password set
+   - ✓ User is a Break the Glass account (the only account type with a password)
    - ✓ User is a member of this team
 5. Repeat for additional users (recommended: 2-3)
 6. Click **Save**
@@ -132,9 +131,9 @@ Break-glass access is limited to 5 users per provider. This is a security best p
 | Error | Cause | Solution |
 |-------|-------|----------|
 | "This user does not exist in the system" | User hasn't created an account | Have the user sign up for NeuralTrust first |
-| "This user has no password configured" | User only signed up via SSO/GitHub | Have the user set a password via "Forgot Password" |
+| "This user has no password configured" | User is not a Break the Glass account (normal accounts are passwordless) | Promote the user to Break the Glass in [User & Roles](/platform/users) first |
 | "This user is not a member of this team" | User exists but not in your team | Invite the user to join your team first |
-| "Maximum number of users reached" | Already have 10 break-glass users | Remove an existing user before adding a new one |
+| "Maximum number of users reached" | Already have 5 break-glass users | Remove an existing user before adding a new one |
 | "This email is already added" | Duplicate email | The user is already in the list |
 
 ---
@@ -145,8 +144,8 @@ Break-glass access is limited to 5 users per provider. This is a security best p
 
 1. User goes to login page
 2. Enters email
-3. System detects SSO is enforced → redirects to "Sign in with Microsoft"
-4. Cannot use password login
+3. System sends a magic link, or redirects to SSO if enforced/configured
+4. No password option — normal accounts are always passwordless
 
 ### For Break-Glass Users
 
@@ -231,7 +230,7 @@ Yes. It works with Microsoft Entra ID, generic OIDC providers, and any future SS
 
 **Q: Can Members be break-glass users?**
 
-Yes. Any team member with a password configured can be added to the break-glass list, regardless of their role (Owner, Admin, or Member).
+Only if they're a Break the Glass account — the only account type with a password. Promote the user to Break the Glass in [User & Roles](/platform/users) first; regular Member/Admin/Owner accounts are passwordless and can't be added directly.
 
 ---
 

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -8,7 +8,7 @@ description: "Configure emergency access for administrators to bypass SSO enforc
 Two related mechanisms keep you from being locked out:
 
 1. **Break the Glass accounts** (org role) — emergency users with **Global Admin** permissions who sign in with a **password** (no MFA). Normal users are **passwordless** (magic link or SSO only).
-2. **SSO break-glass email list** (per IdP) — when SSO enforcement is on, listed emails may still use password login if they have a Break the Glass account/password.
+2. **SSO break-glass email list** (per IdP) — when SSO enforcement is on, listed emails may still sign in with **magic link** (they do not use a password unless they are also Break the Glass accounts).
 
 This page covers both. Max **5** break-glass users per SSO provider (recommended **2–3**).
 
@@ -32,8 +32,8 @@ Break Glass Users are configured **per SSO provider**. If you have both Microsof
 </Note>
 
 This means:
-- If Microsoft Entra ID is down, users in its Break Glass list can log in with password
-- If your OIDC provider is down, users in its Break Glass list can log in with password
+- If Microsoft Entra ID is down, users in its Break Glass list can still use **magic link** (or password if they are Break the Glass accounts)
+- If your OIDC provider is down, users in its Break Glass list can still use **magic link** (or password if they are Break the Glass accounts)
 - You should configure Break Glass users for **each** SSO provider you have enabled
 
 ---
@@ -41,7 +41,7 @@ This means:
 ## How It Works
 
 1. Team Owner/Admin adds email addresses to the Break-Glass Users list **for each SSO provider**
-2. These users can log in with email + password even when "SSO Enforcement" is ON for that provider
+2. Listed users can still use **magic link** when "SSO Enforcement" is ON for that provider (Break the Glass *accounts* can also use password)
 3. All break-glass logins are recorded in Audit Logs for security tracking
 4. Maximum 5 break-glass users per provider (recommended: 2-3)
 
@@ -187,9 +187,9 @@ All break-glass activity is logged for compliance and security monitoring.
 
 ### Viewing Break-Glass Events
 
-1. Go to <a href="https://app.neuraltrust.ai/settings/audit-logs" target="_blank">**Settings** → **Audit Logs**</a>
+1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available)
 2. Filter by Event Type: **Login Success**
-3. Look for events with "Break-glass user logged in via password" in the description
+3. Look for break-glass sign-in events in the description
 
 ---
 

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -347,7 +347,7 @@ If **Trust Identity Provider** is enabled, new users authenticated by the IdP ca
 Configure emergency password access before enforcing SSO.
 
 1. On the **Generic OIDC** tab, scroll below the OIDC credentials form to find **Break the Glass Users** (below **SSO Enforcement**)
-2. Add up to **10** administrator emails who can log in with password during emergencies
+2. Add up to **5** administrator emails (recommended 2-3) who can log in with password during emergencies
 3. Click **Save**
 
 <Note>

--- a/platform/overview.mdx
+++ b/platform/overview.mdx
@@ -102,9 +102,9 @@ Access is driven by **platform roles** and **per-product permission levels**. Se
 
 | Access | Scope |
 | --- | --- |
-| **Owner** | One accountable owner per organization. Everything a Global Admin can do, plus transfer ownership, final billing approval, and delete the organization. |
-| **Global Admin** | Full admin across products and Platform Settings. Multiple Global Admins are allowed. |
-| **Break the Glass** | Emergency access equivalent to Global Admin, with password login and no MFA. See [Break-glass access](/platform/break-glass). |
+| **Owner** | One accountable owner per organization. Everything a Global Admin can do, plus transfer ownership and delete the organization. |
+| **Global Admin** | Admin on all products and Platform Settings, including billing. Multiple Global Admins are allowed. |
+| **Break the Glass** | Global Admin permissions, with password login and no MFA. See [Break-glass access](/platform/break-glass). |
 | **Product Admin / Editor / Viewer** | Per-product levels (and optional gateway/collector scopes). Controls what someone can do inside each product. |
 | **IAM Admin** | Required to manage users, roles, SSO, SCIM, and most Integrations settings. |
 

--- a/platform/scim.mdx
+++ b/platform/scim.mdx
@@ -5,6 +5,10 @@ description: "Set up SCIM automatic user provisioning with Microsoft Entra ID. A
 
 # SCIM Automatic User Provisioning
 
+<Note>
+SCIM is available for **Microsoft Entra ID** only. Generic OIDC SSO does not include SCIM — use invitations or [User sync](/platform/user-sync) where applicable. Prefer SCIM over manual invites when both are enabled to avoid duplicate or conflicting memberships.
+</Note>
+
 SCIM (System for Cross-domain Identity Management) automatically creates, updates, and removes NeuralTrust user accounts when changes happen in your Microsoft Entra ID directory. No manual user management needed.
 
 ## Benefits

--- a/platform/scim.mdx
+++ b/platform/scim.mdx
@@ -265,7 +265,7 @@ When you regenerate a token, you must update the Secret Token in Azure immediate
 
 Provisioning events are logged in NeuralTrust Audit Logs:
 
-1. Go to <a href="https://app.neuraltrust.ai/settings/audit-logs" target="_blank">**Settings** → **Audit Logs**</a>
+1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available)
 2. Filter by Category: **SSO Security**
 3. Look for events like:
    - `scim.user.provisioned`

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -213,16 +213,17 @@ If permissions don't show "Granted", click **Grant admin consent for [Your Organ
 
 | Role | Access Level |
 |------|--------------|
-| **Global Admin** (or Admin template) | Full admin across products and platform settings; billing visibility |
-| **Editor** / **Viewer** / product matrix | Product permission levels — see [User & Roles](/platform/users) |
+| **Global Admin** | Full admin across products and platform settings; billing visibility |
+| **Admin** | Manage members, most settings |
+| **Editor** / **Viewer** | Product permission levels — see [User & Roles](/platform/users) |
 
 <Note>
-Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization; transfer ownership in User & Roles instead.
+Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization; transfer ownership in User & Roles instead. Predefined role templates are Global Admin, Break the Glass, Admin, Editor, and Viewer.
 </Note>
 
-6. Configure **Product Access** when mapping non–Global Admin roles:
+6. Configure **Product Access** when mapping Editor / Viewer (and similar non–full-admin) roles:
    - Select which products/features the group members can access
-   - Global Admin mappings have full product Admin access
+   - Global Admin and Admin mappings have broad product Admin access
 
 7. Enable **Auto Sync** to include this group in synchronization
 8. Click **Save**
@@ -246,7 +247,7 @@ Users are assigned the role from the **first matching group mapping**. If a user
 |--------|-------------|
 | **Azure AD Group** | The source group in Microsoft Entra ID |
 | **NeuralTrust Role** | Role assigned to group members |
-| **Product Access** | Specific products accessible (Member role only) |
+| **Product Access** | Specific products accessible (Editor / Viewer and similar mappings) |
 | **Auto Sync** | Whether group is included in sync operations |
 
 ---

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -213,13 +213,16 @@ If permissions don't show "Granted", click **Grant admin consent for [Your Organ
 
 | Role | Access Level |
 |------|--------------|
-| **Owner** | Full team access, all settings, billing |
-| **Admin** | Manage members, most settings |
-| **Member** | Basic access to team resources |
+| **Global Admin** (or Admin template) | Full admin across products and platform settings; billing visibility |
+| **Editor** / **Viewer** / product matrix | Product permission levels — see [User & Roles](/platform/users) |
 
-6. Configure **Product Access** (for Member role only):
+<Note>
+Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization; transfer ownership in User & Roles instead.
+</Note>
+
+6. Configure **Product Access** when mapping non–Global Admin roles:
    - Select which products/features the group members can access
-   - Admin and Owner roles automatically have full access
+   - Global Admin mappings have full product Admin access
 
 7. Enable **Auto Sync** to include this group in synchronization
 8. Click **Save**

--- a/platform/users.mdx
+++ b/platform/users.mdx
@@ -24,10 +24,12 @@ Managing users and roles requires **IAM Admin** access (or Owner / Global Admin 
 
 Access has two layers:
 
-1. **Structural roles** — Owner, Global Admin, Break the Glass — grant full platform administration.
-2. **Product permission levels** — No access, Viewer, Editor, Admin — set per product (and optionally scoped to specific TrustGate gateways or TrustGuard collectors).
+1. **Org roles** — Owner, Global Admin, Break the Glass, plus product templates (Admin / Editor / Viewer). Owner and Global Admin have **Admin on every product** plus billing; Owner can also **delete the organization**. Break the Glass has the same permissions as Global Admin (emergency password login — see [Break-glass](/platform/break-glass)).
+2. **Product permissions** — No access, Viewer, Editor, Admin — set per product (and optionally scoped to specific TrustGate gateways or TrustGuard collectors).
 
-**Roles** in the Roles tab are reusable templates that apply a structural flag or a product permission matrix when you invite or edit a user.
+**Roles** in the Roles tab are reusable templates that apply an org role or a product permission matrix when you invite or edit a user.
+
+Normal users are **passwordless** (magic link or SSO). Only Break the Glass accounts use a password (minimum 30 characters).
 
 ### Structural roles
 

--- a/platform/users.mdx
+++ b/platform/users.mdx
@@ -35,8 +35,8 @@ Normal users are **passwordless** (magic link or SSO). Only Break the Glass acco
 
 | Role | Who | Capabilities |
 |---|---|---|
-| **Owner** | Exactly one per organization | Everything a Global Admin can do, plus transfer ownership, final billing approval, and delete the organization |
-| **Global Admin** | Multiple allowed | Full admin across all products and Platform Settings; billing visibility (Owner holds final approval) |
+| **Owner** | Exactly one per organization | Everything a Global Admin can do, plus transfer ownership and delete the organization |
+| **Global Admin** | Multiple allowed | Admin on all products and Platform Settings, including billing |
 | **Break the Glass** | Emergency accounts | Global Admin permissions, password login without MFA, sign-ins alert organization admins |
 
 See [Break-glass access](/platform/break-glass) for the difference between Break the Glass *accounts* and the SSO break-glass *email list*.


### PR DESCRIPTION
## Summary
- Clarify org roles vs product permissions (Owner/GA/BtG)
- Normal users passwordless; only Break the Glass has password (max 5, recommend 2–3)
- Remove Owner from Entra group→role mapping; SCIM Entra-only note
- Drop dead `/platform/password-policy` redirect; retarget feature-flags

## Test plan
- [ ] users, break-glass, sso, scim, audit-logs, docs.json redirects

Made with [Cursor](https://cursor.com)