### PR TITLE
docs(trustgate): add Copilot Studio MCP consumer guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -220,7 +220,8 @@
             "group": "MCP",
             "icon": "bot",
             "pages": [
-              "trustgate/mcp/overview"
+              "trustgate/mcp/overview",
+              "trustgate/mcp/copilot-studio"
             ]
           },
           {

--- a/trustgate/mcp/copilot-studio.mdx
+++ b/trustgate/mcp/copilot-studio.mdx
@@ -1,0 +1,177 @@
+---
+title: "Microsoft Copilot Studio"
+description: "Connect Microsoft Copilot Studio to a TrustGate MCP consumer using NeuralTrust as the OAuth identity provider (no Entra ID or Okta setup)."
+---
+
+This guide wires **Microsoft Copilot Studio** to a TrustGate [MCP consumer](/trustgate/concepts/consumers)
+when authentication is handled by **NeuralTrust** (the platform as the default MCP IdP) —
+not by an external identity provider such as Microsoft Entra ID or Okta.
+
+You will:
+
+1. Create an MCP consumer that uses NeuralTrust for OAuth (no external client id/secret).
+2. Register that consumer as an MCP server tool in Copilot Studio (OAuth + dynamic discovery).
+3. Build an agent that calls an upstream MCP (for example Notion) through TrustGate.
+
+For Entra ID or Okta as the IdP instead, see the [Authorization](/trustgate/concepts/authorization/overview)
+manuals.
+
+## Prerequisites
+
+- Access to the NeuralTrust app (**Agent Gateway → Consumers** / **Registries**).
+- A gateway with a public MCP base URL (SaaS: `https://{gateway_slug}.mcp.neuraltrust.ai`).
+- At least one [MCP registry](/trustgate/concepts/registries) connected (e.g. Notion) and
+  granted to the consumer via its toolkit.
+- A Microsoft Copilot Studio environment where you can create agents and tools.
+- Browser pop-ups enabled for the NeuralTrust consent / connect flow.
+
+| Placeholder | Meaning |
+|---|---|
+| `mcp_base_url` | Public MCP host for the gateway, no path — e.g. `https://gw-xxxxxxxx.mcp.neuraltrust.ai` |
+| `consumer_slug` | Slug of the MCP consumer (from the consumer **Connect** tab) |
+| Consumer MCP URL | `https://{mcpHost}/{consumer_slug}/mcp` — the value you paste into Copilot Studio |
+
+<Note>
+**SaaS vs Private:** SaaS uses `{slug}.mcp.neuraltrust.ai`. Private/Hybrid uses the Dataplane
+MCP URL from **Settings → Agent Gateway → General**. Copilot Studio must reach that URL
+from the internet (or your allowed network path).
+</Note>
+
+---
+
+## 1. Create the MCP consumer (NeuralTrust auth)
+
+In the NeuralTrust app go to **Agent Gateway → Consumers → Consumer**.
+
+<Steps>
+  <Step title="Create an MCP consumer with OAuth2">
+    - **Protocol**: `MCP`
+    - **Authentication → Method**: `OAuth2`
+
+    For the OAuth client / identity provider:
+
+    - Leave the external IdP **Client** blank, **or**
+    - Select **Use NeuralTrust** (wording may vary in the UI)
+
+    That choice means you are **not** wiring Entra ID or Okta. TrustGate falls back to the
+    platform as the default MCP identity provider: interactive login uses NeuralTrust
+    (your existing platform session), then TrustGate mints the MCP session token for the
+    agent.
+  </Step>
+  <Step title="Bind registries and toolkit">
+    Attach the MCP [registries](/trustgate/concepts/registries) the agent should see
+    (e.g. Notion) and scope the [toolkit](/trustgate/mcp/overview#toolkits--scoping-what-an-agent-can-use)
+    so the consumer can call the tools you need (e.g. Notion search).
+  </Step>
+  <Step title="Copy the consumer MCP URL">
+    Open the consumer → **Connect** tab and copy the MCP server URL:
+
+    ```text
+    https://{mcpHost}/{consumer_slug}/mcp
+    ```
+
+    Example shape (do not copy this literally — use your own gateway and slug):
+
+    ```text
+    https://gw-sablgc054539.mcp.neuraltrust.ai/2ZLGuh0Z/mcp
+    ```
+  </Step>
+</Steps>
+
+---
+
+## 2. Add the MCP server in Copilot Studio
+
+In **Microsoft Copilot Studio**:
+
+<Steps>
+  <Step title="Create an MCP tool">
+    Go to **Tools** (or the equivalent MCP / connectors area) → add a new **MCP** tool.
+  </Step>
+  <Step title="Choose OAuth with dynamic discovery">
+    Set authentication to **OAuth** and select **Dynamic discovery**.
+
+    Copilot Studio should **not** ask for Client ID or Client secret. Discovery uses
+    TrustGate's OAuth metadata (`/.well-known/oauth-authorization-server` and related
+    endpoints on the MCP plane); with NeuralTrust as the IdP there is no external app
+    registration to paste in.
+  </Step>
+  <Step title="Paste the consumer URL">
+    In **Server URL**, enter the consumer MCP URL from step 1:
+
+    ```text
+    https://{mcpHost}/{consumer_slug}/mcp
+    ```
+
+    Leave other fields at their defaults. When Power Automate opens as part of the
+    connection flow, you typically do **not** need to change anything there.
+  </Step>
+</Steps>
+
+---
+
+## 3. Create an agent and attach the tool
+
+<Steps>
+  <Step title="Create an agent that uses MCP">
+    In Copilot Studio, create an agent that should call tools through your TrustGate
+    consumer — for example a **Notion search** agent. Ensure the upstream server
+    (Notion) is registered under **Registries** and connected to that consumer's toolkit.
+  </Step>
+  <Step title="Add the MCP Server tool">
+    Add the MCP tool you created in step 2 to the agent.
+  </Step>
+  <Step title="Allow pop-ups and complete NeuralTrust consent">
+    Enable pop-ups in the browser. On first use, NeuralTrust may ask you to approve the
+    connection (for example to connect Notion via TrustGate's
+    [forwarded / connect](/trustgate/mcp/overview#forwarded-per-user-oauth) flow).
+  </Step>
+  <Step title="Activate connections">
+    The first run may also prompt you to **activate connections** for the agent tools,
+    including the MCP Server. Complete those prompts so Copilot Studio can obtain and
+    store the OAuth session.
+  </Step>
+</Steps>
+
+---
+
+## How the login flow works
+
+```text
+Copilot Studio ── OAuth (PKCE / DCR) ──▶ TrustGate MCP plane
+                                              │
+                                              ▼ (no external IdP on consumer)
+                                         NeuralTrust platform login
+                                              │
+                                              ▼
+                                         MCP session token → Copilot Studio
+                                              │
+                                              ▼ (optional, per upstream)
+                                         Connect your accounts (e.g. Notion)
+```
+
+1. Copilot Studio discovers TrustGate as the authorization server from the consumer MCP URL.
+2. Because the consumer has no Entra/Okta client configured, TrustGate uses **NeuralTrust**
+   as the default IdP.
+3. After platform login, TrustGate issues the MCP session token used on subsequent calls.
+4. If an upstream registry uses per-user OAuth (`forwarded`), you may see **Connect your
+   accounts** for that provider (e.g. Notion) before tools work end-to-end.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Copilot asks for Client ID / Secret | Auth mode is not **Dynamic discovery**, or the Server URL is wrong (must be the consumer `…/mcp` URL, not the bare `mcp_base_url`). |
+| Pop-up blocked / consent never finishes | Allow pop-ups for NeuralTrust and Copilot Studio domains; retry activation. |
+| Tools listed but Notion (or other) calls fail | Registry not bound to the consumer, toolkit too narrow, or upstream **Connect your accounts** not completed. |
+| `401` / unauthorized from MCP | Session not completed; re-run connection activation for the MCP Server tool. |
+| Works in Cursor but not Copilot Studio | Confirm the same consumer URL and that Copilot can reach the MCP host from its network path. |
+
+## Related
+
+- [MCP plane overview](/trustgate/mcp/overview)
+- [Consumers](/trustgate/concepts/consumers)
+- [Authorization overview](/trustgate/concepts/authorization/overview) (Entra ID / Okta when you need an external IdP)
+- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id)

--- a/trustgate/mcp/copilot-studio.mdx
+++ b/trustgate/mcp/copilot-studio.mdx
@@ -1,177 +1,84 @@
 ---
 title: "Microsoft Copilot Studio"
-description: "Connect Microsoft Copilot Studio to a TrustGate MCP consumer using NeuralTrust as the OAuth identity provider (no Entra ID or Okta setup)."
+description: "Connect Copilot Studio to a TrustGate MCP consumer authenticated with NeuralTrust (no Entra ID or Okta)."
 ---
 
-This guide wires **Microsoft Copilot Studio** to a TrustGate [MCP consumer](/trustgate/concepts/consumers)
-when authentication is handled by **NeuralTrust** (the platform as the default MCP IdP) —
-not by an external identity provider such as Microsoft Entra ID or Okta.
+Connect **Microsoft Copilot Studio** to a TrustGate [MCP consumer](/trustgate/concepts/consumers)
+using **NeuralTrust** as the OAuth IdP — leave the IdP client blank (or choose **Use NeuralTrust**).
+No Entra ID or Okta app is required.
 
-You will:
-
-1. Create an MCP consumer that uses NeuralTrust for OAuth (no external client id/secret).
-2. Register that consumer as an MCP server tool in Copilot Studio (OAuth + dynamic discovery).
-3. Build an agent that calls an upstream MCP (for example Notion) through TrustGate.
-
-For Entra ID or Okta as the IdP instead, see the [Authorization](/trustgate/concepts/authorization/overview)
-manuals.
+For an external IdP instead, see [Authorization](/trustgate/concepts/authorization/overview).
 
 ## Prerequisites
 
-- Access to the NeuralTrust app (**Agent Gateway → Consumers** / **Registries**).
-- A gateway with a public MCP base URL (SaaS: `https://{gateway_slug}.mcp.neuraltrust.ai`).
-- At least one [MCP registry](/trustgate/concepts/registries) connected (e.g. Notion) and
-  granted to the consumer via its toolkit.
-- A Microsoft Copilot Studio environment where you can create agents and tools.
-- Browser pop-ups enabled for the NeuralTrust consent / connect flow.
+- NeuralTrust app access (**Agent Gateway → Consumers** / **Registries**)
+- At least one MCP [registry](/trustgate/concepts/registries) (e.g. Notion) bound to the consumer toolkit
+- Copilot Studio environment; browser **pop-ups enabled**
 
-| Placeholder | Meaning |
-|---|---|
-| `mcp_base_url` | Public MCP host for the gateway, no path — e.g. `https://gw-xxxxxxxx.mcp.neuraltrust.ai` |
-| `consumer_slug` | Slug of the MCP consumer (from the consumer **Connect** tab) |
-| Consumer MCP URL | `https://{mcpHost}/{consumer_slug}/mcp` — the value you paste into Copilot Studio |
+## 1. Create the MCP consumer
 
-<Note>
-**SaaS vs Private:** SaaS uses `{slug}.mcp.neuraltrust.ai`. Private/Hybrid uses the Dataplane
-MCP URL from **Settings → Agent Gateway → General**. Copilot Studio must reach that URL
-from the internet (or your allowed network path).
-</Note>
-
----
-
-## 1. Create the MCP consumer (NeuralTrust auth)
-
-In the NeuralTrust app go to **Agent Gateway → Consumers → Consumer**.
+In **Agent Gateway → Consumers → Consumer**:
 
 <Steps>
-  <Step title="Create an MCP consumer with OAuth2">
+  <Step title="MCP + OAuth2 with NeuralTrust">
     - **Protocol**: `MCP`
     - **Authentication → Method**: `OAuth2`
+    - Leave the OAuth **Client** blank, or select **Use NeuralTrust**
 
-    For the OAuth client / identity provider:
-
-    - Leave the external IdP **Client** blank, **or**
-    - Select **Use NeuralTrust** (wording may vary in the UI)
-
-    That choice means you are **not** wiring Entra ID or Okta. TrustGate falls back to the
-    platform as the default MCP identity provider: interactive login uses NeuralTrust
-    (your existing platform session), then TrustGate mints the MCP session token for the
-    agent.
+    You are not using Entra ID or Okta — NeuralTrust authenticates the MCP session.
   </Step>
-  <Step title="Bind registries and toolkit">
-    Attach the MCP [registries](/trustgate/concepts/registries) the agent should see
-    (e.g. Notion) and scope the [toolkit](/trustgate/mcp/overview#toolkits--scoping-what-an-agent-can-use)
-    so the consumer can call the tools you need (e.g. Notion search).
+  <Step title="Registries and toolkit">
+    Connect the upstream MCP (e.g. Notion) in **Registries** and grant it on the consumer
+    toolkit (e.g. Notion search).
   </Step>
-  <Step title="Copy the consumer MCP URL">
-    Open the consumer → **Connect** tab and copy the MCP server URL:
+  <Step title="Copy the consumer URL">
+    Open the consumer → **Connect** and copy:
 
     ```text
     https://{mcpHost}/{consumer_slug}/mcp
     ```
 
-    Example shape (do not copy this literally — use your own gateway and slug):
-
-    ```text
-    https://gw-sablgc054539.mcp.neuraltrust.ai/2ZLGuh0Z/mcp
-    ```
+    Use this URL in Copilot Studio (not the bare MCP host). Example shape:
+    `https://gw-xxxxxxxx.mcp.neuraltrust.ai/AbCdEf12/mcp`.
   </Step>
 </Steps>
 
----
-
-## 2. Add the MCP server in Copilot Studio
-
-In **Microsoft Copilot Studio**:
+## 2. Add the MCP tool in Copilot Studio
 
 <Steps>
-  <Step title="Create an MCP tool">
-    Go to **Tools** (or the equivalent MCP / connectors area) → add a new **MCP** tool.
+  <Step title="New MCP tool with OAuth dynamic discovery">
+    Create a tool → **MCP** → authentication **OAuth** → **Dynamic discovery**.
+
+    Copilot should **not** ask for Client ID or Client secret.
   </Step>
-  <Step title="Choose OAuth with dynamic discovery">
-    Set authentication to **OAuth** and select **Dynamic discovery**.
-
-    Copilot Studio should **not** ask for Client ID or Client secret. Discovery uses
-    TrustGate's OAuth metadata (`/.well-known/oauth-authorization-server` and related
-    endpoints on the MCP plane); with NeuralTrust as the IdP there is no external app
-    registration to paste in.
-  </Step>
-  <Step title="Paste the consumer URL">
-    In **Server URL**, enter the consumer MCP URL from step 1:
-
-    ```text
-    https://{mcpHost}/{consumer_slug}/mcp
-    ```
-
-    Leave other fields at their defaults. When Power Automate opens as part of the
-    connection flow, you typically do **not** need to change anything there.
+  <Step title="Server URL">
+    Paste the consumer URL from step 1. Leave the rest as default — if Power Automate opens,
+    you do not need to change anything there.
   </Step>
 </Steps>
 
----
-
-## 3. Create an agent and attach the tool
+## 3. Agent and first-run consent
 
 <Steps>
-  <Step title="Create an agent that uses MCP">
-    In Copilot Studio, create an agent that should call tools through your TrustGate
-    consumer — for example a **Notion search** agent. Ensure the upstream server
-    (Notion) is registered under **Registries** and connected to that consumer's toolkit.
+  <Step title="Create the agent and add the tool">
+    Create an agent that should use the MCP (e.g. Notion search) and add the MCP Server tool
+    you just created.
   </Step>
-  <Step title="Add the MCP Server tool">
-    Add the MCP tool you created in step 2 to the agent.
-  </Step>
-  <Step title="Allow pop-ups and complete NeuralTrust consent">
-    Enable pop-ups in the browser. On first use, NeuralTrust may ask you to approve the
-    connection (for example to connect Notion via TrustGate's
-    [forwarded / connect](/trustgate/mcp/overview#forwarded-per-user-oauth) flow).
-  </Step>
-  <Step title="Activate connections">
-    The first run may also prompt you to **activate connections** for the agent tools,
-    including the MCP Server. Complete those prompts so Copilot Studio can obtain and
-    store the OAuth session.
+  <Step title="Approve connections">
+    On first use, allow pop-ups: NeuralTrust may ask you to approve (e.g. connect Notion),
+    and Copilot Studio may ask you to **activate connections** for the tools, including the
+    MCP Server. Complete both.
   </Step>
 </Steps>
-
----
-
-## How the login flow works
-
-```text
-Copilot Studio ── OAuth (PKCE / DCR) ──▶ TrustGate MCP plane
-                                              │
-                                              ▼ (no external IdP on consumer)
-                                         NeuralTrust platform login
-                                              │
-                                              ▼
-                                         MCP session token → Copilot Studio
-                                              │
-                                              ▼ (optional, per upstream)
-                                         Connect your accounts (e.g. Notion)
-```
-
-1. Copilot Studio discovers TrustGate as the authorization server from the consumer MCP URL.
-2. Because the consumer has no Entra/Okta client configured, TrustGate uses **NeuralTrust**
-   as the default IdP.
-3. After platform login, TrustGate issues the MCP session token used on subsequent calls.
-4. If an upstream registry uses per-user OAuth (`forwarded`), you may see **Connect your
-   accounts** for that provider (e.g. Notion) before tools work end-to-end.
-
----
 
 ## Troubleshooting
 
-| Symptom | Likely cause |
+| Symptom | Fix |
 |---|---|
-| Copilot asks for Client ID / Secret | Auth mode is not **Dynamic discovery**, or the Server URL is wrong (must be the consumer `…/mcp` URL, not the bare `mcp_base_url`). |
-| Pop-up blocked / consent never finishes | Allow pop-ups for NeuralTrust and Copilot Studio domains; retry activation. |
-| Tools listed but Notion (or other) calls fail | Registry not bound to the consumer, toolkit too narrow, or upstream **Connect your accounts** not completed. |
-| `401` / unauthorized from MCP | Session not completed; re-run connection activation for the MCP Server tool. |
-| Works in Cursor but not Copilot Studio | Confirm the same consumer URL and that Copilot can reach the MCP host from its network path. |
+| Asks for Client ID / Secret | Use **Dynamic discovery**; Server URL must be `…/{consumer_slug}/mcp`. |
+| Consent / connect never finishes | Enable pop-ups; retry connection activation. |
+| Tools missing or upstream calls fail | Registry + toolkit on the consumer; finish NeuralTrust / provider connect if prompted. |
 
 ## Related
 
-- [MCP plane overview](/trustgate/mcp/overview)
-- [Consumers](/trustgate/concepts/consumers)
-- [Authorization overview](/trustgate/concepts/authorization/overview) (Entra ID / Okta when you need an external IdP)
-- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id)
+[MCP plane](/trustgate/mcp/overview) · [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id)

--- a/trustgate/mcp/copilot-studio.mdx
+++ b/trustgate/mcp/copilot-studio.mdx
@@ -1,73 +1,48 @@
 ---
 title: "Microsoft Copilot Studio"
-description: "Connect Copilot Studio to a TrustGate MCP consumer authenticated with NeuralTrust (no Entra ID or Okta)."
+description: "Connect Microsoft Copilot Studio to a TrustGate MCP consumer."
 ---
 
-Connect **Microsoft Copilot Studio** to a TrustGate [MCP consumer](/trustgate/concepts/consumers)
-using **NeuralTrust** as the OAuth IdP — leave the IdP client blank (or choose **Use NeuralTrust**).
-No Entra ID or Okta app is required.
+Connect **Microsoft Copilot Studio** to a TrustGate [MCP consumer](/trustgate/concepts/consumers).
+The Copilot side is the same regardless of IdP; only how you create the consumer changes.
 
-For an external IdP instead, see [Authorization](/trustgate/concepts/authorization/overview).
+## 1. TrustGate consumer
 
-## Prerequisites
+In **Agent Gateway → Consumers**, create an **MCP** consumer with **OAuth2**, bind the
+[registries](/trustgate/concepts/registries) / toolkit you need, then copy the URL from the
+**Connect** tab:
 
-- NeuralTrust app access (**Agent Gateway → Consumers** / **Registries**)
-- At least one MCP [registry](/trustgate/concepts/registries) (e.g. Notion) bound to the consumer toolkit
-- Copilot Studio environment; browser **pop-ups enabled**
+```text
+https://{mcpHost}/{consumer_slug}/mcp
+```
 
-## 1. Create the MCP consumer
+**Auth — pick one:**
 
-In **Agent Gateway → Consumers → Consumer**:
+| Option | Consumer setup |
+|---|---|
+| **NeuralTrust** (no external IdP) | Leave the OAuth **Client** blank, or select **Use NeuralTrust**. |
+| **Your IdP** (Okta, Entra ID, …) | Attach an OAuth2 auth from [Identity](/trustgate/concepts/authorization/overview). Follow [Okta](/trustgate/concepts/authorization/okta) or [Entra ID](/trustgate/concepts/authorization/entra-id) for the IdP app + redirect URI. |
 
-<Steps>
-  <Step title="MCP + OAuth2 with NeuralTrust">
-    - **Protocol**: `MCP`
-    - **Authentication → Method**: `OAuth2`
-    - Leave the OAuth **Client** blank, or select **Use NeuralTrust**
-
-    You are not using Entra ID or Okta — NeuralTrust authenticates the MCP session.
-  </Step>
-  <Step title="Registries and toolkit">
-    Connect the upstream MCP (e.g. Notion) in **Registries** and grant it on the consumer
-    toolkit (e.g. Notion search).
-  </Step>
-  <Step title="Copy the consumer URL">
-    Open the consumer → **Connect** and copy:
-
-    ```text
-    https://{mcpHost}/{consumer_slug}/mcp
-    ```
-
-    Use this URL in Copilot Studio (not the bare MCP host). Example shape:
-    `https://gw-xxxxxxxx.mcp.neuraltrust.ai/AbCdEf12/mcp`.
-  </Step>
-</Steps>
-
-## 2. Add the MCP tool in Copilot Studio
+## 2. Copilot Studio
 
 <Steps>
-  <Step title="New MCP tool with OAuth dynamic discovery">
-    Create a tool → **MCP** → authentication **OAuth** → **Dynamic discovery**.
+  <Step title="Add an MCP tool">
+    Create a tool → **MCP**.
+  </Step>
+  <Step title="OAuth + Dynamic discovery">
+    Authentication → **OAuth** → **Dynamic discovery**.
 
     Copilot should **not** ask for Client ID or Client secret.
   </Step>
   <Step title="Server URL">
-    Paste the consumer URL from step 1. Leave the rest as default — if Power Automate opens,
-    you do not need to change anything there.
+    Paste the consumer URL from step 1. Leave defaults — if Power Automate opens, no changes needed.
   </Step>
-</Steps>
-
-## 3. Agent and first-run consent
-
-<Steps>
-  <Step title="Create the agent and add the tool">
-    Create an agent that should use the MCP (e.g. Notion search) and add the MCP Server tool
-    you just created.
+  <Step title="Agent">
+    Create an agent, add this MCP Server tool, and enable browser **pop-ups**.
   </Step>
-  <Step title="Approve connections">
-    On first use, allow pop-ups: NeuralTrust may ask you to approve (e.g. connect Notion),
-    and Copilot Studio may ask you to **activate connections** for the tools, including the
-    MCP Server. Complete both.
+  <Step title="First run">
+    Activate connections when prompted (including the MCP Server). Complete any NeuralTrust /
+    IdP login and upstream connect (e.g. Notion) if shown.
   </Step>
 </Steps>
 
@@ -75,10 +50,6 @@ In **Agent Gateway → Consumers → Consumer**:
 
 | Symptom | Fix |
 |---|---|
-| Asks for Client ID / Secret | Use **Dynamic discovery**; Server URL must be `…/{consumer_slug}/mcp`. |
-| Consent / connect never finishes | Enable pop-ups; retry connection activation. |
-| Tools missing or upstream calls fail | Registry + toolkit on the consumer; finish NeuralTrust / provider connect if prompted. |
-
-## Related
-
-[MCP plane](/trustgate/mcp/overview) · [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id)
+| Asks for Client ID / Secret | Use **Dynamic discovery**; URL must end with `/{consumer_slug}/mcp`. |
+| Consent never finishes | Allow pop-ups; retry connection activation. |
+| Tools missing / upstream fails | Check consumer registries + toolkit; finish IdP / provider connect. |

--- a/trustgate/mcp/overview.mdx
+++ b/trustgate/mcp/overview.mdx
@@ -145,5 +145,5 @@ the gateway.
 
 ## Connect from agents
 
-- [Microsoft Copilot Studio](/trustgate/mcp/copilot-studio) — NeuralTrust as MCP IdP (no Entra/Okta).
-- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id) — external IdP (+ Cursor).
+- [Microsoft Copilot Studio](/trustgate/mcp/copilot-studio)
+- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id) (external IdP + Cursor)

--- a/trustgate/mcp/overview.mdx
+++ b/trustgate/mcp/overview.mdx
@@ -145,7 +145,5 @@ the gateway.
 
 ## Connect from agents
 
-- [Microsoft Copilot Studio](/trustgate/mcp/copilot-studio) — MCP consumer with **NeuralTrust**
-  as the OAuth IdP (no Entra ID / Okta client required).
-- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id)
-  — when the consumer uses an external identity provider (includes Cursor connect steps).
+- [Microsoft Copilot Studio](/trustgate/mcp/copilot-studio) — NeuralTrust as MCP IdP (no Entra/Okta).
+- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id) — external IdP (+ Cursor).

