### PR TITLE
docs(platform): clarify SSO enforce and Break the Glass accounts

### DIFF
--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -1,224 +1,121 @@
 ---
 title: Break the Glass
-description: "Configure emergency Break the Glass accounts in User & Roles. Single-organization accounts sign in with password only—bypassing SSO and magic link."
+description: "Configure up to five emergency Break the Glass accounts in User & Roles. A single-organization account signs in with password only."
 ---
 
 # Break the Glass (Emergency Access)
 
-**Break the Glass** accounts are emergency administrators created in
+**Break the Glass** accounts are emergency administrators you create in
 **[User & Roles](/platform/users)**. They have the same permissions as **Global
-Admin** and sign in with a **password** (no MFA). Normal users are
-**passwordless** (magic link or SSO only).
+Admin**, use a **password** (minimum 30 characters, no MFA), and exist so you
+are not locked out when SSO or your identity provider fails.
 
-There is no separate SSO Configurations break-glass email list — only Break the
-Glass accounts managed under User & Roles.
+Normal users are **passwordless** (magic link or SSO only). You may create up to
+**five** Break the Glass accounts per organization (recommended **2–3**).
 
 <Warning>
-Always keep at least one Break the Glass account when **Enforce SSO** is
-enabled. Otherwise an IdP outage can lock out your entire organization.
+Keep at least one Break the Glass account before enabling **Enforce SSO**.
+Otherwise an IdP outage can lock out your entire organization.
 </Warning>
 
----
+## When to use it
 
-## When to Use It
+- Identity provider outage or SSO misconfiguration
+- Incident response when SSO sign-in is unavailable
 
-- Your identity provider (IdP) is down or experiencing issues
-- You need to access NeuralTrust during an SSO misconfiguration
-- Emergency situations where SSO login is not working
-- IT administrators need guaranteed access for incident response
+## Organization membership
 
----
+Treat Break the Glass as **emergency-only**, and assign each account to
+**exactly one organization**.
 
-## Organization membership (required)
+| Membership | Sign-in behavior |
+|---|---|
+| **One organization (required)** | **Password only** — always. Skips SSO and magic link. |
+| **Multiple organizations (avoid)** | Sign-in requires a **magic link first**, then shows the organizations the account can access. Selecting an organization that uses SSO continues with that org's IdP (for example Okta, Entra ID, or another OIDC provider). After IdP authentication succeeds, the user is signed in. |
 
-Treat Break the Glass as an **emergency-only** account:
+The magic-link step for multi-org accounts exists so organization membership is
+not disclosed before the email is verified.
 
-- Assign it to **exactly one organization**.
-- Do not reuse the same Break the Glass user across multiple organizations.
+## Create a Break the Glass account
 
-**Single organization (required):** the account signs in with **password only**.
-It always skips SSO and magic link.
+1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin.
+2. Open **User & Roles**.
+3. Invite a user or edit a member and apply the **Break the glass** role
+   template (or mark the user as Break the Glass). The console provisions a long
+   password (≥ 30 characters) — store it in your secret manager.
+4. Confirm the account belongs to **only this** organization (maximum **five**
+   Break the Glass accounts per organization).
+5. Configure your **Email Domain**, then enable **Enforce SSO** when ready —
+   see [Microsoft Entra ID SSO](/platform/sso) or
+   [Generic OIDC SSO](/platform/generic-oidc-sso).
 
-**Multiple organizations (avoid):** sign-in asks for a **magic link before the
-password**. That step avoids revealing which organizations the account can
-access until the email is verified.
-
----
-
-## How It Works
-
-1. An Owner or Admin creates a Break the Glass account in **User & Roles**
-   (password ≥ 30 characters).
-2. With **exactly one** organization membership, that account always
-   authenticates with **password only** — it does not use SSO or magic link.
-3. When **Enforce SSO** is on, everyone else must use the configured IdP; the
-   Break the Glass account still uses password.
-4. All Break the Glass logins are recorded in Audit Logs.
-
-### Normal user vs Break the Glass
+## Sign-in comparison
 
 | Scenario | Normal user | Break the Glass (single org) |
 |----------|-------------|------------------------------|
-| Sign-in | Magic link or SSO (passwordless) | **Password only** (skips SSO and magic link) |
-| SSO Enforcement ON | Must use the configured IdP SSO | **Password only** |
-| IdP is down | Cannot use SSO | Can log in with password |
+| Day-to-day sign-in | Magic link or SSO | **Password only** |
+| Enforce SSO ON | Must use the configured IdP | **Password only** |
+| IdP down | Cannot use SSO | Password still works |
 
----
-
-## Prerequisites
-
-Before relying on a Break the Glass account for Enforce SSO:
-
-| Requirement | Why |
-|-------------|-----|
-| Account created in [User & Roles](/platform/users) as Break the Glass | Only BtG accounts have passwords |
-| Password ≥ 30 characters | Console-enforced minimum |
-| Member of **exactly one** organization | Password-only path; multi-org triggers magic link first |
-| Email Domain configured for the organization | Required before Enforce SSO |
-
----
-
-## Hardening (recommended)
-
-- Keep **2–3** accounts — not everyone.
-- Rotate BtG passwords periodically; store them in your secret manager.
-- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
-- Disable or remove BtG access when the emergency is over.
-
-## Creating a Break the Glass Account
-
-### Step 1: Open User & Roles
-
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Go to **User & Roles**
-
-### Step 2: Create or promote the account
-
-1. Invite a new user or edit an existing member
-2. Apply the **Break the glass** role template (or mark the user as Break the Glass)
-3. The console provisions a long password (minimum **30** characters)
-4. Store the password in your secret manager
-
-### Step 3: Confirm a single organization
-
-1. Ensure the account belongs to **only this** organization
-2. Do not invite the same Break the Glass user into other organizations
-
-### Step 4: Enable Enforce SSO when ready
-
-1. Configure your **Email Domain** under SSO settings
-2. Toggle **Enforce SSO** on the provider page — see [Microsoft Entra ID SSO](/platform/sso) or [Generic OIDC SSO](/platform/generic-oidc-sso)
-
----
-
-## Validation Errors
+## Validation errors
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Password must be at least 30 characters" | Password too short for Break the Glass | Set a password of at least 30 characters |
-| User cannot use password sign-in | User is not a Break the Glass account | Promote the user to Break the Glass in [User & Roles](/platform/users) |
-| Magic link required before password | Account belongs to more than one organization | Remove extra organization memberships so only one remains |
+| Password too short | Below the 30-character minimum | Set a longer password |
+| Cannot use password sign-in | User is not Break the Glass | Promote the user in [User & Roles](/platform/users) |
+| Magic link required / org picker shown | Account is in more than one organization | Remove extra memberships so only one remains |
+| Maximum accounts reached | Already have five Break the Glass accounts | Remove or demote an existing account first |
 
