### PR TITLE
docs(platform): BtG multi-org, settings nav, organization wording

### DIFF
--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -1,6 +1,6 @@
 ---
 title: Break the Glass
-description: "Configure up to five emergency Break the Glass accounts in User & Roles. A single-organization account signs in with password only."
+description: "Configure emergency Break the Glass accounts in User & Roles. They sign in with password only — including when the account belongs to multiple organizations."
 ---
 
 # Break the Glass (Emergency Access)
@@ -31,110 +31,48 @@ enabled. Otherwise an IdP outage can lock out your entire organization.
 
 ## Organization membership
 
-Treat Break the Glass as an **emergency-only** account, and assign it to
+Treat Break the Glass as an **emergency-only** account. Prefer assigning it to
 **exactly one organization**.
 
 | Membership | Sign-in behavior |
 |---|---|
-| **One organization (required)** | **Password only** — always. Skips SSO and magic link. |
-| **Multiple organizations (avoid)** | Sign-in requires a **magic link first**, then shows the organizations the account can access. Selecting an organization that uses SSO continues with that org's IdP (for example Okta, Entra ID, or another OIDC provider). After IdP authentication succeeds, the user is signed in. |
-
-The magic-link step for multi-org accounts exists so organization membership is
-not disclosed before the email is verified.
+| **One organization (recommended)** | **Password only** — always. Skips SSO and magic link. |
+| **Multiple organizations** | Still **password only** for Break the Glass. The account does **not** take the magic-link / IdP path used by normal multi-org users. Prefer a dedicated single-org emergency account. |
 
 ---
 
 ## How It Works
 
-1. An Owner or Admin creates a Break the Glass account in **User & Roles**
-   (password ≥ 30 characters).
-2. With **exactly one** organization membership, that account always
-   authenticates with **password only** — it does not use SSO or magic link.
-3. When **Enforce SSO** is on, everyone else must use the configured IdP; the
-   Break the Glass account still uses password.
+1. An Owner, Global Admin, or IAM Admin creates a Break the Glass account in
+   **Platform settings → User & Roles** (password ≥ 30 characters).
+2. Break the Glass always authenticates with **password only** — it does not use
+   SSO or magic link (single- or multi-organization).
+3. When **Enforce SSO** is on, members on a **verified** email domain must use the
+   configured IdP. External-domain guests still use magic link. The Break the Glass
+   account still uses password.
 4. Maximum **five** Break the Glass accounts per organization (recommended: 2–3).
 5. All Break the Glass logins are recorded in Audit Logs.
 
 ### Normal user vs Break the Glass
 
-| Scenario | Normal user | Break the Glass (single org) |
-|----------|-------------|------------------------------|
+| Scenario | Normal user | Break the Glass |
+|---|---|---|
 | Sign-in | Magic link or SSO (passwordless) | **Password only** (skips SSO and magic link) |
-| SSO Enforcement ON | Must use the configured IdP SSO | **Password only** |
-| IdP is down | Cannot use SSO | Can log in with password |
+| MFA | Via IdP when using SSO | No MFA on the password |
+| Enforce SSO | Verified-domain members → IdP; external guests → magic link | Password escape hatch |
 
 ---
 
-## Hardening (recommended)
+## Setup
 
-- Keep **2–3** accounts (max **5** per organization) — not everyone.
-- Rotate BtG passwords periodically; store them in your secret manager.
-- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
-- Disable or remove BtG access when the emergency is over.
-
----
-
-## Creating a Break the Glass Account
-
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin.
-2. Go to **User & Roles**.
-3. Invite a user or edit a member and apply the **Break the glass** role
-   template (or mark the user as Break the Glass). The console provisions a long
-   password (≥ 30 characters) — store it in your secret manager.
-4. Confirm the account belongs to **only this** organization.
+1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a>
+   with IAM Admin access (Owner / Global Admin include it).
+2. Open the sidebar gear → **Platform settings → User & Roles**.
+3. **Add User** (or edit) → apply the **Break the glass** template → set a password
+   (≥ 30 characters).
+4. Keep the account in a single organization when possible.
 5. Configure your **Email Domain**, then enable **Enforce SSO** when ready —
