### PR TITLE
docs(trustguard): IPI catalog, URL/Doc analyzers, Moderation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -284,7 +284,8 @@
             "pages": [
               "trustguard/detectors/overview",
               "trustguard/detectors/data-loss-prevention",
-              "trustguard/detectors/content-security"
+              "trustguard/detectors/content-security",
+              "trustguard/detectors/agent-mcp-security"
             ]
           },
           {

--- a/trustguard/api/evaluate.mdx
+++ b/trustguard/api/evaluate.mdx
@@ -120,7 +120,7 @@ Always `200` for a detection — TrustGuard never drops traffic.
 | `source.plugin` | string | Detector findings — the catalog detector slug (e.g. `prompt_guard`). |
 | `source.detector_id` / `source.detector_name` | string | The detector instance that fired. |
 | `source.policy_id` | string | The policy that produced the finding. |
-| `signal.type` | string | What was detected — e.g. `jailbreak`, `pii`, `secret`, `code_injection`, a toxicity category, or `gate_block` / `gate_report`. |
+| `signal.type` | string | What was detected — e.g. `jailbreak`, `injection`, `pii`, `secret`, `keyreg`, `nt_topic`, a toxicity category, or `gate_block` / `gate_report`. Note: `code_injection` is a **signal** produced by the (hidden) `code_sanitation` detector — not a separate catalog plugin you configure. |
 | `signal.confidence` | number | Detector‑specific score in `[0, 1]` (optional). |
 | `outcome.action` | enum | `report`, `transform`, or `block` — the action the rule applied (optional on observational runs). |
 | `evidence` | object | Free‑form, detector‑specific context (e.g. matched entities, masked count, matched rule). |

--- a/trustguard/concepts/detectors.mdx
+++ b/trustguard/concepts/detectors.mdx
@@ -41,7 +41,7 @@ Every catalog detector exposes its own settings schema (the catalog API,
 - `prompt_guard`, `toxicity` — a `threshold` in `[0, 1]`.
 - `data_loss_prevention` — which PII entities to detect/mask, plus custom
   keyword/regex rules.
-- `prompt_moderation` — keyword/regex lists and/or NeuralTrust topic thresholds.
+- Moderation (`prompt_moderation`) — keyword/regex lists and/or NeuralTrust topic thresholds.
 
 See each detector's full settings on its
 [category page](/trustguard/detectors/overview).

--- a/trustguard/detectors/agent-mcp-security.mdx
+++ b/trustguard/detectors/agent-mcp-security.mdx
@@ -1,0 +1,40 @@
+---
+title: "Agent & MCP security detectors"
+description: "Indirect prompt injection detection for MCP tool results and other tool-sourced content."
+---
+
+Agent / MCP security detectors protect tool-using agents from **indirect prompt
+injection** in content that comes back from tools (MCP tool results, tool-role
+messages), not from the end-user prompt alone.
+
+| Detector | Slug | Sides | Protocols | Backend |
+|---|---|---|---|---|
+| Indirect Prompt Injection | `indirect_prompt_injection` | input, output | llm, mcp | NeuralTrust Firewall |
+
+## Indirect Prompt Injection — `indirect_prompt_injection`
+
+Scores MCP tool results (and other tool-sourced content) with the NeuralTrust
+Firewall indirect prompt injection detector. Preferentially inspects
+`role=tool` messages; falls back to all messages or the request body.
+
+Reports a finding when the max category score is at or above threshold
+(`signal.type` is typically `injection` or the top-scoring category).
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `injection.threshold` | number | ✅ | Score in `[0, 1]` above which content is flagged. |
+| `provider` / `credentials` | — | — | Firewall provider + credentials (same pattern as Prompt Guard). |
+
+```json
+{
+  "name": "IPI — tool results",
+  "plugin_slug": "indirect_prompt_injection",
+  "settings": { "injection": { "threshold": 0.7 } }
+}
+```
+
+## When to use
+
+- MCP / tool-calling agents that ingest untrusted tool output into the model context.
+- Pair with [Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)
+  for direct jailbreaks on user prompts.

--- a/trustguard/detectors/content-security.mdx
+++ b/trustguard/detectors/content-security.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Content security detectors"
-description: "Jailbreak and prompt-injection detection, toxicity, topic moderation, and document/URL analysis on AI input and output."
+description: "Jailbreak detection, toxicity, Moderation, and document/URL screening for indirect prompt injection and PII."
 ---
 
-Content‑security detectors are the LLM‑aware core of TrustGuard: they score
-prompts and model output for jailbreaks, toxicity, and off‑topic/disallowed
-content, and analyze documents and URLs. Several call the **NeuralTrust
-Firewall**; its credentials are configured globally (env) or overridden
-per‑detector under `settings.credentials`.
+Content-security detectors are the LLM-aware core of TrustGuard: they score
+prompts and model output for jailbreaks, toxicity, and off-topic/disallowed
+content, and analyze documents and URLs for **indirect prompt injection** and
+PII. Several call the **NeuralTrust Firewall**; its credentials are configured
+globally (env) or overridden per-detector under `settings.credentials`.
 
 All of these are **detection‑only** — the action (**Monitor** / **Block**) and
 evaluation phase (Input / Output) are set on the
@@ -71,12 +71,14 @@ Dual‑mode moderation — enable at least one mode.
 
 ## URL Analyzer — `url_analyzer`
 
-Extracts URLs from content, fetches each page (SSRF‑guarded, size/timeout‑bounded,
-up to 10 URLs per request), and screens the fetched text for jailbreaks and PII.
+Extracts URLs from the request **body / messages** (not from
+`payload.attachments`), fetches each page (SSRF-guarded, size/timeout-bounded,
+up to 10 URLs per request), and screens the fetched text for **indirect prompt
+injection** and PII. **Input side only.**
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `threshold` | number | `0.7` | Jailbreak score threshold. |
+| `threshold` | number | `0.7` | Indirect prompt injection score threshold. |
 | `url.timeout` | integer | `20000` | Milliseconds. |
 | `url.max_content_size` | integer | `1048576` | Bytes (1 MiB). |
 | `url.allowed_domains` / `url.blocked_domains` | array&lt;string&gt; | — | Allow/deny lists. |
@@ -85,13 +87,14 @@ up to 10 URLs per request), and screens the fetched text for jailbreaks and PII.
 ## Document Analyzer — `doc_analyzer`
 
 Extracts text from uploaded documents (PDF, Office, images via OCR, plain text)
-sent as `payload.attachments`, then screens for PII and (optionally) jailbreaks.
+sent as `payload.attachments`, then screens for PII and (optionally) **indirect
+prompt injection**. **Input side only.**
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `max_file_size` | integer | `52428800` (50 MiB) | Bytes. |
 | `entities` | array&lt;enum&gt; | — | PII entities to detect. |
-| `firewall.enabled` | boolean | `false` | Jailbreak screening of extracted text. |
+| `firewall.enabled` | boolean | `false` | Indirect prompt injection screening of extracted text. |
 | `firewall.threshold` | number | `0.7` | |
 | `ocr.enabled` | boolean | `false` | OCR for images/scans (requires the OCR build). |
 | `ocr.languages` | array&lt;string&gt; | — | Tesseract language codes. |
@@ -100,6 +103,7 @@ sent as `payload.attachments`, then screens for PII and (optionally) jailbreaks.
 
 - **`prompt_guard`** is the baseline jailbreak defense for chat traffic.
 - **`url_analyzer` / `doc_analyzer`** for RAG and agent flows that ingest
-  links/files.
+  links/files (content risk in untrusted text — not malware scanning).
 - **`toxicity`** on input and/or output for abuse and safety.
-- **`prompt_moderation`** for topic/scope control ("only answer about X").
+- **Moderation** (`prompt_moderation`) for topic/scope control ("only answer about X").
+- Tool-result IPI → [Indirect Prompt Injection](/trustguard/detectors/agent-mcp-security).

--- a/trustguard/detectors/overview.mdx
+++ b/trustguard/detectors/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Detector catalog"
-description: "The built-in TrustGuard detector catalog: six detectors across data loss prevention and content security, with their supported sides and protocols."
+description: "The built-in TrustGuard detector catalog across data loss prevention, content security, and agent/MCP security."
 ---
 
 TrustGuard ships a fixed **catalog of detectors**. You don't build a detector
@@ -12,8 +12,8 @@ available; each catalog detector's full settings live on its **category page**
 
 The console's **Detectors → Catalog** (Agent Runtime) lists the catalog grouped
 by category, with a configuration form for each detector's settings. **Sensitivity**
-is aligned across detectors to three levels: **Permissive**, **Balanced** (recommended),
-and **Strict**.
+(where exposed) maps to **Permissive**, **Balanced** (recommended), and **Strict**
+in the console.
 
 ## Categories
 
@@ -21,6 +21,7 @@ and **Strict**.
 |---|---|
 | **[Data loss prevention](/trustguard/detectors/data-loss-prevention)** | PII and secret detection + masking. |
 | **[Content security](/trustguard/detectors/content-security)** | Jailbreaks, toxicity, moderation, document/URL analysis. |
+| **[Agent & MCP security](/trustguard/detectors/agent-mcp-security)** | Indirect prompt injection in tool-sourced content. |
 
 ## The catalog
 
@@ -40,16 +41,22 @@ support the **Transform** action).
 |---|---|---|---|---|
 | `prompt_guard` | Jailbreaks / prompt injections, scored by the NeuralTrust Firewall. | input, output | all | — |
 | `toxicity` | Toxic content, scored by the NeuralTrust Firewall. | input, output | all | — |