----
+## Remove Break the Glass access
 
-## How Break the Glass Login Works
+In **User & Roles**, remove the Break the Glass role (or delete the account).
+The user then follows normal passwordless sign-in (magic link or SSO).
 
-### For Normal Users
-
-1. User goes to login page
-2. Enters email
-3. System sends a magic link, or redirects to SSO if enforced/configured
-4. No password option — normal accounts are always passwordless
-
-### For Break the Glass (single organization)
-
-1. User goes to login page
-2. Enters email
-3. Enters password
-4. Login succeeds with password (SSO and magic link are skipped)
-5. Event logged in Audit Logs
-
-### For Break the Glass (multiple organizations — avoid)
-
-1. User goes to login page
-2. Enters email
-3. System requires a **magic link** first (so organization membership is not disclosed)
-4. After the magic link, the user can enter the password
-
----
-
-## Removing Break the Glass Access
-
-1. Go to **User & Roles**
-2. Edit the user and remove the Break the Glass role (or delete the account)
-3. The user will then follow normal passwordless sign-in (magic link or SSO)
-
----
-
-## Audit Logging
-
-All break-glass activity is logged for compliance and security monitoring.
-
-### Events Logged
+## Audit logging
 
 | Event | Description |
 |-------|-------------|
-| `auth.login.success` | Break-glass user logged in successfully (metadata includes `isBreakGlassAccess: true`) |
-| `auth.login.failure` | Break-glass login attempt failed |
+| `auth.login.success` | Successful login (metadata may include `isBreakGlassAccess: true`) |
+| `auth.login.failure` | Failed login attempt |
 
-### Viewing Break-Glass Events
+Review these in **Audit Logs** (under Telemetry / Logs when available). Filter
+by login success to monitor emergency access.
 
-1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available)
-2. Filter by Event Type: **Login Success**
-3. Look for break-glass sign-in events in the description
-
----
-
-## Security Best Practices
+## Security best practices
 
 | Recommendation | Why |
 |----------------|-----|
-| Keep 2–3 Break the Glass accounts | Redundancy if one operator is unavailable |
-| One organization per account | Enables password-only sign-in; avoids magic-link-before-password |
-| Use strong passwords (≥ 30 characters) | Break the Glass accounts are high-value targets |
-| Store passwords in a secret manager | Limit who can retrieve emergency credentials |
-| Test quarterly | Ensure operators can still sign in in an emergency |
-| Document the process | Include in your incident response runbook |
-| Monitor audit logs | Review Break the Glass usage regularly |
-
----
+| Keep 2–3 accounts (hard max **5**) | Redundancy without widening the emergency surface |
+| One organization per account | Keeps the password-only path |
+| Strong password (≥ 30 characters) in a secret manager | Sole credential; no MFA |
+| Treat every BtG sign-in as an incident | Audit alerts notify organization admins |
+| Test quarterly and document the runbook | Operators can still sign in in an emergency |
 
 ## FAQ
 
-**Q: What happens if my IdP is down and I'm not a Break the Glass user?**
+**Q: What if my IdP is down and I am not a Break the Glass user?**
 
-You won't be able to log in until the IdP is restored. Configure Break the Glass accounts proactively before enabling Enforce SSO.
+You cannot sign in until the IdP recovers. Create Break the Glass accounts before
+enabling Enforce SSO.
 
-**Q: Can a Break the Glass account (single org) also use SSO or magic link?**
+**Q: Can a single-org Break the Glass account use SSO or magic link?**
 
-No. With a single organization membership it signs in with **password only** — it always skips SSO and magic link.
+No. It always signs in with **password only**.
 
-**Q: Is there a way to know when Break the Glass was used?**
+**Q: What if my account belongs to several organizations?**
 
-Yes. All Break the Glass logins appear in Audit Logs with a specific flag. Filter for these events to monitor emergency access.
+You receive a **magic link** before any organizations are shown. After you open
+it, pick an organization. If that organization enforces SSO, you complete
+authentication with its IdP (Okta, Entra ID, and so on) and then enter the
+product.
 
-**Q: What if I have no Break the Glass account and SSO goes down?**
+**Q: How do I know Break the Glass was used?**
 
-You would be locked out. Always keep at least one Break the Glass account when Enforce SSO is enabled.
+Check **Audit Logs** for login events flagged as break-glass access.
 
-**Q: Where do I create Break the Glass accounts?**
+## Related documentation
 
-In **User & Roles** only. There is no break-glass email list under SSO Configurations.
-
-**Q: Can Members be Break the Glass users?**
-
-Yes — apply the Break the Glass role in [User & Roles](/platform/users). Regular Member/Admin/Owner accounts without that role are passwordless.
-
----
-
-## Related Documentation
-
-- [User & Roles](/platform/users) — create Break the Glass accounts
-- [Microsoft Entra ID SSO](/platform/sso) — Enforce SSO
-- [Generic OIDC SSO](/platform/generic-oidc-sso) — Enforce SSO
-- [Audit Logs](/platform/audit-logs) — monitor Break the Glass login events
+- [User & Roles](/platform/users)
+- [Microsoft Entra ID SSO](/platform/sso)
+- [Generic OIDC SSO](/platform/generic-oidc-sso)
+- [Audit Logs](/platform/audit-logs)

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -1,241 +1,86 @@
 ---
 title: Break the Glass
-description: "Configure emergency access for administrators to bypass SSO enforcement. Ensure your team is never locked out during identity provider outages."
+description: "Configure emergency Break the Glass accounts for SSO outages. Keep them limited to one organization and use them only for emergency access."
 ---
 
 # Break the Glass (Emergency Access)
 