-   see [Microsoft Entra ID SSO](/platform/sso) or
-   [Generic OIDC SSO](/platform/generic-oidc-sso).
-
----
-
-## Validation Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| Password too short | Below the 30-character minimum | Set a longer password |
-| Cannot use password sign-in | User is not Break the Glass | Promote the user in [User & Roles](/platform/users) |
-| Magic link required / org picker shown | Account is in more than one organization | Remove extra memberships so only one remains |
-| Maximum accounts reached | Already have five Break the Glass accounts | Remove or demote an existing account first |
-
----
-
-## Removing Break the Glass Access
-
-1. Go to **User & Roles**.
-2. Edit the user and remove the Break the Glass role (or delete the account).
-3. The user then follows normal passwordless sign-in (magic link or SSO).
-
----
-
-## Audit Logging
-
-All break-glass activity is logged for compliance and security monitoring.
-
-| Event | Description |
-|-------|-------------|
-| `auth.login.success` | Break-glass user logged in successfully (metadata includes `isBreakGlassAccess: true`) |
-| `auth.login.failure` | Break-glass login attempt failed |
-
-### Viewing Break-Glass Events
-
-1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available).
-2. Filter by Event Type: **Login Success**.
-3. Look for break-glass sign-in events in the description.
-
----
-
-## Security Best Practices
-
-| Recommendation | Why |
-|----------------|-----|
-| Add 2–3 users (max **5** per organization) | Redundancy in case one is unavailable |
-| Use owner/admin–capable accounts | They have permissions to fix SSO issues |
-| Use strong passwords (≥ 30 characters) | Break-glass accounts are high-value targets |
-| One organization per account | Keeps the password-only sign-in path |
-| Test quarterly | Ensure break-glass users remember passwords |
-| Document the process | Include in your incident response runbook |
-| Monitor audit logs | Review break-glass usage regularly |
+   see [Microsoft Entra ID SSO](/platform/sso) or [Generic OIDC SSO](/platform/generic-oidc-sso).
 
 ---
 
@@ -145,17 +83,16 @@ All break-glass activity is logged for compliance and security monitoring.
 You won't be able to log in until the IdP is restored. Configure Break the Glass
 accounts proactively before enabling Enforce SSO.
 
-**Q: Can a Break the Glass account (single org) also use SSO or magic link?**
+**Q: Can a Break the Glass account also use SSO or magic link?**
 
-No. With a single organization membership it signs in with **password only** —
-it always skips SSO and magic link.
+No. Break the Glass always signs in with **password only** — it skips SSO and
+magic link, including if the account belongs to several organizations.
 
-**Q: What if my account belongs to several organizations?**
+**Q: What if a normal (non–Break the Glass) account belongs to several organizations?**
 
-You receive a **magic link** before any organizations are shown. After you open
-it, pick an organization. If that organization enforces SSO, you complete
-authentication with its IdP (Okta, Entra ID, and so on) and then enter the
-product. Prefer a dedicated single-org Break the Glass account for emergencies.
+That user receives a **magic link** first, then picks an organization. If that
+organization enforces SSO, they complete authentication with its IdP. This path
+does **not** apply to Break the Glass accounts.
 
 **Q: Is there a way to know when Break the Glass was used?**
 
@@ -168,11 +105,11 @@ Enforce SSO is enabled.
 
 **Q: Where do I create Break the Glass accounts?**
 
-In **User & Roles**.
+**Platform settings → User & Roles**.
 
-**Q: Can Members be Break the Glass users?**
+**Q: Who can be a Break the Glass user?**
 
-Yes — apply the Break the Glass role in [User & Roles](/platform/users). Accounts
+Apply the **Break the glass** role in [User & Roles](/platform/users). Accounts
 without that role are passwordless.
 
 ---

--- a/platform/break-glass.mdx
+++ b/platform/break-glass.mdx
@@ -1,6 +1,6 @@
 ---
 title: Break the Glass
-description: "Configure emergency Break the Glass accounts in User & Roles. They sign in with password only — including when the account belongs to multiple organizations."
+description: "Configure up to five emergency Break the Glass accounts in User & Roles. A single-organization account signs in with password only."
 ---
 
 # Break the Glass (Emergency Access)
@@ -31,48 +31,111 @@ enabled. Otherwise an IdP outage can lock out your entire organization.
 
 ## Organization membership
 