-| `prompt_moderation` | Off‑topic / disallowed content via keyword+regex, NeuralTrust topics, or an LLM provider. | input, output | all | — |
-| `url_analyzer` | Fetches URLs in the content (SSRF‑guarded) and screens them for jailbreaks and PII. | input | llm, mcp | — |
-| `doc_analyzer` | Extracts text from uploaded documents (incl. OCR) and screens for PII and jailbreaks. | input | llm | — |
+| `prompt_moderation` (**Moderation**) | Off-topic / disallowed content via keyword+regex and/or NeuralTrust topics. | input, output | all | — |
+| `url_analyzer` | Fetches URLs in the content (SSRF-guarded) and screens fetched text for **indirect prompt injection** and PII. | input | llm, mcp | — |
+| `doc_analyzer` | Extracts text from uploaded documents (incl. OCR) and screens for PII and **indirect prompt injection**. | input | llm | — |
+
+### Agent & MCP security
+
+| Detector (`slug`) | Detects | Sides | Protocols | Mutable |
+|---|---|---|---|---|
+| `indirect_prompt_injection` | Indirect prompt injection in tool-sourced content (e.g. `role=tool` / MCP tool results). | input, output | llm, mcp | — |
 
 ## How the catalog, detectors, and policies fit together
 
 - A **catalog detector** is a fixed capability — you can't change its code, only
   its settings.
 - A [**detector**](/trustguard/concepts/detectors) is a named, reusable instance