-Two related mechanisms keep you from being locked out:
+**Break the Glass** accounts are emergency administrators who can sign in with a
+**password** (no MFA) when SSO is enforced or your identity provider is
+unavailable. Normal users are **passwordless** (magic link or SSO only).
 
-1. **Break the Glass accounts** (org role) — emergency users with **Global Admin** permissions who sign in with a **password** (no MFA). Normal users are **passwordless** (magic link or SSO only).
-2. **SSO break-glass email list** (per IdP) — when SSO enforcement is on, listed emails may still sign in with **magic link** (they do not use a password unless they are also Break the Glass accounts).
-
-This page covers both. Max **5** break-glass users per SSO provider (recommended **2–3**).
-
-## When to Use It
-
-- Your identity provider (IdP) is down or experiencing issues
-- You need to access NeuralTrust during an SSO misconfiguration
-- Emergency situations where SSO login is not working
-- IT administrators need guaranteed access for incident response
+Create and manage these accounts under **[User & Roles](/platform/users)** — not
+under SSO Configurations. Break the Glass has the same permissions as **Global
+Admin**.
 
 <Warning>
-Always keep at least one break-glass user configured when SSO Enforcement is enabled. Otherwise, an IdP outage could lock out your entire team.
+Always keep at least one Break the Glass account before enabling **Enforce SSO**.
+Otherwise an IdP outage can lock out your entire organization.
 </Warning>
 
----
+## When to use it
 
-## Per-Provider Configuration
+- Your identity provider (IdP) is down or misconfigured
+- You need guaranteed access for incident response
+- SSO enforcement is on and you need a password fallback for a trusted emergency
+  operator
 
-<Note>
-Break Glass Users are configured **per SSO provider**. If you have both Microsoft Entra ID and Generic OIDC configured, each provider has its own independent Break Glass configuration.
-</Note>
+## Organization membership (required)
 
-This means:
-- If Microsoft Entra ID is down, users in its Break Glass list can still use **magic link** (or password if they are Break the Glass accounts)
-- If your OIDC provider is down, users in its Break Glass list can still use **magic link** (or password if they are Break the Glass accounts)
-- You should configure Break Glass users for **each** SSO provider you have enabled
+Treat Break the Glass as an **emergency-only** account:
 
----
+- Assign it to **exactly one organization**.
+- Do not reuse the same Break the Glass user across multiple organizations.
 
-## How It Works
+If the account belongs to **more than one organization**, sign-in asks for a
+**magic link before the password**. That step avoids revealing which
+organizations the account can access until the email is verified.
 
-1. Team Owner/Admin adds email addresses to the Break-Glass Users list **for each SSO provider**
-2. Listed users can still use **magic link** when "SSO Enforcement" is ON for that provider (Break the Glass *accounts* can also use password)
-3. All break-glass logins are recorded in Audit Logs for security tracking
-4. Maximum 5 break-glass users per provider (recommended: 2-3)
+## How to create a Break the Glass account
 
-### Normal user vs Break the Glass
+1. Open <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as
+   Owner or Admin.
+2. Go to **User & Roles**.
+3. Invite or edit a user and apply the **Break the glass** role template (or
+   mark the user as Break the Glass). The console provisions a long password
+   (minimum **30** characters).
+4. Store the password in your secret manager and restrict who can use it.
+5. Confirm the account is a member of **only this** organization.
 
-| Scenario | Normal user | Break the Glass |
-|----------|-------------|-----------------|
+Then configure your **Email Domain** and enable **Enforce SSO** on the SSO
+provider page. See [Microsoft Entra ID SSO](/platform/sso) or
+[Generic OIDC SSO](/platform/generic-oidc-sso).
+
+## Sign-in behavior
+
+| Scenario | Normal user | Break the Glass (single org) |
+|----------|-------------|------------------------------|
 | Sign-in | Magic link or SSO (passwordless) | Password (and SSO if configured) |
-| SSO Enforcement ON | SSO (or magic link where allowed) | Password **or** SSO |
+| SSO Enforcement ON | Must use the configured IdP SSO | Password **or** SSO |
 | IdP is down | Cannot use SSO | Can log in with password |
-
----
-
-## Prerequisites
-
-Before adding someone to the break-glass list, they must:
-
-| Requirement | Why |
-|-------------|-----|
-| Have an existing NeuralTrust account | Must have signed up first |
-| Be provisioned as Break the Glass (password ≥ 30 chars) | Only BtG accounts have passwords |
-| Be a member of the organization | Must belong to your org |
-
-<Warning>
-Only Break the Glass accounts have passwords. Create/mark the user as Break the Glass in [User & Roles](/platform/users) before adding them to an SSO break-glass list.
-</Warning>
-
----
 
 ## Hardening (recommended)
 
-- Keep **2–3** accounts (max 5 per provider) — not everyone.
-- Rotate BtG passwords periodically; store them in your secret manager.
-- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
-- Disable or remove BtG access when the emergency is over.
+- Keep **2–3** emergency accounts — not every administrator.
+- Rotate Break the Glass passwords periodically; store them in your secret manager.
+- Treat every Break the Glass sign-in as an incident (audit alerts notify
+  organization admins).
+- Disable or remove Break the Glass access when the emergency is over.
 
-## Configuring Break-Glass Users
+## Audit logging
 
