### PR TITLE
docs: add v2 hybrid token flow and external deployment guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -108,6 +108,8 @@
                 "pages": [
                   "neuraltrust/deployment/overview",
                   "neuraltrust/deployment/deployment-models",
+                  "neuraltrust/deployment/external",
+                  "neuraltrust/deployment/hybrid-tokens",
                   "neuraltrust/deployment/feature-flags",
                   "neuraltrust/deployment/images",
                   "neuraltrust/deployment/configuration",

--- a/docs.json
+++ b/docs.json
@@ -109,7 +109,7 @@
                   "neuraltrust/deployment/overview",
                   "neuraltrust/deployment/deployment-models",
                   "neuraltrust/deployment/external",
-                  "neuraltrust/deployment/hybrid-tokens",
+                  "neuraltrust/deployment/console-setup",
                   "neuraltrust/deployment/feature-flags",
                   "neuraltrust/deployment/images",
                   "neuraltrust/deployment/configuration",

--- a/neuraltrust/deployment/console-setup.mdx
+++ b/neuraltrust/deployment/console-setup.mdx
@@ -1,6 +1,6 @@
 ---
-title: Hybrid tokens
-description: Create TrustGate and TrustGuard in the console and collect the tokens the Hybrid data plane needs.
+title: Console setup
+description: Before installing, create TrustGate and TrustGuard in the console and collect the tokens the Hybrid data plane needs.
 ---
 
 A Hybrid data plane runs in **your** cluster but is configured and observed by the

--- a/neuraltrust/deployment/deployment-models.mdx
+++ b/neuraltrust/deployment/deployment-models.mdx
@@ -1,19 +1,20 @@
 ---
 title: Deployment models
-description: Choose between SaaS and Hybrid.
+description: Choose between SaaS, Hybrid, and External (self-hosted).
 ---
 
 ## Comparison
 
-| | **SaaS** | **Hybrid** |
-| --- | --- | --- |
-| Control plane | NeuralTrust | NeuralTrust |
-| Data plane (TrustGate / TrustGuard) | NeuralTrust | Your environment |
-| Raw payloads | NeuralTrust | Your PostgreSQL |
-| Metadata / analytics | NeuralTrust | Exported to NeuralTrust (OTLP) |
-| Setup | Nothing to install | Private TrustGate wizard |
+| | **SaaS** | **Hybrid** | **External** |
+| --- | --- | --- | --- |
+| Control plane | NeuralTrust | NeuralTrust | Your environment |
+| Data plane (TrustGate / TrustGuard) | NeuralTrust | Your environment | Your environment |
+| Raw payloads | NeuralTrust | Your PostgreSQL | Your PostgreSQL |
+| Metadata / analytics | NeuralTrust | Exported to NeuralTrust (OTLP) | Your in-cluster ClickHouse |
+| SaaS dependency at runtime | Full | Config sync + metadata export | None (optional hosted export) |
+| Setup | Nothing to install | Private wizard + [tokens](/neuraltrust/deployment/hybrid-tokens) | Self-hosted chart (`deploymentMode: external`) |
 
-The private TrustGate wizard is the starting point for Hybrid. It creates a gateway-scoped deployment and generates its runtime configuration before you install anything.
+The private TrustGate wizard is the starting point for Hybrid. It creates a gateway-scoped deployment and generates its runtime configuration before you install anything. External skips the console entirely and runs every plane in your cluster.
 
 ## SaaS
 
@@ -27,6 +28,8 @@ You run the data plane; NeuralTrust runs the control plane.
 
 **On NeuralTrust SaaS:** the console and control plane that configure and observe that data plane.
 
+Each product you run is a separate console object with its **own** tokens. If you deploy both TrustGate and TrustGuard, create both in the console and collect two token sets. See [Hybrid tokens](/neuraltrust/deployment/hybrid-tokens).
+
 **Between the planes:**
 
 - Outbound OTLP for metadata (payloads stay local)
@@ -39,6 +42,17 @@ No inbound control-plane connection into your network is required for configurat
 Use **Kubernetes** for production-grade deployments. Treat the wizard-generated values as credential and setup input: map them into the maintained `neuraltrust-platform` chart or manifests before deployment. Use **Docker** for local development or evaluation of the LLM/proxy path on `8081`; the generated Compose path does not run MCP. Choose **Manual** for a custom deployment; Manual provides `CONTROL_PLANE_JWT` and `DATA_AGENT_JWT`.
 
 See [Create a private TrustGate gateway](/neuraltrust/deployment/overview#create-a-private-trustgate-gateway) for the current setup flow, [Configuration](/neuraltrust/deployment/configuration) for generated setup and store sizes, [High availability](/neuraltrust/deployment/high-availability) for regional active/passive data planes, and [Secrets](/neuraltrust/deployment/secrets) for credential handling.
+
+## External
+
+You run **everything** — control planes, data planes, the product console, and a
+self-hosted analytics stack (ClickStack collector, ClickHouse, DataCore, and
+AlertEngine). There is no runtime dependency on NeuralTrust SaaS, so **no console
+tokens are issued** and DataAgent does not run. Select it with
+`global.deploymentMode: external`.
+
+Choose External for air-gapped or strict data-residency environments. See the
+[External (self-hosted)](/neuraltrust/deployment/external) guide.
 
 ## Connectivity checklist
 

--- a/neuraltrust/deployment/deployment-models.mdx
+++ b/neuraltrust/deployment/deployment-models.mdx
@@ -12,7 +12,7 @@ description: Choose between SaaS, Hybrid, and External (self-hosted).
 | Raw payloads | NeuralTrust | Your PostgreSQL | Your PostgreSQL |
 | Metadata / analytics | NeuralTrust | Exported to NeuralTrust (OTLP) | Your in-cluster ClickHouse |
 | SaaS dependency at runtime | Full | Config sync + metadata export | None (optional hosted export) |
-| Setup | Nothing to install | Private wizard + [tokens](/neuraltrust/deployment/hybrid-tokens) | Self-hosted chart (`deploymentMode: external`) |
+| Setup | Nothing to install | [Console setup](/neuraltrust/deployment/console-setup) + install | Self-hosted chart (`deploymentMode: external`) |
 
 The private TrustGate wizard is the starting point for Hybrid. It creates a gateway-scoped deployment and generates its runtime configuration before you install anything. External skips the console entirely and runs every plane in your cluster.
 
@@ -28,7 +28,7 @@ You run the data plane; NeuralTrust runs the control plane.
 
 **On NeuralTrust SaaS:** the console and control plane that configure and observe that data plane.
 
-Each product you run is a separate console object with its **own** tokens. If you deploy both TrustGate and TrustGuard, create both in the console and collect two token sets. See [Hybrid tokens](/neuraltrust/deployment/hybrid-tokens).
+Each product you run is a separate console object with its **own** tokens. If you deploy both TrustGate and TrustGuard, create both in the console and collect two token sets. See [Console setup](/neuraltrust/deployment/console-setup).
 
 **Between the planes:**
 

--- a/neuraltrust/deployment/external.mdx
+++ b/neuraltrust/deployment/external.mdx
@@ -1,0 +1,145 @@
+---
+title: External (self-hosted)
+description: Run the full NeuralTrust platform — control plane, data plane, and analytics — inside your own cluster.
+---
+
+**External** is the fully self-hosted topology. Unlike [Hybrid](/neuraltrust/deployment/deployment-models#hybrid),
+which keeps the control plane on NeuralTrust SaaS, External runs **every** plane
+in your environment: control planes, data planes, the product console, and the
+analytics stack. Nothing leaves your network unless you explicitly enable hosted
+export.
+
+Choose External for air-gapped environments, strict data-residency mandates, or
+when policy forbids any outbound dependency on NeuralTrust SaaS.
+
+## What runs in your cluster
+
+External deploys the components Hybrid leaves in SaaS, plus a self-hosted
+analytics pipeline:
+
+| Component | Purpose |
+| --- | --- |
+| AgentGateway admin, proxy, MCP | Gateway administration and the AI request path |
+| TrustGuard control + data planes | Policy administration and runtime safety evaluation |
+| Control-plane API + web app | The product console and its API |
+| ClickStack OTel Collector | Receives product OTLP and writes it to ClickHouse |
+| ClickHouse | Self-hosted analytics store (External only) |
+| DataCore | Residency query API over ClickHouse + PostgreSQL metadata |
+| AlertEngine (API + worker) | Evaluates alert rules and forwards to SIEM/integrations |
+| Firewall | Optional prompt/response safety, deployed with TrustGuard |
+
+<Note>
+**DataAgent does not run in External mode**, and there are **no console-issued
+config-sync or enrollment tokens** to collect. Because the control planes are
+in-cluster, the platform is its own configuration source — you do not create a
+Private gateway in [app.neuraltrust.ai](https://app.neuraltrust.ai/en/v2/) as you
+do for [Hybrid](/neuraltrust/deployment/hybrid-tokens).
+</Note>
+
+## Select the topology
+
+One global value switches the whole platform to self-hosted:
+
+```yaml
+global:
+  deploymentMode: external
+  platform: kubernetes      # aws | gcp | azure | openshift | kubernetes
+  domain: platform.example.com
+```
+
+### First administrator
+
+External seeds an initial super-admin for the console. Prefer a pre-created
+Secret over inline credentials so they never enter Helm release history:
+
+```yaml
+global:
+  superadmin:
+    existingSecret:
+      name: onprem-superadmin   # ONPREM_SUPERADMIN_EMAIL / ONPREM_SUPERADMIN_PASSWORD
+```
+
+## Datastores
+
+PostgreSQL and Redis deploy in-cluster by default in both modes. ClickHouse
+deploys in-cluster **only** in External mode — Hybrid keeps analytics in SaaS.
+
+In External mode, control-plane services use **per-service** databases, and
+AlertEngine owns its own PostgreSQL database. The data-plane API shim reads from
+ClickHouse. The shared `global.postgresql` / `global.redis` connection contract
+used by Hybrid is ignored here; configure datastores through the per-service
+overlays instead.
+
+To use managed datastores, disable the in-cluster components and point each
+service at its endpoint:
+
+```yaml
+global:
+  postgresql:
+    deploy: false
+  redis:
+    deploy: false
+
+infrastructure:
+  clickhouse:
+    deploy: false
+```
+
+Pre-create external PostgreSQL roles and databases before install — the chart
+does not create users in managed services. See
+[Configuration](/neuraltrust/deployment/configuration#managed-stores) for minimum
+sizes and the chart repository's `values-v2-managed-datastores.yaml.example`.
+
+## Telemetry egress
+
+External keeps product telemetry in your in-cluster ClickHouse. To run with **no**
+outbound NeuralTrust SaaS telemetry — the air-gapped default — disable hosted
+export:
+
+```yaml
+global:
+  observability:
+    hostedExport:
+      enabled: false
+```
+
+Disabling hosted export does not disable the in-cluster ClickStack pipeline; it
+only stops optional egress to NeuralTrust.
+
+## Public routing
+
+AgentGateway exposes three surfaces in External mode: **admin** (External only),
+**proxy**, and **MCP**. `global.domain` combines with default prefixes to render
+hostnames, and the chart can auto-add wildcard hosts (`*.llm.<domain>` /
+`*.mcp.<domain>`) for slug-based discovery. DNS, certificates, and cloud
+controller settings remain operator prerequisites. See
+[Configuration](/neuraltrust/deployment/configuration#ingress).
+
+## Install
+
+Start from the maintained `neuraltrust-platform` chart and the tracked
+`values-v2-external.yaml.example`, then layer your platform, domain, ingress, and
+datastore choices:
+
+```bash
+helm upgrade --install neuraltrust-platform <chart> \
+  --namespace neuraltrust --create-namespace \
+  -f values-v2-external.yaml
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Deployment models" icon="diagram-project" href="/neuraltrust/deployment/deployment-models">
+    Compare SaaS, Hybrid, and External responsibilities.
+  </Card>
+  <Card title="Configuration" icon="sliders" href="/neuraltrust/deployment/configuration">
+    Datastores, ingress, and TLS.
+  </Card>
+  <Card title="Secrets" icon="key" href="/neuraltrust/deployment/secrets">
+    Credential handling for a self-hosted install.
+  </Card>
+  <Card title="Firewall" icon="shield" href="/neuraltrust/deployment/firewall">
+    Size the optional Firewall deployed with TrustGuard.
+  </Card>
+</CardGroup>

--- a/neuraltrust/deployment/external.mdx
+++ b/neuraltrust/deployment/external.mdx
@@ -33,7 +33,7 @@ analytics pipeline:
 config-sync or enrollment tokens** to collect. Because the control planes are
 in-cluster, the platform is its own configuration source — you do not create a
 Private gateway in [app.neuraltrust.ai](https://app.neuraltrust.ai/en/v2/) as you
-do for [Hybrid](/neuraltrust/deployment/hybrid-tokens).
+do for [Hybrid](/neuraltrust/deployment/console-setup).
 </Note>
 
 ## Select the topology

--- a/neuraltrust/deployment/feature-flags.mdx
+++ b/neuraltrust/deployment/feature-flags.mdx
@@ -5,18 +5,31 @@ description: Chart switches that change the Hybrid data plane.
 
 | Value | Hybrid guidance | Effect |
 | --- | --- | --- |
-| `global.deploymentMode` | `hybrid` | Required. Renders the data plane. |
+| `global.deploymentMode` | `hybrid` | Required. Selects the Hybrid topology. Use `external` for the self-hosted stack. |
+| `global.products.trustgate` | `true` to run TrustGate | Renders the TrustGate proxy/MCP data plane. Defaults to `false`; select at least one product. |
+| `global.products.trustguard` | `true` to run TrustGuard | Renders the TrustGuard data plane (Firewall follows). |
+| `global.products.dataPlane` | `true` for red-teaming shim | Renders the data-plane API shim. |
 | `global.postgresql.deploy` | **`false` in production** | Use managed PostgreSQL. Set `true` only for an in-cluster evaluation or non-production store. |
 | `global.redis.deploy` | **`false` in production** | Use managed Redis. Set `true` only for an in-cluster evaluation or non-production store. |
-| `global.clickstack.enabled` | `true` | Metadata export to SaaS (OTLP). |
+| `agentgateway.configSync.existingSecret` | Reference your Secret | TrustGate config-sync token + LKG key. Config sync is on by default in Hybrid — do not restate `enabled: true`. |
+| `trustguard.configSync.existingSecret` | Reference your Secret | TrustGuard config-sync token + LKG key. |
+| `agentgateway.dataagent.enrolment.existingSecret` | Reference your Secret | TrustGate DataAgent enrollment token (OTLP egress + DataBridge). |
+| `trustguard.dataagent.enrolment.existingSecret` | Reference your Secret | TrustGuard DataAgent enrollment token. |
 | `agentgateway.mcp.enabled` | `true` | TrustGate MCP (chart key `agentgateway`). |
-| `agentgateway.configSync.enabled` | Enable for Hybrid | TrustGate initiates an outbound configuration pull (chart key `agentgateway`). |
-| `trustguard.configSync.enabled` | Enable for Hybrid | TrustGuard initiates an outbound configuration pull. |
 | `firewall.enabled` / `firewall.firewall.enabled` / `trustguard.firewall.enabled` | Keep aligned | Optional Firewall with TrustGuard. |
 | `global.autoGenerateSecrets` | `true` | Chart-owned secrets when values are empty. |
 | `global.preserveExistingSecrets` | `false` | GitOps: pre-create secrets and set `true`. |
 
 Leave `trustlens.enabled` and `watchdog.enabled` off unless NeuralTrust asks you to enable them.
+
+<Note>
+Product telemetry export is **mandatory** in Hybrid and always on — there is no
+`global.clickstack.enabled: false` opt-out. TrustGate and TrustGuard send OTLP to
+a co-located, enrollment-backed egress collector, so the tokens you collect when
+[creating each product](/neuraltrust/deployment/hybrid-tokens) are required. For a
+deployment with **no** NeuralTrust SaaS dependency, use
+[External mode](/neuraltrust/deployment/external) instead.
+</Note>
 
 Configuration sync is pull-based. TrustGate and TrustGuard dial the SaaS control-plane endpoint from the customer environment; no inbound control-plane connection into the customer network is required.
 

--- a/neuraltrust/deployment/feature-flags.mdx
+++ b/neuraltrust/deployment/feature-flags.mdx
@@ -26,7 +26,7 @@ Leave `trustlens.enabled` and `watchdog.enabled` off unless NeuralTrust asks you
 Product telemetry export is **mandatory** in Hybrid and always on — there is no
 `global.clickstack.enabled: false` opt-out. TrustGate and TrustGuard send OTLP to
 a co-located, enrollment-backed egress collector, so the tokens you collect when
-[creating each product](/neuraltrust/deployment/hybrid-tokens) are required. For a
+[creating each product](/neuraltrust/deployment/console-setup) are required. For a
 deployment with **no** NeuralTrust SaaS dependency, use
 [External mode](/neuraltrust/deployment/external) instead.
 </Note>

--- a/neuraltrust/deployment/hybrid-tokens.mdx
+++ b/neuraltrust/deployment/hybrid-tokens.mdx
@@ -1,0 +1,130 @@
+---
+title: Hybrid tokens
+description: Create TrustGate and TrustGuard in the console and collect the tokens the Hybrid data plane needs.
+---
+
+A Hybrid data plane runs in **your** cluster but is configured and observed by the
+NeuralTrust SaaS control plane. To connect the two, each runtime authenticates to
+SaaS with **tokens issued by the console** at [app.neuraltrust.ai](https://app.neuraltrust.ai/en/v2/).
+
+<Note>
+Tokens are issued **per product instance**. TrustGate and TrustGuard are separate
+console objects, so a Hybrid install that runs both must create **both** and
+collect **two token sets** — one per product.
+</Note>
+
+## What the console issues
+
+When you create a **Private** TrustGate or TrustGuard, the console generates two
+credentials for that instance:
+
+| Token | Purpose | Chart key (`CONFIG_SYNC_TOKEN` / `ENROLMENT_TOKEN`) |
+| --- | --- | --- |
+| **Config-sync token** | Authenticates the runtime's outbound pull of compiled configuration from SaaS. | `CONFIG_SYNC_TOKEN` |
+| **DataAgent enrollment token** | Authorizes the co-located DataAgent for OTLP metadata egress and DataBridge retrieval. | `ENROLMENT_TOKEN` |
+
+Both are JWTs scoped to the specific gateway or TrustGuard instance. The enrollment
+JWT already carries the tenant and instance identifiers — you do not set them
+separately.
+
+## Create a private TrustGate
+
+1. Open [app.neuraltrust.ai](https://app.neuraltrust.ai/en/v2/) and go to **TrustGate → Agent Gateway → Getting started**.
+2. Choose **New Gateway**, enter a name, and select **Private** (*High stakes* — fixed capacity, no cold starts).
+3. Under **Where do you want to run your gateway?** choose **Kubernetes** (recommended for production). Creating the gateway issues its **config-sync token** and **DataAgent enrollment token**.
+4. Copy the two tokens from the generated `values.yaml`. Treat the whole file as a secret — see [Secrets](/neuraltrust/deployment/secrets).
+5. Leave the wizard open. After the data plane is running you return here to set the **Dataplane URL** (see [Overview](/neuraltrust/deployment/overview#create-a-private-trustgate-gateway)).
+
+<Tip>
+**Docker** and **Manual** are also offered. Docker is for local evaluation of the
+LLM/proxy path only (no MCP). Manual returns `CONTROL_PLANE_JWT` and
+`DATA_AGENT_JWT` for fully custom manifests. Use **Kubernetes** for production.
+</Tip>
+
+## Create a private TrustGuard
+
+1. Go to **TrustGuard → Agent Runtime → Getting started**.
+2. Choose **New TrustGuard**, enter a name, and select **Private**.
+3. Choose **Kubernetes**. Creating the TrustGuard issues **its own** config-sync token and DataAgent enrollment token — distinct from TrustGate's.
+4. Copy both tokens.
+
+<Note>
+The TrustGuard wizard offers **Kubernetes** and **Manual** only (no Docker). In a
+combined install, TrustGate and TrustGuard each keep independent tokens; never
+reuse one product's token for the other.
+</Note>
+
+## Map tokens to chart Secrets
+
+For a production Kubernetes install, pre-create the Secrets below and reference
+them from values — keep the raw tokens out of `values.yaml` and source control.
+The config-sync Secret also needs a `CONFIG_SYNC_LKG_KEY`: an operator-generated
+base64 32-byte key that encrypts the last-known-good configuration snapshot
+(`openssl rand -base64 32`).
+
+| Kubernetes Secret | Keys | From |
+| --- | --- | --- |
+| `agentgateway-config-sync` | `CONFIG_SYNC_TOKEN`, `CONFIG_SYNC_LKG_KEY` | TrustGate config-sync token + generated LKG key |
+| `dataagent-enrolment-trustgate` | `ENROLMENT_TOKEN` | TrustGate enrollment token |
+| `trustguard-config-sync` | `CONFIG_SYNC_TOKEN`, `CONFIG_SYNC_LKG_KEY` | TrustGuard config-sync token + generated LKG key |
+| `dataagent-enrolment-trustguard` | `ENROLMENT_TOKEN` | TrustGuard enrollment token |
+
+Reference them from the maintained `neuraltrust-platform` chart. Select the
+products you run with `global.products`, then point each config-sync and
+enrollment block at its Secret:
+
+```yaml
+global:
+  deploymentMode: hybrid
+  products:
+    trustgate: true
+    trustguard: true
+
+agentgateway:
+  configSync:
+    existingSecret:
+      name: agentgateway-config-sync
+  dataagent:
+    enrolment:
+      existingSecret:
+        name: dataagent-enrolment-trustgate
+
+trustguard:
+  configSync:
+    existingSecret:
+      name: trustguard-config-sync
+  dataagent:
+    enrolment:
+      existingSecret:
+        name: dataagent-enrolment-trustguard
+```
+
+Config-sync is **on by default** in Hybrid (mode-derived) — set only
+`existingSecret`; do not restate `enabled: true`. For local or evaluation
+installs you may inline the raw values with `configSync.token` and
+`dataagent.enrolment.token` instead of an `existingSecret`, but those values
+enter Helm release history.
+
+## Regenerate tokens
+
+Issue fresh tokens any time from **Settings → Agent Gateway → Deployment** (TrustGate)
+or the equivalent TrustGuard deployment settings. Regenerating invalidates the
+previous install credentials, so update the corresponding Secret and roll the
+runtime pods.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Overview" icon="compass" href="/neuraltrust/deployment/overview">
+    See the full private-gateway setup flow and network requirements.
+  </Card>
+  <Card title="Secrets" icon="key" href="/neuraltrust/deployment/secrets">
+    Handle config-sync, enrollment, and LKG credentials safely.
+  </Card>
+  <Card title="Feature flags" icon="toggle-right" href="/neuraltrust/deployment/feature-flags">
+    Chart switches that shape the Hybrid data plane.
+  </Card>
+  <Card title="Configuration" icon="sliders" href="/neuraltrust/deployment/configuration">
+    Managed stores, ingress, and generated setup.
+  </Card>
+</CardGroup>

--- a/neuraltrust/deployment/overview.mdx
+++ b/neuraltrust/deployment/overview.mdx
@@ -58,7 +58,7 @@ The private gateway wizard offers three deployment methods:
 Each product runs as a separate console object with its own credentials. A Hybrid
 install that also runs TrustGuard must create a **private TrustGuard** in
 **TrustGuard → Agent Runtime** as well, and collect its own config-sync and
-enrollment tokens. See [Hybrid tokens](/neuraltrust/deployment/hybrid-tokens) for
+enrollment tokens. See [Console setup](/neuraltrust/deployment/console-setup) for
 the full token flow and how to map both products' tokens into chart Secrets.
 </Note>
 

--- a/neuraltrust/deployment/overview.mdx
+++ b/neuraltrust/deployment/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Create and operate a private TrustGate data plane from the NeuralTrust console.
 ---
 
-NeuralTrust supports **SaaS** and **Hybrid**. SaaS is fully operated by NeuralTrust. Hybrid runs the request-path **data plane** in your environment and keeps the **control plane** on NeuralTrust SaaS.
+NeuralTrust supports **SaaS**, **Hybrid**, and **External**. SaaS is fully operated by NeuralTrust. Hybrid runs the request-path **data plane** in your environment and keeps the **control plane** on NeuralTrust SaaS. [External](/neuraltrust/deployment/external) runs every plane — control, data, and analytics — in your own cluster with no runtime SaaS dependency. This guide covers Hybrid; see the [External (self-hosted)](/neuraltrust/deployment/external) guide for the fully self-hosted topology.
 
 ## Architecture
 
@@ -53,6 +53,14 @@ The private gateway wizard offers three deployment methods:
 | **Manual** | Custom or operator-managed deployments | `CONTROL_PLANE_JWT` and `DATA_AGENT_JWT` |
 
 ## Create a private TrustGate gateway
+
+<Note>
+Each product runs as a separate console object with its own credentials. A Hybrid
+install that also runs TrustGuard must create a **private TrustGuard** in
+**TrustGuard → Agent Runtime** as well, and collect its own config-sync and
+enrollment tokens. See [Hybrid tokens](/neuraltrust/deployment/hybrid-tokens) for
+the full token flow and how to map both products' tokens into chart Secrets.
+</Note>
 
 1. Open **TrustGate** and choose **New Gateway**.
 2. Enter a gateway name and choose **Private**.

--- a/neuraltrust/deployment/secrets.mdx
+++ b/neuraltrust/deployment/secrets.mdx
@@ -5,11 +5,15 @@ description: Handle credentials generated for a private TrustGate gateway.
 
 ## Wizard-issued credentials
 
-The [private TrustGate wizard](/neuraltrust/deployment/overview#create-a-private-trustgate-gateway) issues credentials before you deploy:
+The console issues credentials **per product instance** before you deploy. Create
+each product you run — TrustGate under **Agent Gateway** and TrustGuard under
+**Agent Runtime** — and collect its own set. See
+[Hybrid tokens](/neuraltrust/deployment/hybrid-tokens) for the step-by-step flow.
 
-- A gateway-scoped configuration-sync token
-- An OTLP collector endpoint and token for metadata export
-- A DataAgent enrollment token
+Each private instance issues:
+
+- A configuration-sync token, scoped to that gateway or TrustGuard
+- A DataAgent enrollment token that authorizes OTLP metadata egress and DataBridge retrieval
 
 The Docker command injects the configuration-sync token, DataAgent enrollment token, and a generated local cache key. The maintained Compose manifest also requires operator-supplied `SERVER_SECRET_KEY`, `CONFIG_SYNC_GRPC_ENDPOINT`, and `DATABRIDGE_ADDR`.
 

--- a/neuraltrust/deployment/secrets.mdx
+++ b/neuraltrust/deployment/secrets.mdx
@@ -8,7 +8,7 @@ description: Handle credentials generated for a private TrustGate gateway.
 The console issues credentials **per product instance** before you deploy. Create
 each product you run — TrustGate under **Agent Gateway** and TrustGuard under
 **Agent Runtime** — and collect its own set. See
-[Hybrid tokens](/neuraltrust/deployment/hybrid-tokens) for the step-by-step flow.
+[Console setup](/neuraltrust/deployment/console-setup) for the step-by-step flow.
 
 Each private instance issues:
 


### PR DESCRIPTION
## Summary

Adds the missing v2 deployment documentation for both topologies and fixes several inaccuracies in the existing Hybrid pages.

**New pages**
- **Hybrid tokens** (`neuraltrust/deployment/hybrid-tokens`) — explains that TrustGate (Agent Gateway) and TrustGuard (Agent Runtime) are **separate console objects** created at [app.neuraltrust.ai](https://app.neuraltrust.ai/en/v2/), that each issues its **own** config-sync + DataAgent enrollment token, and how to map both token sets into the chart Secrets (`agentgateway-config-sync`, `dataagent-enrolment-trustgate`, `trustguard-config-sync`, `dataagent-enrolment-trustguard`). Includes the operator-generated `CONFIG_SYNC_LKG_KEY` and the regenerate-from-Settings flow.
- **External (self-hosted)** (`neuraltrust/deployment/external`) — documents `global.deploymentMode: external`: everything in-cluster (control + data planes, console, ClickStack collector, ClickHouse, DataCore, AlertEngine), the super-admin Secret, per-service datastores, air-gapped `hostedExport.enabled: false`, and that **no console tokens / DataAgent** are involved.

**Fixes to existing Hybrid docs**
- Deployment models: added an **External** column and section, plus cross-links; clarified that running both products means two token sets.
- Feature flags: corrected the misleading `global.clickstack.enabled` row — Hybrid product telemetry export is **mandatory** (no `enabled: false` opt-out; air-gap → External); added `global.products.*` selection and per-product config-sync / enrollment Secret references.
- Overview + Secrets: clarified that credentials are issued **per product instance** and that a Hybrid TrustGuard must be created separately.

Sourced against the `neuraltrust-platform` chart (`docs/platform-v2.md`, `values-v2-external.yaml.example`) and the console wizard in `app` (`privateDeployValues.ts`, `issuePrivate{Gateway,TrustGuard}InstallConfigAction.ts`, `NewGatewayModal.tsx`).

## Test plan

- [x] `docs.json` is valid JSON and both new pages are wired into the Deployment nav
- [x] New pages use existing Mintlify components (`<Note>`, `<Tip>`, `<CardGroup>`, `<Card>`)
- [ ] Mintlify preview renders the two new pages and updated nav