-Treat Break the Glass as an **emergency-only** account. Prefer assigning it to
+Treat Break the Glass as an **emergency-only** account, and assign it to
 **exactly one organization**.
 
 | Membership | Sign-in behavior |
 |---|---|
-| **One organization (recommended)** | **Password only** — always. Skips SSO and magic link. |
-| **Multiple organizations** | Still **password only** for Break the Glass. The account does **not** take the magic-link / IdP path used by normal multi-org users. Prefer a dedicated single-org emergency account. |
+| **One organization (required)** | **Password only** — always. Skips SSO and magic link. |
+| **Multiple organizations (avoid)** | Still **password only** for Break the Glass (skips SSO and magic link). Prefer a dedicated single-org emergency account. |
+
+Normal (non–Break the Glass) multi-org users may see a magic link first so membership
+is not disclosed before the email is verified — that path does **not** apply to Break
+the Glass.
 
 ---
 
 ## How It Works
 
-1. An Owner, Global Admin, or IAM Admin creates a Break the Glass account in
+1. An Owner or Admin creates a Break the Glass account in
    **Platform settings → User & Roles** (password ≥ 30 characters).
-2. Break the Glass always authenticates with **password only** — it does not use
-   SSO or magic link (single- or multi-organization).
-3. When **Enforce SSO** is on, members on a **verified** email domain must use the
-   configured IdP. External-domain guests still use magic link. The Break the Glass
-   account still uses password.
+2. Break the Glass authenticates with **password only** — it does not use SSO or
+   magic link (single- or multi-organization).
+3. When **Enforce SSO** is on, other members use the configured IdP (or magic link
+   if they are external-domain guests); the Break the Glass account still uses password.
 4. Maximum **five** Break the Glass accounts per organization (recommended: 2–3).
 5. All Break the Glass logins are recorded in Audit Logs.
 
 ### Normal user vs Break the Glass
 
 | Scenario | Normal user | Break the Glass |
-|---|---|---|
+|----------|-------------|-----------------|
 | Sign-in | Magic link or SSO (passwordless) | **Password only** (skips SSO and magic link) |
-| MFA | Via IdP when using SSO | No MFA on the password |
-| Enforce SSO | Verified-domain members → IdP; external guests → magic link | Password escape hatch |
+| SSO Enforcement ON | Must use the configured IdP SSO | **Password only** |
+| IdP is down | Cannot use SSO | Can log in with password |
 
 ---
 
-## Setup
+## Hardening (recommended)
 
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a>
-   with IAM Admin access (Owner / Global Admin include it).
-2. Open the sidebar gear → **Platform settings → User & Roles**.
-3. **Add User** (or edit) → apply the **Break the glass** template → set a password
-   (≥ 30 characters).
-4. Keep the account in a single organization when possible.
+- Keep **2–3** accounts (max **5** per organization) — not everyone.
+- Rotate BtG passwords periodically; store them in your secret manager.
+- Treat every BtG sign-in as an incident (audit alerts fire for organization admins).
+- Disable or remove BtG access when the emergency is over.
+
+---
+
+## Creating a Break the Glass Account
+
+1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin.
+2. Open **Platform settings → User & Roles**.
+3. Invite a user or edit a member and apply the **Break the glass** role
+   template (or mark the user as Break the Glass). The console provisions a long
+   password (≥ 30 characters) — store it in your secret manager.
+4. Confirm the account belongs to **only this** organization when possible.
 5. Configure your **Email Domain**, then enable **Enforce SSO** when ready —