-  you create from a catalog detector plus its settings. It is **detection‑only**.
+  you create from a catalog detector plus its settings. It is **detection-only**.
 - A [**policy**](/trustguard/concepts/policies) references detectors in rules
   that set the action (**Monitor** / **Block** / **Transform**) and the
   evaluation phase (Input / Output).

--- a/trustguard/how-it-works.mdx
+++ b/trustguard/how-it-works.mdx
@@ -63,11 +63,11 @@ Each rule's action — **Monitor** (`report`), **Block**, or **Transform** — s
 the `outcome.action` on the findings it produces. A `block` rule also stops the
 remaining detector chain.
 
-File attachments (`payload.attachments`) are decoded once and shared with the
-detectors that consume them (`doc_analyzer`, `url_analyzer`). Remote attachment
-URLs are fetched server‑side under a strict SSRF guard (HTTPS only; loopback,
-private, link‑local, CGNAT, and cloud‑metadata addresses blocked) and are
-**never stored**.
+File attachments (`payload.attachments`) are decoded once and shared with
+detectors that consume them — today **`doc_analyzer`**. (`url_analyzer` finds
+URLs in the body/messages, not in attachments.) Remote attachment URLs are
+fetched server-side under a strict SSRF guard (HTTPS only; loopback, private,
+link-local, CGNAT, and cloud-metadata addresses blocked) and are **never stored**.
 
 ## 5. Reduce to a status
 

--- a/trustguard/overview.mdx
+++ b/trustguard/overview.mdx
@@ -22,7 +22,7 @@ inline anywhere — a failure or timeout can never take your application down.
 <CardGroup cols={2}>
   <Card title="Prompt & content security" icon="shield-check">
     Jailbreak and prompt-injection detection, topic moderation, toxicity scoring,
-    and document/URL analysis on both input and output.
+    plus document/URL screening for indirect prompt injection and PII (input).
   </Card>
   <Card title="Data loss prevention" icon="eye-off">
     Detect and mask 43 PII entities and secrets (API keys, tokens, JWTs) in flight,
@@ -30,7 +30,7 @@ inline anywhere — a failure or timeout can never take your application down.
   </Card>
   <Card title="URL & document analysis" icon="file-search">
     Fetch and screen URLs, and extract text from uploaded documents (including OCR)
-    for jailbreaks and PII before they reach the model.
+    for indirect prompt injection and PII before they reach the model.
   </Card>
   <Card title="Secrets in flight" icon="key">
     Catch leaked credentials and sensitive tokens in prompts and model outputs


### PR DESCRIPTION
## Summary
- New **Agent & MCP security** page + nav: `indirect_prompt_injection`.
- **URL / Document analyzers:** indirect prompt injection + PII (not jailbreak/malware); input-only; attachments only for `doc_analyzer`.
- **Moderation** (`prompt_moderation`): keyword/regex + NeuralTrust topics (no LLM-provider mode).
- **Evaluate API:** `code_injection` is a finding signal from hidden `code_sanitation`, not a catalog plugin.

## Test plan
- [ ] Detectors nav shows Agent & MCP security
- [ ] Content security URL/Doc sections match product copy
- [ ] evaluate.mdx signal.type note is clear


Made with [Cursor](https://cursor.com)