### PR TITLE
docs(trustgate): auth matrix, MCP OAuth/NeuralTrust IdP, telemetry sources

### DIFF
--- a/trustgate/api/openapi.json
+++ b/trustgate/api/openapi.json
@@ -6887,7 +6887,7 @@
           "status": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Status"
           },
-          "team_id": {
+          "tenant_id": {
             "type": "string"
           },
           "timestamp": {

--- a/trustgate/concepts/auth.mdx
+++ b/trustgate/concepts/auth.mdx
@@ -15,28 +15,26 @@ The same auth (API key or IdP credential) can be attached to several consumers. 
 This is distinct from a registry's [target auth](/trustgate/concepts/registries#target-auth),
 which is how TrustGate authenticates to the **upstream provider**.
 
-## Auth types × routing mode
+## Auth types
 
-| `type` | How the client authenticates | LLM routing mode |
+| `type` | How the client authenticates | Routing mode |
 |---|---|---|
-| **`api_key`** | `X-AG-API-Key: ag_…` header | **inline** only |
-| **`oauth2`** | `Authorization: Bearer …` (interactive broker and/or JWT validation) | **inline** only |
-| **`oidc`** | `Authorization: Bearer <jwt>` from your IdP; claims select a [role](/trustgate/concepts/roles) | **role_based** only |
-| **`mtls`** | Client certificate (MCP identity chain) | MCP plane |
+| **`api_key`** | `X-AG-API-Key: ag_…` header | inline |
+| **`oauth2`** | `Authorization: Bearer <jwt>` (or opaque token + introspection) validated against an OAuth2 provider | inline or role_based |
+| **`oidc`** | `Authorization: Bearer <jwt>` from your IdP; claims select a [role](/trustgate/concepts/roles) | inline or role_based |
+| **`mtls`** | Client certificate (or a trusted `X-Forwarded-Client-Cert` header) | inline |
 
-| Plane | Consumer auth |
+| Plane | Consumer auth types |
 |---|---|
-| **LLM · inline** | `api_key` or `oauth2` |
-| **LLM · role_based** | `oidc` (exactly one) |
-| **MCP** | `oauth2` — IdP client **or** NeuralTrust as identity provider (see below) |
+| **LLM** | `api_key`, `oauth2`, `oidc` |
+| **MCP** | `oauth2` |
 
-A `role_based` LLM consumer does **not** accept `oauth2` or `api_key` on the proxy.
-An `inline` LLM consumer does **not** accept `oidc` for Bearer auth.
+A `role_based` LLM consumer carries exactly one identity credential — `oauth2` or `oidc`.
 
 ## MCP: OAuth2 with your IdP or NeuralTrust
 
-MCP consumers always use the **OAuth2** auth type (interactive agents discover TrustGate
-and run authorization-code + PKCE). Who issues the login:
+MCP consumers use the **OAuth2** auth type (interactive agents discover TrustGate and run
+authorization-code + PKCE). Who issues the login:
 
 | Option | Consumer setup |
 |---|---|
@@ -70,11 +68,13 @@ JWT- and certificate-based credentials carry a `config` block:
 | `oidc` | `issuer`, `audiences`, `jwks_url`, `public_keys`, `required_scopes`, `allowed_algorithms`, `subject_claim`. |
 | `mtls` | `ca_cert`, `allowed_common_names`, `allowed_dns_names`, `allowed_fingerprints`. |
 
-For **`oidc`** on a `role_based` LLM consumer, the validated token's claims are matched
-against role [OIDC mappings](/trustgate/concepts/roles) to select routing.
+For **`oidc`** credentials on a `role_based` consumer, the validated token's claims are
+matched against role [OIDC mappings](/trustgate/concepts/roles) to select the consumer's
+routing — this is how identity-based routing works.
 
-For provider-specific setup, see
-[Authorization](/trustgate/concepts/authorization/overview) —
+For end-to-end, provider-specific setup (custom authorization servers, scopes, group/role
+claims, and the exact credential payloads), see the
+[Authorization](/trustgate/concepts/authorization/overview) manuals for
 [Okta](/trustgate/concepts/authorization/okta) and
 [Entra ID](/trustgate/concepts/authorization/entra-id).
 

--- a/trustgate/concepts/auth.mdx
+++ b/trustgate/concepts/auth.mdx
@@ -15,21 +15,35 @@ The same auth (API key or IdP credential) can be attached to several consumers. 
 This is distinct from a registry's [target auth](/trustgate/concepts/registries#target-auth),
 which is how TrustGate authenticates to the **upstream provider**.
 
-## Auth types
+## Auth types × routing mode
 
-| `type` | How the client authenticates | Routing mode |
+| `type` | How the client authenticates | LLM routing mode |
 |---|---|---|
-| **`api_key`** | `X-AG-API-Key: ag_…` header | inline |
-| **`oauth2`** | `Authorization: Bearer <jwt>` (or opaque token + introspection) validated against an OAuth2 provider | inline or role_based |
-| **`oidc`** | `Authorization: Bearer <jwt>` from your IdP; claims select a [role](/trustgate/concepts/roles) | inline or role_based |
-| **`mtls`** | Client certificate (or a trusted `X-Forwarded-Client-Cert` header) | inline |
+| **`api_key`** | `X-AG-API-Key: ag_…` header | **inline** only |
+| **`oauth2`** | `Authorization: Bearer …` (interactive broker and/or JWT validation) | **inline** only |
+| **`oidc`** | `Authorization: Bearer <jwt>` from your IdP; claims select a [role](/trustgate/concepts/roles) | **role_based** only |
+| **`mtls`** | Client certificate (MCP identity chain) | MCP plane |
 
-| Plane | Consumer auth types |
+| Plane | Consumer auth |
 |---|---|
-| **LLM** | `api_key`, `oauth2`, `oidc` |
-| **MCP** | `oauth2` |
+| **LLM · inline** | `api_key` or `oauth2` |
+| **LLM · role_based** | `oidc` (exactly one) |
+| **MCP** | `oauth2` — IdP client **or** NeuralTrust as identity provider (see below) |
 
-A `role_based` LLM consumer carries exactly one identity credential — `oauth2` or `oidc`.
+A `role_based` LLM consumer does **not** accept `oauth2` or `api_key` on the proxy.
+An `inline` LLM consumer does **not** accept `oidc` for Bearer auth.
+
+## MCP: OAuth2 with your IdP or NeuralTrust
+
+MCP consumers always use the **OAuth2** auth type (interactive agents discover TrustGate
+and run authorization-code + PKCE). Who issues the login:
+
+| Option | Consumer setup |
+|---|---|
+| **Your IdP** (Okta, Entra ID, …) | Attach an OAuth2 auth with client id/secret — see [Authorization](/trustgate/concepts/authorization/overview). |
+| **NeuralTrust** (built-in) | Leave the OAuth **Client** blank, or select **Use NeuralTrust**. No Entra/Okta app required. |
+
+Consumer MCP URL (from the **Connect** tab): `https://{mcpHost}/{consumer_slug}/mcp`.
 
 ## API keys
 
@@ -56,13 +70,11 @@ JWT- and certificate-based credentials carry a `config` block:
 | `oidc` | `issuer`, `audiences`, `jwks_url`, `public_keys`, `required_scopes`, `allowed_algorithms`, `subject_claim`. |
 | `mtls` | `ca_cert`, `allowed_common_names`, `allowed_dns_names`, `allowed_fingerprints`. |
 
-For **`oidc`** credentials on a `role_based` consumer, the validated token's claims are
-matched against role [OIDC mappings](/trustgate/concepts/roles) to select the consumer's
-routing — this is how identity-based routing works.
+For **`oidc`** on a `role_based` LLM consumer, the validated token's claims are matched
+against role [OIDC mappings](/trustgate/concepts/roles) to select routing.
 
-For end-to-end, provider-specific setup (custom authorization servers, scopes, group/role
-claims, and the exact credential payloads), see the
-[Authorization](/trustgate/concepts/authorization/overview) manuals for
+For provider-specific setup, see
+[Authorization](/trustgate/concepts/authorization/overview) —
 [Okta](/trustgate/concepts/authorization/okta) and
 [Entra ID](/trustgate/concepts/authorization/entra-id).
 
@@ -70,4 +82,3 @@ claims, and the exact credential payloads), see the
 
 CRUD lives under `/v1/gateways/{gateway_id}/auths`; attach/detach via the consumer's
 `…/auths/{auth_id}` sub-resource. See the [Auth API](/trustgate/api/overview).
-

--- a/trustgate/concepts/authorization/overview.mdx
+++ b/trustgate/concepts/authorization/overview.mdx
@@ -17,8 +17,8 @@ Entra tenant for both — they are two TrustGate **auth types**, not two differe
 
 | Pattern | App auth type | Consumer | Purpose |
 |---|---|---|---|
-| **OIDC · Identity-based LLM** | **OIDC** | **LLM** with **role_based** / Identity-based routing | Token claims (`groups`, `roles`, …) select a [role](/trustgate/concepts/roles) that decides which registries, models, and tools the caller may reach. |
-| **OAuth2 · MCP** | **OAuth2** (interactive discovery) | **MCP** | Interactive agents use TrustGate's authorization-code + PKCE broker. Login is either your **IdP** (Okta/Entra) or **NeuralTrust** (leave OAuth Client blank / **Use NeuralTrust**). **Required scopes** apply when using an external IdP. |
+| **OIDC · Identity-based LLM** | **OIDC** | **LLM** with **Identity-based** routing | Token claims (`groups`, `roles`, …) select a [role](/trustgate/concepts/roles) that decides which registries, models, and tools the caller may reach. |
+| **OAuth2 · MCP** | **OAuth2** (interactive discovery) | **MCP** | Interactive agents (Cursor, etc.) use TrustGate's authorization-code + PKCE broker against your IdP **or** NeuralTrust (leave OAuth Client blank / **Use NeuralTrust**). **Required scopes** gate MCP access when using an external IdP. Optional client-credentials tokens are for curl checks only. |
 
 ### How OIDC and OAuth2 relate
 
@@ -37,9 +37,10 @@ routing, and an **OAuth2** auth for MCP login. MCP cannot use **OIDC** because a
 the gateway to run the interactive OAuth login.
 
 <Note>
-**LLM · role_based** carries exactly one **OIDC** auth (not OAuth2). **LLM · inline**
-uses **API key** or **OAuth2**. **MCP** uses **OAuth2** only — with your IdP client, or
-NeuralTrust as the identity provider when the Client field is left blank / **Use NeuralTrust**.
+An Identity-based LLM consumer carries **exactly one** identity auth (**OIDC** or
+**OAuth2**). LLM consumers can also use **API key**. MCP consumers use **OAuth2** only —
+**not** OIDC or API key — with your IdP client, or NeuralTrust when the Client field is
+left blank / **Use NeuralTrust**.
 </Note>
 
 ## Where to configure in the app

--- a/trustgate/concepts/authorization/overview.mdx
+++ b/trustgate/concepts/authorization/overview.mdx
@@ -17,8 +17,8 @@ Entra tenant for both — they are two TrustGate **auth types**, not two differe
 
 | Pattern | App auth type | Consumer | Purpose |
 |---|---|---|---|
-| **OIDC · Identity-based LLM** | **OIDC** | **LLM** with **Identity-based** routing | Token claims (`groups`, `roles`, …) select a [role](/trustgate/concepts/roles) that decides which registries, models, and tools the caller may reach. |
-| **OAuth2 · MCP** | **OAuth2** (interactive discovery) | **MCP** | Interactive agents (Cursor, etc.) use TrustGate's authorization-code + PKCE broker against your IdP. **Required scopes** gate MCP access. Optional client-credentials tokens are for curl checks only. |
+| **OIDC · Identity-based LLM** | **OIDC** | **LLM** with **role_based** / Identity-based routing | Token claims (`groups`, `roles`, …) select a [role](/trustgate/concepts/roles) that decides which registries, models, and tools the caller may reach. |
+| **OAuth2 · MCP** | **OAuth2** (interactive discovery) | **MCP** | Interactive agents use TrustGate's authorization-code + PKCE broker. Login is either your **IdP** (Okta/Entra) or **NeuralTrust** (leave OAuth Client blank / **Use NeuralTrust**). **Required scopes** apply when using an external IdP. |
 
 ### How OIDC and OAuth2 relate
 
@@ -37,8 +37,9 @@ routing, and an **OAuth2** auth for MCP login. MCP cannot use **OIDC** because a
 the gateway to run the interactive OAuth login.
 
 <Note>
-An Identity-based LLM consumer carries **exactly one** identity auth (**OIDC** or
-**OAuth2**). LLM consumers can also use **API key**. MCP consumers use **OAuth2** only — **not** OIDC or API key.
+**LLM · role_based** carries exactly one **OIDC** auth (not OAuth2). **LLM · inline**
+uses **API key** or **OAuth2**. **MCP** uses **OAuth2** only — with your IdP client, or
+NeuralTrust as the identity provider when the Client field is left blank / **Use NeuralTrust**.
 </Note>
 
 ## Where to configure in the app

--- a/trustgate/concepts/consumers.mdx
+++ b/trustgate/concepts/consumers.mdx
@@ -25,8 +25,8 @@ A consumer routes in one of two modes:
 
 | Mode | Routing config lives on | Auth |
 |---|---|---|
-| **`inline`** (default) | The consumer directly — `registry_ids`, `lb_config`, `fallback`, `model_policies`. | LLM: `api_key`, `oauth2`, or `oidc`. MCP: `oauth2`. |
-| **`role_based`** | The consumer's [roles](/trustgate/concepts/roles); roles are selected from OIDC token claims. | A single `oauth2` or `oidc` credential. |
+| **`inline`** (default) | The consumer directly — `registry_ids`, `lb_config`, `fallback`, `model_policies`. | LLM: `api_key` or `oauth2`. MCP: `oauth2` (IdP or NeuralTrust). |
+| **`role_based`** | The consumer's [roles](/trustgate/concepts/roles); roles are selected from OIDC token claims. | LLM: a single **`oidc`** credential. |
 
 ### Inline routing
 

--- a/trustgate/concepts/consumers.mdx
+++ b/trustgate/concepts/consumers.mdx
@@ -25,8 +25,8 @@ A consumer routes in one of two modes:
 
 | Mode | Routing config lives on | Auth |
 |---|---|---|
-| **`inline`** (default) | The consumer directly — `registry_ids`, `lb_config`, `fallback`, `model_policies`. | LLM: `api_key` or `oauth2`. MCP: `oauth2` (IdP or NeuralTrust). |
-| **`role_based`** | The consumer's [roles](/trustgate/concepts/roles); roles are selected from OIDC token claims. | LLM: a single **`oidc`** credential. |
+| **`inline`** (default) | The consumer directly — `registry_ids`, `lb_config`, `fallback`, `model_policies`. | LLM: `api_key`, `oauth2`, or `oidc`. MCP: `oauth2` (IdP or NeuralTrust — see [Auth](/trustgate/concepts/auth#mcp-oauth2-with-your-idp-or-neuraltrust)). |
+| **`role_based`** | The consumer's [roles](/trustgate/concepts/roles); roles are selected from OIDC token claims. | A single `oauth2` or `oidc` credential. |
 
 ### Inline routing
 

--- a/trustgate/mcp/overview.mdx
+++ b/trustgate/mcp/overview.mdx
@@ -127,18 +127,21 @@ For SaaS servers where each end-user must connect their own account (e.g. their 
 
 ## Agent authentication
 
-The MCP plane is itself an **OAuth2 authorization server** for the agents connecting to it,
-implementing the standard discovery and flow endpoints:
+Agents connect to `/{consumer_slug}/mcp`. The MCP plane is an **OAuth2 authorization
+server** for those agents. MCP consumers use the **OAuth2** auth type; the login IdP is
+either your external provider or **NeuralTrust** (leave OAuth Client blank / **Use NeuralTrust**)
+— see [Auth](/trustgate/concepts/auth#mcp-oauth2-with-your-idp-or-neuraltrust).
 
 | Endpoint | Purpose |
 |---|---|
 | `/.well-known/oauth-protected-resource` | Protected-resource metadata. |
 | `/.well-known/oauth-authorization-server` | Authorization-server metadata. |
-| `/register` | Dynamic Client Registration (DCR). |
-| `/authorize` · `/callback` · `/token` | Authorization-code flow with **PKCE**. |
+| `/oauth/register` | Dynamic Client Registration (DCR). |
+| `/oauth/authorize` · `/oauth/callback` · `/oauth/token` | Authorization-code flow with **PKCE**. |
 | `/.well-known/jwks.json` | Public keys for token verification. |
-| `/connect` · `/disconnect` | Connect/disconnect an agent's link to a downstream provider (the consent flow used by `forwarded` auth). |
+| `/oauth/connect/*` · `/oauth/disconnect/*` | Connect/disconnect an agent's link to a downstream provider (`forwarded` auth). |
 
+Register `{mcp_base_url}/oauth/callback` on an external IdP app when not using NeuralTrust.
 Together these let an agent register, obtain a token, call the unified MCP endpoint, and —
 when a downstream needs per-user authorization — complete a one-time connect without leaving
 the gateway.

--- a/trustgate/observability/telemetry.mdx
+++ b/trustgate/observability/telemetry.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Telemetry"
-description: "TrustGate streams a rich per-request event to Kafka — model, tokens, cost, latency breakdown, policy chain, and routing attempts — and can forward to TrustLens."
+description: "TrustGate streams a rich per-request event to Kafka and optional OTLP — model, tokens, cost, latency breakdown, policy chain, and routing attempts."
 ---
 
 **Telemetry** is the per-request event that the [metrics worker](/trustgate/observability/metrics)
 builds and ships off the critical path. Each event captures everything needed to analyze
 cost, latency, routing, and policy decisions. The default sink is **Kafka**; a per-gateway
-**OpenTelemetry (OTLP)** exporter and **TrustLens** forwarding are opt-in.
+**OpenTelemetry (OTLP)** exporter is opt-in.
+
+Platform [Telemetry Alerts](/platform/alerts) consume gateway events (and other product
+streams). **[TrustLens](/trustlens/overview)** (Agent-SPM) is an additional telemetry
+**source** for that platform surface — inventory and posture signals — not a replacement
+for the TrustGate Kafka/OTLP request stream.
 
 ## Configuration
 
@@ -18,8 +23,6 @@ Telemetry is configured globally by environment and refined per gateway.
 | `TELEMETRY_KAFKA_TOPIC` | `agentgateway.requests` | Destination topic. |
 | `TELEMETRY_ENABLE_REQUEST_TRACES` | `true` | Include request traces. |
 | `TELEMETRY_ENABLE_PLUGIN_TRACES` | `true` | Include per-policy traces. |
-| `TELEMETRY_TRUSTLENS_ENABLED` | `false` | Forward to TrustLens. |
-| `TELEMETRY_TRUSTLENS_URL` | — | TrustLens endpoint. |
 
 Per [gateway](/trustgate/concepts/gateways), `telemetry` can define its own exporters,
 static `extra_params` appended to every event, trace toggles, and a `header_mapping` that
@@ -33,7 +36,7 @@ A gateway's `telemetry.exporters[]` selects where its events go. Per-gateway exp
 | `name` | Settings | Notes |
 |---|---|---|
 | `kafka` | `{ host, port, topic }` | Stream events to a Kafka topic. |
-| `otlp` | OTLP endpoint / headers | Export each request as an OpenTelemetry **log record** (`event.name = "gateway.request"`). Only the `logs` signal is supported. |
+| `otlp` | OTLP endpoint / headers | Export each request as an OpenTelemetry **log record** (`event.name` like `trustgate.<schema_version>.metadata`). Only the `logs` signal is supported. |
 
 Process-level OTLP defaults come from the standard `OTEL_EXPORTER_OTLP_*` environment
 variables; a gateway opts in by adding an `otlp` exporter.
@@ -45,7 +48,7 @@ Events are versioned (`schema_version`, currently **3**) and carry a `kind` of `
 
 | Group | Fields |
 |---|---|
-| Identity | `trace_id`, `gateway_id`, `team_id`, `consumer`, `session_id`, `turn_id`, `ip`. |
+| Identity | `trace_id`, `gateway_id`, `tenant_id`, `consumer`, `session_id`, `turn_id`, `ip`. |
 | Request | method, path, provider, registry id, requested vs resolved model, temperature, max tokens, stream flag, prompt tokens. |
 | Response | status code, latency, completion tokens, finish reason, streaming. |
 | Usage | prompt / completion / total tokens, cached input, reasoning output. |
@@ -56,12 +59,12 @@ Events are versioned (`schema_version`, currently **3**) and carry a `kind` of `
 
 ## Using the stream
 
-Point any Kafka consumer at the topic to build dashboards, billing, or anomaly detection;
-or enable the **TrustLens** integration to forward events to NeuralTrust's analytics. The
-`attempts` and `policy_chain` arrays make it possible to reconstruct exactly how each
+Point any Kafka consumer at the topic to build dashboards, billing, or anomaly detection.
+The `attempts` and `policy_chain` arrays make it possible to reconstruct exactly how each
 request was routed and which policies fired.
 
-Once forwarded to NeuralTrust, these events also power [Telemetry Alerts](/platform/alerts) —
-predefined and custom detection rules (elevated error rate, latency degradation,
-authentication anomalies, rate-limit abuse, upstream-provider errors) that raise deduplicated
-alerts and forward them to your SIEM.
+These gateway events also feed [Telemetry Alerts](/platform/alerts) — predefined and custom
+detection rules (elevated error rate, latency degradation, authentication anomalies,
+rate-limit abuse, upstream-provider errors) that raise deduplicated alerts and forward them
+to your SIEM. TrustLens contributes posture/inventory telemetry as a separate source into
+that same alerting fabric.

--- a/trustgate/operate/configuration.mdx
+++ b/trustgate/operate/configuration.mdx
@@ -43,7 +43,6 @@ with safe defaults.
 |---|---|---|
 | `TELEMETRY_ENABLED` | `true` | Emit request telemetry. |
 | `TELEMETRY_KAFKA_TOPIC` | `agentgateway.requests` | Telemetry topic. |
-| `TELEMETRY_TRUSTLENS_ENABLED` / `_URL` | `false` / — | TrustLens forwarding. |
 | `METRICS_ENABLED` | `true` | Per-request [metrics worker](/trustgate/observability/metrics) (no scrape endpoint). |
 | `METRICS_QUEUE_SIZE` / `_WORKER_COUNT` / `_FLUSH_INTERVAL` | `1000` / `1` / `5s` | Metrics worker queue, workers, and flush interval. |
 | `UPSTREAM_TIMEOUT` | `60s` | Upstream request timeout. |

--- a/trustgate/overview.mdx
+++ b/trustgate/overview.mdx
@@ -31,9 +31,9 @@ Putting TrustGate between your apps and your model providers gives you one contr
 - **Guardrails** — built-in [TrustGuard](/trustguard/overview), OpenAI Moderation, Azure
   Content Safety, AWS Bedrock, and Regex Replace policies to inspect or rewrite prompts and
   responses inline.
-- **Multi-tenancy & auth** — per-gateway consumers authenticated by API key, OAuth2, or OIDC
-  (see [Auth](/trustgate/concepts/auth)). LLM **inline**: API key or OAuth2; LLM
-  **role_based**: OIDC; MCP: OAuth2 (your IdP or NeuralTrust).
+- **Multi-tenancy & auth** — per-gateway consumers authenticated by API key, OAuth2, OIDC,
+  or mTLS (see [Auth](/trustgate/concepts/auth)). LLM consumers use API key, OAuth2, or OIDC;
+  MCP consumers use OAuth2 (your IdP or NeuralTrust).
 - **Observability** — rich per-request telemetry (model, tokens, cost, latency breakdown,
   routing attempts, policy chain) via Kafka and OpenTelemetry (OTLP). Events feed
   [Telemetry Alerts](/platform/alerts); [TrustLens](/trustlens/overview) is an additional
@@ -51,7 +51,7 @@ then send traffic to the proxy. Six objects make up a gateway:
 | **[Gateway](/trustgate/concepts/gateways)** | The top-level tenant, addressed by a `slug`. Owns everything below. |
 | **[Registry](/trustgate/concepts/registries)** | An upstream backend — an LLM provider endpoint or an MCP server. |
 | **[Consumer](/trustgate/concepts/consumers)** | The calling application's identity. Owns routing and credentials, addressed by a `slug` in the URL. |
-| **[Auth](/trustgate/concepts/auth)** | A credential that authenticates as a consumer — see Auth for the LLM vs MCP matrix. |
+| **[Auth](/trustgate/concepts/auth)** | A credential that authenticates as a consumer — LLM: API key / OAuth2 / OIDC; MCP: OAuth2. |
 | **[Policy](/trustgate/policies/overview)** | A governance rule that runs at request/response stages — rate limiting, budgets, caching, tool governance, guardrails, and more. |
 | **[Role](/trustgate/concepts/roles)** | Routing config selected from OIDC token claims, for identity-based routing. |
 

--- a/trustgate/overview.mdx
+++ b/trustgate/overview.mdx
@@ -31,12 +31,13 @@ Putting TrustGate between your apps and your model providers gives you one contr
 - **Guardrails** — built-in [TrustGuard](/trustguard/overview), OpenAI Moderation, Azure
   Content Safety, AWS Bedrock, and Regex Replace policies to inspect or rewrite prompts and
   responses inline.
-- **Multi-tenancy & auth** — per-gateway consumers authenticated by API key, OAuth2, OIDC,
-  or mTLS (see Auth). LLM consumers use API key, OAuth2, or OIDC; MCP consumers use OAuth2.
+- **Multi-tenancy & auth** — per-gateway consumers authenticated by API key, OAuth2, or OIDC
+  (see [Auth](/trustgate/concepts/auth)). LLM **inline**: API key or OAuth2; LLM
+  **role_based**: OIDC; MCP: OAuth2 (your IdP or NeuralTrust).
 - **Observability** — rich per-request telemetry (model, tokens, cost, latency breakdown,
-  routing attempts, policy chain) exported through OpenTelemetry (OTLP) and forwarded to
-  TrustLens, where it powers
-  [detection alerts](/platform/alerts).
+  routing attempts, policy chain) via Kafka and OpenTelemetry (OTLP). Events feed
+  [Telemetry Alerts](/platform/alerts); [TrustLens](/trustlens/overview) is an additional
+  telemetry source (Agent-SPM inventory/posture), not the request analytics sink.
 - **Agent tooling** — a dedicated MCP plane exposes [MCP](/trustgate/mcp/overview) servers
   and tools to agents with full OAuth2 support.
 
@@ -50,7 +51,7 @@ then send traffic to the proxy. Six objects make up a gateway:
 | **[Gateway](/trustgate/concepts/gateways)** | The top-level tenant, addressed by a `slug`. Owns everything below. |
 | **[Registry](/trustgate/concepts/registries)** | An upstream backend — an LLM provider endpoint or an MCP server. |
 | **[Consumer](/trustgate/concepts/consumers)** | The calling application's identity. Owns routing and credentials, addressed by a `slug` in the URL. |
-| **[Auth](/trustgate/concepts/auth)** | A credential that authenticates as a consumer — LLM: API key / OAuth2 / OIDC; MCP: OAuth2. |
+| **[Auth](/trustgate/concepts/auth)** | A credential that authenticates as a consumer — see Auth for the LLM vs MCP matrix. |
 | **[Policy](/trustgate/policies/overview)** | A governance rule that runs at request/response stages — rate limiting, budgets, caching, tool governance, guardrails, and more. |
 | **[Role](/trustgate/concepts/roles)** | Routing config selected from OIDC token claims, for identity-based routing. |
 


### PR DESCRIPTION
## Summary
- **Auth matrix:** LLM inline = `api_key` | `oauth2`; LLM role_based = `oidc` only; MCP = `oauth2`.
- **MCP IdP:** external IdP client **or** NeuralTrust (blank Client / Use NeuralTrust).
- **MCP paths:** `/oauth/authorize`, `/oauth/callback`, `/oauth/token`, etc.; consumer URL `/{slug}/mcp`.
- **Telemetry:** Event identity `tenant_id`; remove obsolete `TELEMETRY_TRUSTLENS_*`; TrustLens framed as an **additional telemetry source** for platform alerts (Agent-SPM), not the Kafka sink for request analytics.
- Kafka topic default left unchanged (out of scope).

## Test plan
- [ ] Auth + consumers + authorization overview tables agree
- [ ] MCP overview paths match Okta/Entra manuals
- [ ] Telemetry page has no “forward to TrustLens analytics” wording


Made with [Cursor](https://cursor.com)