-   see [Microsoft Entra ID SSO](/platform/sso) or [Generic OIDC SSO](/platform/generic-oidc-sso).
+   see [Microsoft Entra ID SSO](/platform/sso) or
+   [Generic OIDC SSO](/platform/generic-oidc-sso).
+
+---
+
+## Validation Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Password too short | Below the 30-character minimum | Set a longer password |
+| Cannot use password sign-in | User is not Break the Glass | Promote the user in [User & Roles](/platform/users) |
+| Magic link required / org picker shown | Account is not Break the Glass (or not marked as such) | Confirm the Break the glass role is applied; BtG itself uses password only |
+| Maximum accounts reached | Already have five Break the Glass accounts | Remove or demote an existing account first |
+
+---
+
+## Removing Break the Glass Access
+
+1. Go to **User & Roles**.
+2. Edit the user and remove the Break the Glass role (or delete the account).
+3. The user then follows normal passwordless sign-in (magic link or SSO).
+
+---
+
+## Audit Logging
+
+All break-glass activity is logged for compliance and security monitoring.
+
+| Event | Description |
+|-------|-------------|
+| `auth.login.success` | Break-glass user logged in successfully (metadata includes `isBreakGlassAccess: true`) |
+| `auth.login.failure` | Break-glass login attempt failed |
+
+### Viewing Break-Glass Events
+
+1. Open **Audit Logs** in the console (location is moving; look under Telemetry / Logs when available).
+2. Filter by Event Type: **Login Success**.
+3. Look for break-glass sign-in events in the description.
+
+---
+
+## Security Best Practices
+
+| Recommendation | Why |
+|----------------|-----|
+| Add 2–3 users (max **5** per organization) | Redundancy in case one is unavailable |
+| Use owner/admin–capable accounts | They have permissions to fix SSO issues |
+| Use strong passwords (≥ 30 characters) | Break-glass accounts are high-value targets |
+| One organization per account | Keeps the password-only sign-in path |
+| Test quarterly | Ensure break-glass users remember passwords |
+| Document the process | Include in your incident response runbook |
+| Monitor audit logs | Review break-glass usage regularly |
 
 ---
 
@@ -90,9 +153,9 @@ magic link, including if the account belongs to several organizations.
 
 **Q: What if a normal (non–Break the Glass) account belongs to several organizations?**
 