-### Step 1: Open SSO Settings
-
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO**</a>
-3. Select the SSO provider tab you want to configure:
-   - **Microsoft Entra ID** tab
-   - **Generic OIDC** tab
-
-### Step 2: Enable SSO Enforcement
-
-<Note>
-Break-glass configuration only appears when SSO Enforcement is enabled for that provider.
-</Note>
-
-1. In the selected provider tab, toggle **Enforce SSO** to ON
-2. You'll see a warning that password login will be disabled for non-break-glass users
-
-### Step 3: Add Break-Glass Users
-
-1. The **Break Glass Users** section appears below the Enforce SSO toggle
-2. Click **Edit** to enter editing mode
-3. Enter the email address of a team administrator
-4. Click **Add** — the system validates the user meets requirements:
-   - ✓ User exists in the system
-   - ✓ User is a Break the Glass account (the only account type with a password)
-   - ✓ User is a member of this team
-5. Repeat for additional users (recommended: 2-3)
-6. Click **Save**
-
-### Step 4: Verify Configuration
-
-1. You should see the email(s) listed as badges in the Break-Glass Users section
-2. These users can now log in with password even with SSO enforced for this provider
-
-### Step 5: Repeat for Other Providers (If Applicable)
-
-If you have multiple SSO providers configured:
-1. Switch to the other provider tab
-2. Repeat Steps 2-4 to configure Break Glass users for that provider
-
-<Note>
-Break-glass access is limited to 5 users per provider. This is a security best practice — emergency access should be limited to essential administrators only.
-</Note>
-
----
-
-## Validation Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| "This user does not exist in the system" | User hasn't created an account | Have the user sign up for NeuralTrust first |
-| "This user has no password configured" | User is not a Break the Glass account (normal accounts are passwordless) | Promote the user to Break the Glass in [User & Roles](/platform/users) first |
-| "This user is not a member of this team" | User exists but not in your team | Invite the user to join your team first |
-| "Maximum number of users reached" | Already have 5 break-glass users | Remove an existing user before adding a new one |
-| "This email is already added" | Duplicate email | The user is already in the list |
-
----
-
-## How Break-Glass Login Works
-
-### For Normal Users (Not Break-Glass)
-
-1. User goes to login page
-2. Enters email
-3. System sends a magic link, or redirects to SSO if enforced/configured
-4. No password option — normal accounts are always passwordless
-
-### For Break-Glass Users
-
-1. User goes to login page
-2. Enters email
-3. Enters password
-4. System checks: Is this email in the break-glass list? ✓
-5. System checks: Is user a team member? ✓
-6. Login succeeds with password
-7. Event logged in Audit Logs
-
----
-
-## Removing Break-Glass Access
-
-### Step 1: Open Break-Glass Settings
-
-1. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO**</a>
-2. Scroll to **Break the Glass Users**
-
-### Step 2: Remove User
-
-1. Click the **X** or **Remove** button next to the email
-2. Click **Save Break-Glass Users**
-3. The user will now be required to use SSO like everyone else
-
----
-
-## Audit Logging
-
-All break-glass activity is logged for compliance and security monitoring.
-
-### Events Logged
+Break the Glass activity is recorded for compliance monitoring.
 
 | Event | Description |
 |-------|-------------|
-| `auth.login.success` | Break-glass user logged in successfully (metadata includes `isBreakGlassAccess: true`) |
-| `auth.login.failure` | Break-glass login attempt failed |
+| `auth.login.success` | Successful login (metadata may include break-glass access) |
+| `auth.login.failure` | Failed login attempt |
 
-### Viewing Break-Glass Events
+Review sign-in events in **Audit Logs** when investigating emergency access.
 
-1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available)
-2. Filter by Event Type: **Login Success**
-3. Look for break-glass sign-in events in the description
+## Related documentation
 
----
-
-## Security Best Practices
-
-| Recommendation | Why |
-|----------------|-----|
-| Add 2-3 users per provider | Redundancy in case one is unavailable |
-| Use owner/admin accounts | They have permissions to fix SSO issues |
-| Use strong passwords | Break-glass accounts are high-value targets |
-| Test quarterly | Ensure break-glass users remember passwords |
-| Document the process | Include in your incident response runbook |
-| Monitor audit logs | Review break-glass usage regularly |
-
----
-
-## FAQ
-
-**Q: What happens if my IdP is down and I'm not a break-glass user?**
-
-You won't be able to log in until the IdP is restored. This is why it's important to configure break-glass users proactively.
-
-**Q: Can break-glass users also use SSO?**
-
-Yes. Break-glass users can choose either method — password OR SSO. The break-glass setting only enables password as an additional option.
-
-**Q: Is there a way to know when break-glass was used?**
-
-Yes. All break-glass logins appear in Audit Logs with a specific flag. You can filter for these events to monitor emergency access usage.
-
-**Q: What if I remove all break-glass users and SSO goes down?**
-
-You would be locked out. Always keep at least one break-glass user configured when SSO Enforcement is enabled.
-
-**Q: Does break-glass work with any SSO provider?**
-
-Yes. It works with Microsoft Entra ID, generic OIDC providers, and any future SSO integrations. The feature is provider-agnostic.
-
-**Q: Can Members be break-glass users?**
-
-Only if they're a Break the Glass account — the only account type with a password. Promote the user to Break the Glass in [User & Roles](/platform/users) first; regular Member/Admin/Owner accounts are passwordless and can't be added directly.
-
----
-
-## Related Documentation
-
-- [Microsoft Entra ID SSO](/platform/sso) — Set up SSO with Microsoft
-- [Generic OIDC SSO](/platform/generic-oidc-sso) — Set up SSO with Okta, Auth0, etc.
-- [Audit Logs](/platform/audit-logs) — Monitor break-glass login events
+- [User & Roles](/platform/users) — create Break the Glass accounts
+- [Microsoft Entra ID SSO](/platform/sso) — Enforce SSO
+- [Generic OIDC SSO](/platform/generic-oidc-sso) — Enforce SSO
+- [Audit Logs](/platform/audit-logs) — monitor emergency sign-ins

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -14,18 +14,24 @@ Normal users are **passwordless** (magic link or SSO only). You may create up to
 **five** Break the Glass accounts per organization (recommended **2–3**).
 
 <Warning>
-Keep at least one Break the Glass account before enabling **Enforce SSO**.
-Otherwise an IdP outage can lock out your entire organization.
+Always keep at least one Break the Glass account when **Enforce SSO** is
+enabled. Otherwise an IdP outage can lock out your entire organization.
 </Warning>
 
-## When to use it
+---
 
-- Identity provider outage or SSO misconfiguration
-- Incident response when SSO sign-in is unavailable
+## When to Use It
+
+- Your identity provider (IdP) is down or experiencing issues
+- You need to access NeuralTrust during an SSO misconfiguration
+- Emergency situations where SSO login is not working
+- IT administrators need guaranteed access for incident response
+
+---
 
 ## Organization membership
 
