### PR TITLE
docs(platform): No access role, models vs registries, SSO guest magic link

### DIFF
--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -51,8 +51,10 @@ the Glass.
    **Platform settings → User & Roles** (password ≥ 30 characters).
 2. Break the Glass authenticates with **password only** — it does not use SSO or
    magic link (single- or multi-organization).
-3. When **Enforce SSO** is on, other members use the configured IdP (or magic link
-   if they are external-domain guests); the Break the Glass account still uses password.
+3. When **Enforce SSO** is on, members on a **verified** email domain use the
+   configured IdP. External-domain guests still use magic link (see
+   [SSO](/platform/sso#part-5-enable-sso-only-mode-optional)). The Break the Glass
+   account still uses password.
 4. Maximum **five** Break the Glass accounts per organization (recommended: 2–3).
 5. All Break the Glass logins are recorded in Audit Logs.
 
@@ -61,7 +63,7 @@ the Glass.
 | Scenario | Normal user | Break the Glass |
 |----------|-------------|-----------------|
 | Sign-in | Magic link or SSO (passwordless) | **Password only** (skips SSO and magic link) |
-| SSO Enforcement ON | Must use the configured IdP SSO | **Password only** |
+| SSO Enforcement ON | Verified-domain members use IdP; external-domain guests use magic link | **Password only** |
 | IdP is down | Cannot use SSO | Can log in with password |
 
 ---

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -350,18 +350,24 @@ When ready to require SSO for all users:
 3. Users will now be required to authenticate via your OIDC provider
 
 <Note>
-When enabled, all users must authenticate through the SSO of the IdP configured for
-your organization's access—except break-the-glass accounts, which sign in with
-**password only** (they skip SSO and magic link).
+When enabled, members whose email domain is **verified** for the organization must
+authenticate through your OIDC provider.
+
+Exceptions:
+
+- **Break the Glass** accounts sign in with **password only** (skip SSO and magic link).
+- **External-domain members** (invited with an email whose domain is *not* among the
+  organization's verified domains — e.g. a guest `@partner.com`) sign in with a
+  **magic link**, even when Enforce SSO is on.
 
 **Prerequisites:** Add at least one break-the-glass account under
 [User & Roles](/platform/users) and configure your **Email Domain** first.
 </Note>
 
 <Warning>
-Before enabling SSO Enforcement, ensure team members can sign in through your OIDC
-provider. Keep a [Break the Glass](/platform/break-glass) emergency account for IdP
-outages.
+Before enabling SSO Enforcement, ensure members on verified domains can sign in
+through your OIDC provider. Keep a [Break the Glass](/platform/break-glass) emergency
+account for IdP outages. External-domain guests continue to use magic link.
 </Warning>
 
 ---

--- a/platform/models.mdx
+++ b/platform/models.mdx
@@ -15,7 +15,9 @@ The **Models** panel in Platform Settings is where you pick which provider handl
 Open it from the sidebar gear → **Platform settings → Models**.
 
 <Note>
-This page **does not** change which models your *applications* can call through a TrustGate Gateway. Those upstreams are configured per-route on the Gateway itself — see [Routes](/trustgate/overview).
+This page does **not** configure which models your applications call through TrustGate.
+Application upstreams live under TrustGate **[Registries](/trustgate/concepts/registries)**
+(LLM registries), not here.
 </Note>
 
 ## Model provider
@@ -73,6 +75,5 @@ On Hybrid deployments, configuring your own provider is usually the whole point 
 
 ## Related
 
-- [Deployment modes](/trustgate/overview) — when to consider bring-your-own-model vs NeuralTrust-managed.
-- [Security features](/trustgate/overview) — which detectors consume the model provider and which are fully deterministic.
-- [Routes](/trustgate/overview) — not the same thing; routes configure which LLMs *your applications* call, this panel configures which LLM *NeuralTrust itself* calls.
+- [Registries](/trustgate/concepts/registries) — LLM / MCP upstreams your applications call through TrustGate.
+- [Deployment models](/neuraltrust/deployment/deployment-models) — SaaS vs Hybrid when bring-your-own makes sense.

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -218,7 +218,7 @@ If permissions don't show "Granted", click **Grant admin consent for [Your Organ
 | **Editor** / **Viewer** | Product permission levels — see [User & Roles](/platform/users) |
 
 <Note>
-Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization; transfer ownership in User & Roles instead. Predefined role templates are Global Admin, Break the Glass, Admin, Editor, and Viewer.
+Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization; transfer ownership in User & Roles instead. Predefined role templates are Global Admin, Break the Glass, Admin, Editor, Viewer, and No access — see [User & Roles](/platform/users).
 </Note>
 
 6. Configure **Product Access** when mapping Editor / Viewer (and similar non–full-admin) roles:
@@ -266,18 +266,26 @@ for your organization.
 3. Confirm the action
 
 <Note>
-When enabled, all users must authenticate through the SSO of the IdP configured for
-your organization's access—except break-the-glass accounts, which sign in with
-**password only** (they skip SSO and magic link).
+When enabled, members whose email domain is **verified** for the organization must
+authenticate through the configured IdP.
+
+Exceptions:
+
+- **Break the Glass** accounts sign in with **password only** (skip SSO and magic link).
+- **External-domain members** (invited with an email whose domain is *not* among the
+  organization's verified domains — e.g. a guest `@partner.com`) sign in with a
+  **magic link**, even when Enforce SSO is on. They cannot use the corporate IdP
+  for that address.
 
 **Prerequisites:** Add at least one break-the-glass account under
 [User & Roles](/platform/users) and configure your **Email Domain** first.
 </Note>
 
 <Warning>
-Before enabling SSO-only mode, ensure members on verified domains can sign in with Microsoft.
-Users without access through the IdP will be locked out. Keep a
-[Break the Glass](/platform/break-glass) emergency account for IdP outages.
+Before enabling SSO-only mode, ensure members on verified domains can sign in with
+Microsoft. Keep a [Break the Glass](/platform/break-glass) emergency account for IdP
+outages. External-domain guests continue to use magic link — they are not locked out
+by Enforce SSO.
 </Warning>
 
 ---

--- a/platform/users.mdx
+++ b/platform/users.mdx
@@ -24,7 +24,7 @@ Managing users and roles requires **IAM Admin** access (or Owner / Global Admin 
 
 Access has two layers:
 
-1. **Org roles** — Owner, Global Admin, Break the Glass, plus product templates (Admin / Editor / Viewer). Owner and Global Admin have **Admin on every product** plus billing; Owner can also **delete the organization**. Break the Glass has the same permissions as Global Admin (emergency password login — see [Break-glass](/platform/break-glass)).
+1. **Org roles** — Owner, Global Admin, Break the Glass, plus product templates (Admin / Editor / Viewer / No access). Owner and Global Admin have **Admin on every product** plus billing; Owner can also **delete the organization**. Break the Glass has the same permissions as Global Admin (emergency password login — see [Break-glass](/platform/break-glass)).
 2. **Product permissions** — No access, Viewer, Editor, Admin — set per product (and optionally scoped to specific TrustGate gateways or TrustGuard collectors).
 
 **Roles** in the Roles tab are reusable templates that apply an org role or a product permission matrix when you invite or edit a user.
@@ -60,6 +60,7 @@ Levels nest: Viewer ⊂ Editor ⊂ Admin.
 | **TrustGate** | View policies, consumers, registry | Edit policies / registry, run playground | Manage consumers, configure gateway, delete gateway resources |
 | **TrustGuard** | View runtime policies, detectors, collectors | Edit those | Configure runtime, delete runtime resources |
 | **TrustTest** | View targets, scenarios, runs | Edit and run tests | Manage API tokens, delete resources |
+| **TrustLens** | View inventory | Edit inventory | Delete resources |
 | **Telemetry** | View dashboards and alerts | Edit use cases | Configure SIEM integrations, delete telemetry resources |
 | **IAM** | View users and roles | Manage invitations | Manage users, roles, and SSO |
 
@@ -74,8 +75,9 @@ The **Permissions** tab in the UI shows the same cards filtered to the products 
 | **Admin** | Admin on all shippable products |
 | **Editor** | Editor on all shippable products |
 | **Viewer** | Viewer on all shippable products |
+| **No access** | No product grants — the user belongs to the organization but cannot open any product |
 
-Custom roles let you pick an arbitrary matrix of product levels (and gateway / collector scopes for TrustGate / TrustGuard). Global Admin and Break the Glass templates are view-only — they cannot be edited or duplicated.
+Custom roles let you pick an arbitrary matrix of product levels (and gateway / collector scopes for TrustGate / TrustGuard). Global Admin, Break the Glass, and No access templates are view-only — they cannot be edited or duplicated.
 
 ---
 
@@ -103,7 +105,7 @@ Toolbar: search, filter by access level, refresh, **Add User**.
 The invite appears under **Invite sent**. When accepted, the user moves to **Users**.
 
 <Note>
-If the organization enforces SSO, invitees sign in through your identity provider. If SCIM or Entra user sync is enabled, most users should be **provisioned automatically** — see [SCIM](/platform/scim) and [User sync](/platform/user-sync).
+If the organization enforces SSO, invitees whose email domain is **verified** for the org sign in through your identity provider. Invitees from an **external domain** (e.g. a consultant `@other.com`) sign in with a **magic link** even when SSO is enforced — see [SSO](/platform/sso#part-5-enable-sso-only-mode-optional). If SCIM or Entra user sync is enabled, most users should be **provisioned automatically** — see [SCIM](/platform/scim) and [User sync](/platform/user-sync).
 </Note>
 
 ### Edit access


### PR DESCRIPTION
## Summary
- **Roles:** document predefined **No access** (no product grants; view-only template).
- **Models:** clarify Platform Settings → Models is *internal* NeuralTrust providers; application models live in TrustGate **Registries** (replace outdated Routes pointer / “team” wording).
- **SSO Enforce:** verified-domain members use the IdP; **external-domain guests** (e.g. `@partner.com`) keep **magic link** even when Enforce SSO is on (Entra + Generic OIDC + invites + Break the Glass cross-links).

## Test plan
- [ ] `/platform/users` — No access in predefined templates table
- [ ] `/platform/models` — Note points to Registries, not Routes
- [ ] `/platform/sso` and `/platform/generic-oidc-sso` — Enforce SSO exceptions list guests + BtG


Made with [Cursor](https://cursor.com)