--- a/trustgate/mcp/overview.mdx
+++ b/trustgate/mcp/overview.mdx
@@ -142,3 +142,10 @@ implementing the standard discovery and flow endpoints:
 Together these let an agent register, obtain a token, call the unified MCP endpoint, and —
 when a downstream needs per-user authorization — complete a one-time connect without leaving
 the gateway.
+
+## Connect from agents
+
+- [Microsoft Copilot Studio](/trustgate/mcp/copilot-studio) — MCP consumer with **NeuralTrust**
+  as the OAuth IdP (no Entra ID / Okta client required).
+- [Okta](/trustgate/concepts/authorization/okta) · [Entra ID](/trustgate/concepts/authorization/entra-id)
+  — when the consumer uses an external identity provider (includes Cursor connect steps).


### PR DESCRIPTION
## Summary
- New how-to: connect **Microsoft Copilot Studio** to a TrustGate MCP consumer using **NeuralTrust as the OAuth IdP** (leave Client blank / Use NeuralTrust — no Entra ID or Okta).
- Documents Copilot Studio MCP tool setup with **OAuth + Dynamic discovery** (no Client ID/Secret), agent attachment, pop-ups, and first-time connection activation.
- Adds the page under TrustGate → MCP in `docs.json` and a short “Connect from agents” link from the MCP overview.

## Test plan
- [ ] Preview Mintlify nav: TrustGate → MCP → Microsoft Copilot Studio
- [ ] Walk through steps against a SaaS consumer MCP URL with a Notion (or similar) registry
- [ ] Confirm Dynamic discovery does not prompt for Client ID/Secret
- [ ] Confirm first-run NeuralTrust consent + connection activation works with pop-ups enabled


Made with [Cursor](https://cursor.com)