-Treat Break the Glass as **emergency-only**, and assign each account to
+Treat Break the Glass as an **emergency-only** account, and assign it to
 **exactly one organization**.
 
 | Membership | Sign-in behavior |
@@ -36,28 +42,53 @@ Treat Break the Glass as **emergency-only**, and assign each account to
 The magic-link step for multi-org accounts exists so organization membership is
 not disclosed before the email is verified.
 
-## Create a Break the Glass account
+---
+
+## How It Works
+
+1. An Owner or Admin creates a Break the Glass account in **User & Roles**
+   (password ≥ 30 characters).
+2. With **exactly one** organization membership, that account always
+   authenticates with **password only** — it does not use SSO or magic link.
+3. When **Enforce SSO** is on, everyone else must use the configured IdP; the
+   Break the Glass account still uses password.
+4. Maximum **five** Break the Glass accounts per organization (recommended: 2–3).
+5. All Break the Glass logins are recorded in Audit Logs.
+
+### Normal user vs Break the Glass
+
+| Scenario | Normal user | Break the Glass (single org) |
+|----------|-------------|------------------------------|
+| Sign-in | Magic link or SSO (passwordless) | **Password only** (skips SSO and magic link) |
+| SSO Enforcement ON | Must use the configured IdP SSO | **Password only** |
+| IdP is down | Cannot use SSO | Can log in with password |
+
+---
+
+## Hardening (recommended)
+
+- Keep **2–3** accounts (max **5** per organization) — not everyone.
+- Rotate BtG passwords periodically; store them in your secret manager.
+- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
+- Disable or remove BtG access when the emergency is over.
+
+---
+
+## Creating a Break the Glass Account
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin.
-2. Open **User & Roles**.
+2. Go to **User & Roles**.
 3. Invite a user or edit a member and apply the **Break the glass** role
    template (or mark the user as Break the Glass). The console provisions a long
    password (≥ 30 characters) — store it in your secret manager.
-4. Confirm the account belongs to **only this** organization (maximum **five**
-   Break the Glass accounts per organization).
+4. Confirm the account belongs to **only this** organization.
 5. Configure your **Email Domain**, then enable **Enforce SSO** when ready —
    see [Microsoft Entra ID SSO](/platform/sso) or
    [Generic OIDC SSO](/platform/generic-oidc-sso).
 
-## Sign-in comparison
+---
 
-| Scenario | Normal user | Break the Glass (single org) |
-|----------|-------------|------------------------------|
-| Day-to-day sign-in | Magic link or SSO | **Password only** |
-| Enforce SSO ON | Must use the configured IdP | **Password only** |
-| IdP down | Cannot use SSO | Password still works |
-
-## Validation errors
+## Validation Errors
 
 | Error | Cause | Solution |
 |-------|-------|----------|
@@ -66,56 +97,89 @@ not disclosed before the email is verified.
 | Magic link required / org picker shown | Account is in more than one organization | Remove extra memberships so only one remains |
 | Maximum accounts reached | Already have five Break the Glass accounts | Remove or demote an existing account first |
 
-## Remove Break the Glass access
+---
 
-In **User & Roles**, remove the Break the Glass role (or delete the account).
-The user then follows normal passwordless sign-in (magic link or SSO).
+## Removing Break the Glass Access
 
-## Audit logging
+1. Go to **User & Roles**.
+2. Edit the user and remove the Break the Glass role (or delete the account).
+3. The user then follows normal passwordless sign-in (magic link or SSO).
+
+---
+
+## Audit Logging
+
+All break-glass activity is logged for compliance and security monitoring.
 
 | Event | Description |
 |-------|-------------|
-| `auth.login.success` | Successful login (metadata may include `isBreakGlassAccess: true`) |
-| `auth.login.failure` | Failed login attempt |
+| `auth.login.success` | Break-glass user logged in successfully (metadata includes `isBreakGlassAccess: true`) |
+| `auth.login.failure` | Break-glass login attempt failed |
 
-Review these in **Audit Logs** (under Telemetry / Logs when available). Filter
-by login success to monitor emergency access.
+### Viewing Break-Glass Events
 
-## Security best practices
+1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available).
+2. Filter by Event Type: **Login Success**.
+3. Look for break-glass sign-in events in the description.
+
+---
+
+## Security Best Practices
 
 | Recommendation | Why |
 |----------------|-----|
-| Keep 2–3 accounts (hard max **5**) | Redundancy without widening the emergency surface |
-| One organization per account | Keeps the password-only path |
-| Strong password (≥ 30 characters) in a secret manager | Sole credential; no MFA |
-| Treat every BtG sign-in as an incident | Audit alerts notify organization admins |
-| Test quarterly and document the runbook | Operators can still sign in in an emergency |
+| Add 2–3 users (max **5** per organization) | Redundancy in case one is unavailable |
+| Use owner/admin–capable accounts | They have permissions to fix SSO issues |
+| Use strong passwords (≥ 30 characters) | Break-glass accounts are high-value targets |
+| One organization per account | Keeps the password-only sign-in path |
+| Test quarterly | Ensure break-glass users remember passwords |
+| Document the process | Include in your incident response runbook |
+| Monitor audit logs | Review break-glass usage regularly |
+
+---
 
 ## FAQ
 
-**Q: What if my IdP is down and I am not a Break the Glass user?**
+**Q: What happens if my IdP is down and I'm not a Break the Glass user?**
 
-You cannot sign in until the IdP recovers. Create Break the Glass accounts before
-enabling Enforce SSO.
+You won't be able to log in until the IdP is restored. Configure Break the Glass
+accounts proactively before enabling Enforce SSO.
 
-**Q: Can a single-org Break the Glass account use SSO or magic link?**
+**Q: Can a Break the Glass account (single org) also use SSO or magic link?**
 
-No. It always signs in with **password only**.
+No. With a single organization membership it signs in with **password only** —
+it always skips SSO and magic link.
 
 **Q: What if my account belongs to several organizations?**
 
 You receive a **magic link** before any organizations are shown. After you open
 it, pick an organization. If that organization enforces SSO, you complete
 authentication with its IdP (Okta, Entra ID, and so on) and then enter the
