### PR TITLE
docs(trustgate): clarify shared auth across consumers via slug

### DIFF
--- a/trustgate/concepts/auth.mdx
+++ b/trustgate/concepts/auth.mdx
@@ -8,6 +8,10 @@ An **auth** credential is how a client proves it may act as a
 **attached** to one or more consumers, so you can rotate or share them independently of the
 consumer itself.
 
+<Note>
+The same auth (API key or IdP credential) can be attached to several consumers. The request still targets a consumer by **`/{consumer_slug}/…`** — the credential proves access; the slug selects which consumer. Prefer one auth per consumer when you can; sharing is supported but weaker for audit and rotation.
+</Note>
+
 This is distinct from a registry's [target auth](/trustgate/concepts/registries#target-auth),
 which is how TrustGate authenticates to the **upstream provider**.
 


### PR DESCRIPTION
## Summary
- Note on Auth: one API key / IdP credential can attach to several consumers; `/{consumer_slug}/…` selects the consumer
- Prefer one auth per consumer; sharing is supported but weaker for audit/rotation

## Test plan
- [ ] Preview Auth page Note renders correctly


Made with [Cursor](https://cursor.com)