-That user receives a **magic link** first, then picks an organization. If that
-organization enforces SSO, they complete authentication with its IdP. This path
-does **not** apply to Break the Glass accounts.
+That user receives a **magic link** before any organizations are shown, then picks
+an organization (and may continue with that org's IdP if SSO is enforced). Prefer
+a dedicated single-org Break the Glass account for emergencies.
 
 **Q: Is there a way to know when Break the Glass was used?**
 
@@ -107,9 +170,9 @@ Enforce SSO is enabled.
 
 **Platform settings → User & Roles**.
 
-**Q: Who can be a Break the Glass user?**
+**Q: Can Members be Break the Glass users?**
 
-Apply the **Break the glass** role in [User & Roles](/platform/users). Accounts
+Yes — apply the Break the Glass role in [User & Roles](/platform/users). Accounts
 without that role are passwordless.
 
 ---

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -23,7 +23,7 @@ NeuralTrust supports authentication with any OIDC-compliant identity provider, g
 
 Before configuring Generic OIDC SSO, ensure you have:
 
-- **NeuralTrust Account**: Owner or Global Admin (IAM Admin) in your organization
+- **NeuralTrust Account**: Owner role in your team
 - **OIDC Provider**: Administrator access to create applications
 - **Discovery Endpoint**: Your provider must support OIDC Discovery (`.well-known/openid-configuration`)
 
@@ -47,7 +47,7 @@ Only **Microsoft Entra ID** **or** **Generic OIDC** can be configured at a time�
 | **Display Name** | No | Custom name shown on the login button (e.g., "Sign in with Okta") |
 | **Scopes** | No | OAuth scopes to request (default: `openid profile email`) |
 | **Trust Identity Provider** | No | When enabled, users authenticated by the IdP can join the team without DNS email-domain verification. Default: off. |
-| **Role Mapping from IdP** | No | When enabled, extracts organization role from an OIDC token claim and maps IdP values to NeuralTrust roles. |
+| **Role Mapping from IdP** | No | When enabled, extracts team role from an OIDC token claim and maps IdP values to NeuralTrust roles. |
 | **Role Claim Name** | When role mapping enabled | Exact claim key in the token (e.g., `role`, `roles`, `groups`). |
 | **Role Mappings** | When role mapping enabled | Map IdP claim values to `Admin` or `Member`. Keys are case-sensitive. |
 | **Default Role** | No | Role when claim is missing or unmatched. Default: `Member`. |
@@ -128,7 +128,7 @@ When **Trust Identity Provider** is enabled:
 
 When disabled (default):
 
-- New users must either already be organization members **or** belong to a **verified** email domain configured under Email Domains.
+- New users must either already be team members **or** belong to a **verified** email domain configured under Email Domains.
 
 <Warning>
 Only enable Trust Identity Provider if you fully trust the IdP to authenticate authorized users only. This bypasses domain ownership verification for user provisioning.
@@ -143,7 +143,7 @@ Only enable Trust Identity Provider if you fully trust the IdP to authenticate a
 **UI label:** Role Mapping from IdP  
 **Default:** disabled
 
-Automatically assign **Admin** or **Member** organization roles during OIDC login based on token claims.
+Automatically assign **Admin** or **Member** team roles during OIDC login based on token claims.
 
 ### Setup Steps
 
@@ -164,7 +164,7 @@ Automatically assign **Admin** or **Member** organization roles during OIDC logi
 | Case sensitivity | Mapping keys must match IdP values **exactly** |
 | Multiple matches | Highest privilege wins: **Admin** > **Member** |
 | No match | **Default Role** is applied (default: Member) |
-| Existing members (default) | Role is assigned on **first join** only; subsequent logins **preserve** the existing organization role unless sync is enabled (see [Federated role policy](#federated-role-policy-oidc-only)) |
+| Existing members (default) | Role is assigned on **first join** only; subsequent logins **preserve** the existing team role unless sync is enabled (see [Federated role policy](#federated-role-policy-oidc-only)) |
 
 ### Example: Multi-Value Group Claim
 
@@ -223,7 +223,7 @@ When enabled:
 - Login is **denied** if **no** value in the configured claim maps to a NeuralTrust role.
 - The user is **not** created in the team for that login attempt.
 - Redirect: `/login?error=insufficient_role`
-- User-facing message: *Access denied: your account does not have a role assigned for this organization. Contact your administrator.*
+- User-facing message: *Access denied: your account does not have a role assigned for this team. Contact your administrator.*
 
 Requirements before enabling:
 
@@ -239,7 +239,7 @@ Test mappings thoroughly before enabling. Any authenticated user without a mappe
 
 When enabled:
 
-- The user's NeuralTrust organization role is **updated on every OIDC login** to reflect their current IdP role mapping.
+- The user's NeuralTrust team role is **updated on every OIDC login** to reflect their current IdP role mapping.
 - Promotions and demotions in the IdP take effect on the next login.
 
 Safeguard:
@@ -248,7 +248,7 @@ Safeguard:
 
 When disabled (default):
 
-- Existing team members **keep their current role** on subsequent logins; mapping applies only when the user first joins the organization.
+- Existing team members **keep their current role** on subsequent logins; mapping applies only when the user first joins the team.
 
 #### Behavior Matrix
 
@@ -337,7 +337,7 @@ A verification token will be displayed. Add a TXT record to your DNS:
 | **Verified** ✓ | Domain ownership confirmed | Domain is active for SSO |
 | **Failed** ✗ | Verification unsuccessful | Check DNS record and retry |
 
-If **Trust Identity Provider** is enabled, new users authenticated by the IdP can join without a verified domain. If Trust IdP is disabled, new users need a verified domain or an existing organization membership.
+If **Trust Identity Provider** is enabled, new users authenticated by the IdP can join without a verified domain. If Trust IdP is disabled, new users need a verified domain or an existing team membership.
 
 ---
 
@@ -359,7 +359,7 @@ your organization's access—except break-the-glass accounts, which sign in with
 </Note>
 
 <Warning>
-Before enabling SSO Enforcement, ensure organization members can sign in through your OIDC
+Before enabling SSO Enforcement, ensure team members can sign in through your OIDC
 provider. Keep a [Break the Glass](/platform/break-glass) emergency account for IdP
 outages.
 </Warning>

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -23,7 +23,7 @@ NeuralTrust supports authentication with any OIDC-compliant identity provider, g
 
 Before configuring Generic OIDC SSO, ensure you have:
 
-- **NeuralTrust Account**: Owner role in your team
+- **NeuralTrust Account**: Owner or Global Admin (IAM Admin) in your organization
 - **OIDC Provider**: Administrator access to create applications
 - **Discovery Endpoint**: Your provider must support OIDC Discovery (`.well-known/openid-configuration`)
 
@@ -47,12 +47,12 @@ Only **Microsoft Entra ID** **or** **Generic OIDC** can be configured at a time�
 | **Display Name** | No | Custom name shown on the login button (e.g., "Sign in with Okta") |
 | **Scopes** | No | OAuth scopes to request (default: `openid profile email`) |
 | **Trust Identity Provider** | No | When enabled, users authenticated by the IdP can join the team without DNS email-domain verification. Default: off. |
-| **Role Mapping from IdP** | No | When enabled, extracts team role from an OIDC token claim and maps IdP values to NeuralTrust roles. |
+| **Role Mapping from IdP** | No | When enabled, extracts organization role from an OIDC token claim and maps IdP values to NeuralTrust roles. |
 | **Role Claim Name** | When role mapping enabled | Exact claim key in the token (e.g., `role`, `roles`, `groups`). |
 | **Role Mappings** | When role mapping enabled | Map IdP claim values to `Admin` or `Member`. Keys are case-sensitive. |
 | **Default Role** | No | Role when claim is missing or unmatched. Default: `Member`. |
 | **Require IdP role match** | No | OIDC only. Deny login if no claim value maps to a NeuralTrust role. Default: off. |
-| **Sync team role from IdP on login** | No | OIDC only. Update the user's team role on every OIDC login from IdP. Default: off. |
+| **Sync organization role from IdP on login** | No | OIDC only. Update the user's organization role on every OIDC login from IdP. Default: off. |
 | **Session Policy** | No | `Align with IdP id_token.exp` (default, recommended) or `Fixed app-defined cap`. |
 | **Fixed session cap** | When Fixed policy selected | Duration in minutes (5 min – 30 days; default 24 h if empty). |
 
@@ -94,8 +94,7 @@ From your identity provider, copy:
 
 ### Step 3: Configure in NeuralTrust
 
-1. Navigate to **Team Settings** → **SSO** → tab **Generic OIDC**
-   - URL pattern: `https://app.neuraltrust.ai/{locale}/{teamId}/settings/sso`
+1. Open the sidebar gear → **Platform settings → SSO Configuration** → **Generic OIDC**
 2. Click **Edit** to enable editing mode
 3. In the **Generic OIDC Configuration** section, enter your credentials:
    - **Issuer URL**: Paste your issuer URL
@@ -129,7 +128,7 @@ When **Trust Identity Provider** is enabled:
 
 When disabled (default):
 
-- New users must either already be team members **or** belong to a **verified** email domain configured under Email Domains.
+- New users must either already be organization members **or** belong to a **verified** email domain configured under Email Domains.
 
 <Warning>
 Only enable Trust Identity Provider if you fully trust the IdP to authenticate authorized users only. This bypasses domain ownership verification for user provisioning.
@@ -144,7 +143,7 @@ Only enable Trust Identity Provider if you fully trust the IdP to authenticate a
 **UI label:** Role Mapping from IdP  
 **Default:** disabled
 
-Automatically assign **Admin** or **Member** team roles during OIDC login based on token claims.
+Automatically assign **Admin** or **Member** organization roles during OIDC login based on token claims.
 
 ### Setup Steps
 
@@ -165,7 +164,7 @@ Automatically assign **Admin** or **Member** team roles during OIDC login based 
 | Case sensitivity | Mapping keys must match IdP values **exactly** |
 | Multiple matches | Highest privilege wins: **Admin** > **Member** |
 | No match | **Default Role** is applied (default: Member) |
-| Existing members (default) | Role is assigned on **first join** only; subsequent logins **preserve** the existing team role unless sync is enabled (see [Federated role policy](#federated-role-policy-oidc-only)) |
+| Existing members (default) | Role is assigned on **first join** only; subsequent logins **preserve** the existing organization role unless sync is enabled (see [Federated role policy](#federated-role-policy-oidc-only)) |
 
 ### Example: Multi-Value Group Claim
 
@@ -224,7 +223,7 @@ When enabled:
 - Login is **denied** if **no** value in the configured claim maps to a NeuralTrust role.
 - The user is **not** created in the team for that login attempt.
 - Redirect: `/login?error=insufficient_role`
-- User-facing message: *Access denied: your account does not have a role assigned for this team. Contact your administrator.*
+- User-facing message: *Access denied: your account does not have a role assigned for this organization. Contact your administrator.*
 
 Requirements before enabling:
 
@@ -240,7 +239,7 @@ Test mappings thoroughly before enabling. Any authenticated user without a mappe
 
 When enabled:
 
-- The user's NeuralTrust team role is **updated on every OIDC login** to reflect their current IdP role mapping.
+- The user's NeuralTrust organization role is **updated on every OIDC login** to reflect their current IdP role mapping.
 - Promotions and demotions in the IdP take effect on the next login.
 
 Safeguard:
@@ -249,7 +248,7 @@ Safeguard:
 
 When disabled (default):
 
-- Existing team members **keep their current role** on subsequent logins; mapping applies only when the user first joins the team.
+- Existing team members **keep their current role** on subsequent logins; mapping applies only when the user first joins the organization.
 
 #### Behavior Matrix
 
@@ -338,7 +337,7 @@ A verification token will be displayed. Add a TXT record to your DNS:
 | **Verified** ✓ | Domain ownership confirmed | Domain is active for SSO |
 | **Failed** ✗ | Verification unsuccessful | Check DNS record and retry |
 
-If **Trust Identity Provider** is enabled, new users authenticated by the IdP can join without a verified domain. If Trust IdP is disabled, new users need a verified domain or an existing team membership.
+If **Trust Identity Provider** is enabled, new users authenticated by the IdP can join without a verified domain. If Trust IdP is disabled, new users need a verified domain or an existing organization membership.
 
 ---
 
@@ -360,7 +359,7 @@ your organization's access—except break-the-glass accounts, which sign in with
 </Note>
 
 <Warning>
-Before enabling SSO Enforcement, ensure team members can sign in through your OIDC
+Before enabling SSO Enforcement, ensure organization members can sign in through your OIDC
 provider. Keep a [Break the Glass](/platform/break-glass) emergency account for IdP
 outages.
 </Warning>
@@ -418,7 +417,7 @@ outages.
 | `unauthorized_team_access` | Email domain not verified and user is not a team member | Add and verify domain, invite user, or enable Trust IdP |
 | `User not authorized` | Generic (legacy message) | See rows above |
 | Wrong role on first login | Mapping misconfiguration | Check case-sensitive keys; for array claims verify all group values |
-| Role not updating on later logins | Sync disabled | Enable **Sync team role from IdP on login** |
+| Role not updating on later logins | Sync disabled | Enable **Sync organization role from IdP on login** |
 | Admin not demoted after IdP change | Sole-admin safeguard | Expected—add another admin before demotion can apply |
 | `Redirect URI mismatch` | Callback not registered | Register the exact URL shown in the in-app setup guide (includes custom domains) |
 | `Invalid issuer` | Issuer URL wrong or no OIDC Discovery | Verify issuer; ensure `/.well-known/openid-configuration` resolves |

--- a/platform/scim.mdx
+++ b/platform/scim.mdx
@@ -49,7 +49,7 @@ If you prefer on-demand user import instead of automatic provisioning, you can u
 ### Step 1: Open SCIM Settings
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner
-2. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO**</a>
+2. Open the sidebar gear → **Platform settings → SSO Configuration** (SCIM tile)
 3. Click the **SCIM Provisioning** tab
 
 ### Step 2: Generate Token
@@ -177,11 +177,11 @@ Before enabling provisioning for your entire organization, test with a single us
 2. Search for and select a test user
 3. Click **Provision**
 4. Review the provisioning steps and results
-5. Check NeuralTrust — the user should appear in your team
+5. Check NeuralTrust — the user should appear in your organization
 
 ### Verify User in NeuralTrust
 
-1. Go to <a href="https://app.neuraltrust.ai/settings/team" target="_blank">**Settings** → **Team**</a> in NeuralTrust
+1. Open **Platform settings → User & Roles** in NeuralTrust
 2. Confirm the provisioned user appears in the member list
 3. Verify their display name and email are correct
 

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -1,11 +1,11 @@
 ---
 title: Microsoft Entra ID SSO
-description: "Step-by-step guide to configure Microsoft Entra ID (Azure AD) Single Sign-On for NeuralTrust. Enable corporate authentication for your team."
+description: "Step-by-step guide to configure Microsoft Entra ID (Azure AD) Single Sign-On for NeuralTrust. Enable corporate authentication for your organization."
 ---
 
 # Microsoft Entra ID Single Sign-On
 
-Single Sign-On (SSO) allows your team members to sign in to NeuralTrust using their corporate Microsoft credentials instead of a separate password.
+Single Sign-On (SSO) allows your organization members to sign in to NeuralTrust using their corporate Microsoft credentials instead of a separate password.
 
 <Note>
 **Using a different identity provider?** If you use Okta, Auth0, Google Workspace, or another OIDC-compliant provider, see [Generic OIDC SSO](/platform/generic-oidc-sso) instead.
@@ -94,7 +94,7 @@ Only required if you plan to use the Manual User Sync feature.
 ### Step 1: Open SSO Settings
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO**</a>
+2. Open the sidebar gear → **Platform settings → SSO Configuration**
 
 ### Step 2: Enter Your Azure Credentials
 
@@ -116,7 +116,7 @@ Domain verification prevents unauthorized users from claiming your company's dom
 
 ### Step 1: Add Your Domain
 
-1. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO** → **Domains**</a>
+1. Open **Platform settings → SSO Configuration** → **Domains**
 2. Click **Add Domain**
 3. Enter your company domain (e.g., `yourcompany.com`)
 4. Click **Add**
@@ -172,7 +172,7 @@ Before configuring role mapping, ensure:
 
 1. Go to <a href="https://portal.azure.com/#view/Microsoft_AAD_IAM/GroupsManagementMenuBlade/~/AllGroups" target="_blank">Azure Portal → Groups</a>
 2. Click **+ New group**
-3. Create groups for your team structure (e.g., "NeuralTrust Admins", "NeuralTrust Members")
+3. Create groups for your organization structure (e.g., "NeuralTrust Admins", "NeuralTrust Members")
 4. Set **Group type** to **Security**
 5. Click **Create**
 
@@ -257,7 +257,7 @@ Users are assigned the role from the **first matching group mapping**. If a user
 Enforcing SSO-only mode requires all users to authenticate through the IdP configured
 for your organization.
 
-1. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">**Settings** → **SSO**</a>
+1. Open **Platform settings → SSO Configuration**
 2. Toggle **Enforce SSO** to ON
 3. Confirm the action
 
@@ -271,7 +271,7 @@ your organization's access—except break-the-glass accounts, which sign in with
 </Note>
 
 <Warning>
-Before enabling SSO-only mode, ensure all team members can sign in with Microsoft.
+Before enabling SSO-only mode, ensure members on verified domains can sign in with Microsoft.
 Users without access through the IdP will be locked out. Keep a
 [Break the Glass](/platform/break-glass) emergency account for IdP outages.
 </Warning>

--- a/platform/user-sync.mdx
+++ b/platform/user-sync.mdx
@@ -38,7 +38,7 @@ Before syncing users, you need to map Azure AD groups to NeuralTrust roles.
 ### Step 1: Open User Sync Settings
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Go to <a href="https://app.neuraltrust.ai/settings/sso" target="_blank">Settings → SSO</a>
+2. Open the sidebar gear → **Platform settings → SSO Configuration**
 3. Click the **Entra ID User Sync** tab
 
 ### Step 2: Add Group Mappings
@@ -98,7 +98,7 @@ If no groups appear in the dropdown, verify that your app registration has `Grou
 
 ### Step 2: Verify in Team Members
 
-1. Go to <a href="https://app.neuraltrust.ai/settings/team" target="_blank">**Settings** → **Team**</a>
+1. Open **Platform settings → User & Roles**
 2. Confirm users appear with correct roles
 3. Verify they can sign in via SSO
 


### PR DESCRIPTION
## Summary
- **Break the Glass:** multi-org accounts also use **password only** (not magic link → IdP). FAQ updated.
- **Settings nav:** Platform settings → SSO Configuration / User & Roles (drop `/settings/sso`, `/settings/team`, Team Settings URLs).
- **Wording:** team → organization in SSO / OIDC / SCIM / user-sync Identity docs.

## Test plan
- [ ] break-glass membership table + FAQ match password-only for multi-org BtG
- [ ] No leftover `settings/team` or `Team Settings → SSO` in platform SSO/SCIM pages


Made with [Cursor](https://cursor.com)