-product.
+product. Prefer a dedicated single-org Break the Glass account for emergencies.
 
-**Q: How do I know Break the Glass was used?**
+**Q: Is there a way to know when Break the Glass was used?**
 
-Check **Audit Logs** for login events flagged as break-glass access.
+Yes. All Break the Glass logins appear in Audit Logs with a specific flag.
 
-## Related documentation
+**Q: What if I have no Break the Glass account and SSO goes down?**
 
-- [User & Roles](/platform/users)
-- [Microsoft Entra ID SSO](/platform/sso)
-- [Generic OIDC SSO](/platform/generic-oidc-sso)
-- [Audit Logs](/platform/audit-logs)
+You would be locked out. Always keep at least one Break the Glass account when
+Enforce SSO is enabled.
+
+**Q: Where do I create Break the Glass accounts?**
+
+In **User & Roles**.
+
+**Q: Can Members be Break the Glass users?**
+
+Yes — apply the Break the Glass role in [User & Roles](/platform/users). Accounts
+without that role are passwordless.
+
+---
+
+## Related Documentation
+
+- [User & Roles](/platform/users) — create Break the Glass accounts
+- [Microsoft Entra ID SSO](/platform/sso) — Enforce SSO
+- [Generic OIDC SSO](/platform/generic-oidc-sso) — Enforce SSO
+- [Audit Logs](/platform/audit-logs) — monitor Break the Glass login events

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -1,29 +1,33 @@
 ---
 title: Break the Glass
-description: "Configure emergency Break the Glass accounts for SSO outages. Keep them limited to one organization and use them only for emergency access."
+description: "Configure emergency Break the Glass accounts in User & Roles. Single-organization accounts sign in with password only—bypassing SSO and magic link."
 ---
 
 # Break the Glass (Emergency Access)
 
-**Break the Glass** accounts are emergency administrators who can sign in with a
-**password** (no MFA) when SSO is enforced or your identity provider is
-unavailable. Normal users are **passwordless** (magic link or SSO only).
+**Break the Glass** accounts are emergency administrators created in
+**[User & Roles](/platform/users)**. They have the same permissions as **Global
+Admin** and sign in with a **password** (no MFA). Normal users are
+**passwordless** (magic link or SSO only).
 
-Create and manage these accounts under **[User & Roles](/platform/users)** — not
-under SSO Configurations. Break the Glass has the same permissions as **Global
-Admin**.
+There is no separate SSO Configurations break-glass email list — only Break the
+Glass accounts managed under User & Roles.
 
 <Warning>
-Always keep at least one Break the Glass account before enabling **Enforce SSO**.
-Otherwise an IdP outage can lock out your entire organization.
+Always keep at least one Break the Glass account when **Enforce SSO** is
+enabled. Otherwise an IdP outage can lock out your entire organization.
 </Warning>
 
-## When to use it
+---
 
-- Your identity provider (IdP) is down or misconfigured
-- You need guaranteed access for incident response
-- SSO enforcement is on and you need a password fallback for a trusted emergency
-  operator
+## When to Use It
+
+- Your identity provider (IdP) is down or experiencing issues
+- You need to access NeuralTrust during an SSO misconfiguration
+- Emergency situations where SSO login is not working
+- IT administrators need guaranteed access for incident response
+
+---
 
 ## Organization membership (required)
 
@@ -32,55 +36,189 @@ Treat Break the Glass as an **emergency-only** account:
 - Assign it to **exactly one organization**.
 - Do not reuse the same Break the Glass user across multiple organizations.
 
-If the account belongs to **more than one organization**, sign-in asks for a
-**magic link before the password**. That step avoids revealing which
-organizations the account can access until the email is verified.
+**Single organization (required):** the account signs in with **password only**.
+It always skips SSO and magic link.
 
-## How to create a Break the Glass account
+**Multiple organizations (avoid):** sign-in asks for a **magic link before the
+password**. That step avoids revealing which organizations the account can
+access until the email is verified.
 
-1. Open <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as
-   Owner or Admin.
-2. Go to **User & Roles**.
-3. Invite or edit a user and apply the **Break the glass** role template (or
-   mark the user as Break the Glass). The console provisions a long password
-   (minimum **30** characters).
-4. Store the password in your secret manager and restrict who can use it.
-5. Confirm the account is a member of **only this** organization.
+---
 
-Then configure your **Email Domain** and enable **Enforce SSO** on the SSO
-provider page. See [Microsoft Entra ID SSO](/platform/sso) or
-[Generic OIDC SSO](/platform/generic-oidc-sso).
+## How It Works
 
-## Sign-in behavior
+1. An Owner or Admin creates a Break the Glass account in **User & Roles**
+   (password ≥ 30 characters).
+2. With **exactly one** organization membership, that account always
+   authenticates with **password only** — it does not use SSO or magic link.
+3. When **Enforce SSO** is on, everyone else must use the configured IdP; the
+   Break the Glass account still uses password.
+4. All Break the Glass logins are recorded in Audit Logs.
+
+### Normal user vs Break the Glass
 
 | Scenario | Normal user | Break the Glass (single org) |
 |----------|-------------|------------------------------|
-| Sign-in | Magic link or SSO (passwordless) | Password (and SSO if configured) |
-| SSO Enforcement ON | Must use the configured IdP SSO | Password **or** SSO |
+| Sign-in | Magic link or SSO (passwordless) | **Password only** (skips SSO and magic link) |
+| SSO Enforcement ON | Must use the configured IdP SSO | **Password only** |
 | IdP is down | Cannot use SSO | Can log in with password |
+
+---
+
+## Prerequisites
+
+Before relying on a Break the Glass account for Enforce SSO:
+
+| Requirement | Why |
+|-------------|-----|
+| Account created in [User & Roles](/platform/users) as Break the Glass | Only BtG accounts have passwords |
+| Password ≥ 30 characters | Console-enforced minimum |
+| Member of **exactly one** organization | Password-only path; multi-org triggers magic link first |
+| Email Domain configured for the organization | Required before Enforce SSO |
+
+---
 
 ## Hardening (recommended)
 
-- Keep **2–3** emergency accounts — not every administrator.
-- Rotate Break the Glass passwords periodically; store them in your secret manager.
-- Treat every Break the Glass sign-in as an incident (audit alerts notify
-  organization admins).
-- Disable or remove Break the Glass access when the emergency is over.
+- Keep **2–3** accounts — not everyone.
+- Rotate BtG passwords periodically; store them in your secret manager.
+- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
+- Disable or remove BtG access when the emergency is over.
 
-## Audit logging
+## Creating a Break the Glass Account
 
-Break the Glass activity is recorded for compliance monitoring.
+### Step 1: Open User & Roles
+
+1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
+2. Go to **User & Roles**
+
+### Step 2: Create or promote the account
+
+1. Invite a new user or edit an existing member
+2. Apply the **Break the glass** role template (or mark the user as Break the Glass)
+3. The console provisions a long password (minimum **30** characters)
+4. Store the password in your secret manager
+
+### Step 3: Confirm a single organization
+
+1. Ensure the account belongs to **only this** organization
+2. Do not invite the same Break the Glass user into other organizations
+
+### Step 4: Enable Enforce SSO when ready
+
+1. Configure your **Email Domain** under SSO settings
+2. Toggle **Enforce SSO** on the provider page — see [Microsoft Entra ID SSO](/platform/sso) or [Generic OIDC SSO](/platform/generic-oidc-sso)
+
+---
+
+## Validation Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Password must be at least 30 characters" | Password too short for Break the Glass | Set a password of at least 30 characters |
+| User cannot use password sign-in | User is not a Break the Glass account | Promote the user to Break the Glass in [User & Roles](/platform/users) |
+| Magic link required before password | Account belongs to more than one organization | Remove extra organization memberships so only one remains |
+
+---
+
+## How Break the Glass Login Works
+
+### For Normal Users
+
+1. User goes to login page
+2. Enters email
+3. System sends a magic link, or redirects to SSO if enforced/configured
+4. No password option — normal accounts are always passwordless
+
+### For Break the Glass (single organization)
+
+1. User goes to login page
+2. Enters email
+3. Enters password
+4. Login succeeds with password (SSO and magic link are skipped)
+5. Event logged in Audit Logs
+
+### For Break the Glass (multiple organizations — avoid)
+
+1. User goes to login page
+2. Enters email
+3. System requires a **magic link** first (so organization membership is not disclosed)
+4. After the magic link, the user can enter the password
+
+---
+
+## Removing Break the Glass Access
+
+1. Go to **User & Roles**
+2. Edit the user and remove the Break the Glass role (or delete the account)
+3. The user will then follow normal passwordless sign-in (magic link or SSO)
+
+---
+
+## Audit Logging
+
+All break-glass activity is logged for compliance and security monitoring.
+
+### Events Logged
 
 | Event | Description |
 |-------|-------------|
-| `auth.login.success` | Successful login (metadata may include break-glass access) |
-| `auth.login.failure` | Failed login attempt |
+| `auth.login.success` | Break-glass user logged in successfully (metadata includes `isBreakGlassAccess: true`) |
+| `auth.login.failure` | Break-glass login attempt failed |
 
-Review sign-in events in **Audit Logs** when investigating emergency access.
+### Viewing Break-Glass Events
 
-## Related documentation
+1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available)
+2. Filter by Event Type: **Login Success**
+3. Look for break-glass sign-in events in the description
+
+---
+
+## Security Best Practices
+
+| Recommendation | Why |
+|----------------|-----|
+| Keep 2–3 Break the Glass accounts | Redundancy if one operator is unavailable |
+| One organization per account | Enables password-only sign-in; avoids magic-link-before-password |
+| Use strong passwords (≥ 30 characters) | Break the Glass accounts are high-value targets |
+| Store passwords in a secret manager | Limit who can retrieve emergency credentials |
+| Test quarterly | Ensure operators can still sign in in an emergency |
+| Document the process | Include in your incident response runbook |
+| Monitor audit logs | Review Break the Glass usage regularly |
+
+---
+
+## FAQ
+
+**Q: What happens if my IdP is down and I'm not a Break the Glass user?**
+
+You won't be able to log in until the IdP is restored. Configure Break the Glass accounts proactively before enabling Enforce SSO.
+
+**Q: Can a Break the Glass account (single org) also use SSO or magic link?**
+
+No. With a single organization membership it signs in with **password only** — it always skips SSO and magic link.
+
+**Q: Is there a way to know when Break the Glass was used?**
+
+Yes. All Break the Glass logins appear in Audit Logs with a specific flag. Filter for these events to monitor emergency access.
+
+**Q: What if I have no Break the Glass account and SSO goes down?**
+
+You would be locked out. Always keep at least one Break the Glass account when Enforce SSO is enabled.
+
+**Q: Where do I create Break the Glass accounts?**
+
+In **User & Roles** only. There is no break-glass email list under SSO Configurations.
+
+**Q: Can Members be Break the Glass users?**
+
+Yes — apply the Break the Glass role in [User & Roles](/platform/users). Regular Member/Admin/Owner accounts without that role are passwordless.
+
+---
+
+## Related Documentation
 
 - [User & Roles](/platform/users) — create Break the Glass accounts
 - [Microsoft Entra ID SSO](/platform/sso) — Enforce SSO
 - [Generic OIDC SSO](/platform/generic-oidc-sso) — Enforce SSO
-- [Audit Logs](/platform/audit-logs) — monitor emergency sign-ins
+- [Audit Logs](/platform/audit-logs) — monitor Break the Glass login events

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -352,7 +352,8 @@ When ready to require SSO for all users:
 
 <Note>
 When enabled, all users must authenticate through the SSO of the IdP configured for
-your organization's access—except break-the-glass accounts.
+your organization's access—except break-the-glass accounts, which sign in with
+**password only** (they skip SSO and magic link).
 
 **Prerequisites:** Add at least one break-the-glass account under
 [User & Roles](/platform/users) and configure your **Email Domain** first.

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -342,22 +342,6 @@ If **Trust Identity Provider** is enabled, new users authenticated by the IdP ca
 
 ---
 
-## Break Glass Users
-
-Configure emergency password access before enforcing SSO.
-
-1. On the **Generic OIDC** tab, scroll below the OIDC credentials form to find **Break the Glass Users** (below **SSO Enforcement**)
-2. Add up to **5** administrator emails (recommended 2-3) who can log in with password during emergencies
-3. Click **Save**
-
-<Note>
-Break-glass lists are **per provider**. Because only one SSO provider can be active at a time, you configure break-glass users for whichever provider is currently enabled. See [Break the Glass](/platform/break-glass) for full details.
-</Note>
-
-**Requirements:** Users must already exist in NeuralTrust, have a password set, and be team members.
-
----
-
 ## Enable SSO Enforcement
 
 When ready to require SSO for all users:
@@ -366,8 +350,18 @@ When ready to require SSO for all users:
 2. Confirm the warning about password login being disabled
 3. Users will now be required to authenticate via your OIDC provider
 
+<Note>
+When enabled, all users must authenticate through the SSO of the IdP configured for
+your organization's access—except break-the-glass accounts.
+
+**Prerequisites:** Add at least one break-the-glass account under
+[User & Roles](/platform/users) and configure your **Email Domain** first.
+</Note>
+
 <Warning>
-Before enabling SSO Enforcement, ensure you have configured [Break Glass Users](#break-glass-users) to prevent being locked out during identity provider outages.
+Before enabling SSO Enforcement, ensure team members can sign in through your OIDC
+provider. Keep a [Break the Glass](/platform/break-glass) emergency account for IdP
+outages.
 </Warning>
 
 ---

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -263,7 +263,8 @@ for your organization.
 
 <Note>
 When enabled, all users must authenticate through the SSO of the IdP configured for
-your organization's access—except break-the-glass accounts.
+your organization's access—except break-the-glass accounts, which sign in with
+**password only** (they skip SSO and magic link).
 
 **Prerequisites:** Add at least one break-the-glass account under
 [User & Roles](/platform/users) and configure your **Email Domain** first.

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -254,19 +254,26 @@ Users are assigned the role from the **first matching group mapping**. If a user
 
 ## Part 5: Enable SSO-Only Mode (Optional)
 
-Enforcing SSO-only mode disables password login for your entire team, requiring all users to sign in with Microsoft.
+Enforcing SSO-only mode requires all users to authenticate through the IdP configured
+for your organization.
 
 1. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO**</a>
 2. Toggle **Enforce SSO** to ON
 3. Confirm the action
 
-<Warning>
-Before enabling SSO-only mode, ensure all team members have Microsoft accounts linked. Users without Microsoft accounts will be locked out.
-</Warning>
-
 <Note>
-To prevent lockouts during identity provider outages, configure [Break the Glass](/platform/break-glass) users who can log in with password even when SSO is enforced.
+When enabled, all users must authenticate through the SSO of the IdP configured for
+your organization's access—except break-the-glass accounts.
+
+**Prerequisites:** Add at least one break-the-glass account under
+[User & Roles](/platform/users) and configure your **Email Domain** first.
 </Note>
+
+<Warning>
+Before enabling SSO-only mode, ensure all team members can sign in with Microsoft.
+Users without access through the IdP will be locked out. Keep a
+[Break the Glass](/platform/break-glass) emergency account for IdP outages.
+</Warning>
 
 ---
 

--- a/platform/users.mdx
+++ b/platform/users.mdx
@@ -39,8 +39,8 @@ Normal users are **passwordless** (magic link or SSO). Only Break the Glass acco
 | **Global Admin** | Multiple allowed | Admin on all products and Platform Settings, including billing |
 | **Break the Glass** | Emergency accounts | Global Admin permissions, password login without MFA, sign-ins alert organization admins |
 
-See [Break the Glass](/platform/break-glass) for emergency-account setup (single
-organization membership and password sign-in when SSO is enforced).
+See [Break the Glass](/platform/break-glass) for emergency accounts (maximum five
+per organization; single-organization membership for password-only sign-in).
 
 ### Product permission levels
 

--- a/platform/users.mdx
+++ b/platform/users.mdx
@@ -39,7 +39,8 @@ Normal users are **passwordless** (magic link or SSO). Only Break the Glass acco
 | **Global Admin** | Multiple allowed | Admin on all products and Platform Settings, including billing |
 | **Break the Glass** | Emergency accounts | Global Admin permissions, password login without MFA, sign-ins alert organization admins |
 
-See [Break-glass access](/platform/break-glass) for the difference between Break the Glass *accounts* and the SSO break-glass *email list*.
+See [Break the Glass](/platform/break-glass) for emergency-account setup (single
+organization membership and password sign-in when SSO is enforced).
 
 ### Product permission levels
 
@@ -164,5 +165,5 @@ Educational reference cards for No access, Viewer, Editor, Admin, Global Admin, 
 - [Microsoft Entra ID SSO](/platform/sso) / [Generic OIDC SSO](/platform/generic-oidc-sso) — sign-in for members.
 - [SCIM Provisioning](/platform/scim) — automate member creation and removal.
 - [User sync & group mappings](/platform/user-sync) — map IdP groups to platform roles.
-- [Break-glass access](/platform/break-glass) — SSO email allowlist and Break the Glass accounts.
+- [Break the Glass](/platform/break-glass) — emergency password accounts for SSO outages.
 - [Audit Logs](/platform/audit-logs) — invites, accepts, role changes, and removals are recorded.


### PR DESCRIPTION
## Summary
- Remove the **SSO Configurations → Break-glass users** email-list documentation (Microsoft Entra and Generic OIDC pages).
- On **Enforce SSO**, add the formal note: all users must use the org IdP SSO except break-the-glass accounts; prerequisites are at least one Break the Glass account under **User & Roles** and a configured **Email Domain**.
- Rewrite [Break the Glass](/platform/break-glass) around emergency accounts only: single-organization membership; multi-org accounts receive a magic link before the password so organizations are not disclosed.

## Test plan
- [ ] Enforce SSO sections on `/platform/sso` and `/platform/generic-oidc-sso` show the new note
- [ ] No remaining steps that add emails under SSO → Break-glass users
- [ ] Break the Glass page covers User & Roles, one-org rule, and magic-link-before-password

Made with [Cursor](https://cursor.com)