### PR TITLE
docs(trustlens): Shadow AI browser extension guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -352,6 +352,12 @@
                 "pages": [
                   "trustlens/integrations/endpoint-mdm"
                 ]
+              },
+              {
+                "group": "Shadow AI",
+                "pages": [
+                  "trustlens/integrations/shadow-extension"
+                ]
               }
             ]
           },
@@ -562,6 +568,10 @@
     {
       "source": "/trustguard/api/guard",
       "destination": "/trustguard/api/evaluate"
+    },
+    {
+      "source": "/extension",
+      "destination": "/trustlens/integrations/shadow-extension"
     },
     {
       "source": "/platform/telemetry-data",

--- a/trustlens/alerts.mdx
+++ b/trustlens/alerts.mdx
@@ -129,7 +129,7 @@ Posture alerts differ from runtime alerts in one important way: the SOC's first 
 1. **Validate.** Pivot to the SaaS resource in TrustLens. Confirm the provider, category (coding assistant carries elevated risk), and detection count.
 2. **Engage the user.** Reach out to the affected employees or the owning team. Assume good intent — most shadow-AI is productivity-driven.
 3. **Decide.** Either fast-track the tool through the approval process and add it to the AI tools catalogue, or block it via MDM and provide an approved alternative.
-4. **Configure enforcement.** Once approved, register the SaaS in the policy. If blocked, configure the [Runtime browser extension](/trustgate/overview) to enforce the block on managed browsers.
+4. **Configure enforcement.** Once approved, register the SaaS in the policy. If blocked, update Shadow AI policy and redeploy the [browser extension](/trustlens/integrations/shadow-extension) config to managed browsers.
 
 ### 5. Deprecated model still running in production
 

--- a/trustlens/integrations/shadow-extension.mdx
+++ b/trustlens/integrations/shadow-extension.mdx
@@ -1,0 +1,95 @@
+---
+title: "Shadow AI browser extension"
+description: "Deploy the Discover by NeuralTrust Chromium extension via Google Admin or Microsoft Intune to inventory AI SaaS usage in TrustLens — metadata only, no prompt or response content."
+---
+
+The **Shadow AI** integration (`shadow_extension`) deploys the **Discover by NeuralTrust**
+Chromium extension to managed browsers. It reports which AI SaaS domains users visit
+(ChatGPT, Claude.ai, Gemini, Copilot, Perplexity, …) into the TrustLens **SaaS** inventory
+and Shadow AI controls — **metadata only**. No prompts, responses, or page content leave
+the browser for this discovery path.
+
+This is separate from the TrustGuard [browser collector](/trustguard/integrations/browser),
+which inspects traffic with `/v1/evaluate` for runtime DLP / jailbreak policies.
+
+<Note>
+Endpoint Discovery ([MDM script](/trustlens/integrations/endpoint-mdm)) inventories installed
+AI software and extensions on the device. The Shadow extension observes **SaaS visits in
+the browser**. Use both for full Shadow AI coverage.
+</Note>
+
+## What it reports
+
+| Signal | Notes |
+|---|---|
+| AI SaaS app detected | Domain / app from the NeuralTrust catalog when a user visits a known AI site |
+| Browser / device / user context | As supplied by the managed browser / MDM identity |
+| Policy-driven allow / block hints | Extensions pull a versioned config bundle (ETag) with org Shadow AI policies |
+
+**Does not capture:** prompt or response text, cookies, or full browsing history.
+
+## Prerequisites
+
+- TrustLens access to create integrations
+- Admin rights in **Google Admin** (Chrome browser management) and/or **Microsoft Intune**
+- Managed Chromium browsers (Chrome and/or Edge)
+
+## Create the integration
+
+1. In NeuralTrust go to **TrustLens → Integrations**.
+2. Add **Chromium extension** / Shadow AI (`shadow_extension`).
+3. Save — no initial credentials are required. TrustLens generates an
+   **OrganizationConfig** JSON (token + endpoints) after creation.
+4. Open the integration detail → **Setup** and choose **Google Workspace** or
+   **Microsoft Intune** to reveal the config JSON (copy or download).
+
+Treat the token as a secret. Use **Renew Token** when rotating; redeploy the updated JSON
+in your MDM.
+
+## Deploy with Google Admin
+
+<Steps>
+  <Step title="Open Chrome Apps & extensions">
+    In **Google Admin Console** go to **Chrome Browser → Apps & extensions → Users & browsers**.
+  </Step>
+  <Step title="Add from Chrome Web Store">
+    Click **Add (+) → Add from Chrome Web Store**. Search for **Discover by NeuralTrust**
+    and select it.
+  </Step>
+  <Step title="Force install">
+    Set the installation policy to **Force install and pin to browser toolbar**.
+  </Step>
+  <Step title="Paste OrganizationConfig">
+    Open the extension side panel and paste the **OrganizationConfig** JSON from NeuralTrust
+    into **Extension policy**. Save and wait for propagation to managed devices.
+  </Step>
+</Steps>
+
+## Deploy with Microsoft Intune
+
+<Steps>
+  <Step title="Open managed extension policy">
+    In the **Microsoft Intune admin center**, open the Chrome or Edge managed extension
+    policy area for the target device group.
+  </Step>
+  <Step title="Apply Intune setup JSON">
+    Use the Intune setup JSON from NeuralTrust as the forced extension configuration payload.
+  </Step>
+  <Step title="Assign and sync">
+    Assign the policy to the users or devices that should receive the extension. Save and
+    wait for Intune to sync to managed browsers.
+  </Step>
+</Steps>
+
+## After deployment
+
+- SaaS visits appear under TrustLens **Inventory → SaaS**.
+- Shadow AI controls (e.g. unsanctioned usage, app approval) evaluate those resources —
+  see [Risk & findings](/trustlens/risk-and-findings#shadow-ai-saas).
+- For SOC playbooks on unsanctioned SaaS, see [Alerts](/trustlens/alerts).
+
+## Related
+
+- [Endpoint Discovery (MDM)](/trustlens/integrations/endpoint-mdm) — installed AI tools on devices
+- [Inventory](/trustlens/inventory) — SaaS category
+- [TrustGuard browser collector](/trustguard/integrations/browser) — runtime inspection (different product surface)

--- a/trustlens/inventory.mdx
+++ b/trustlens/inventory.mdx
@@ -52,7 +52,9 @@ The **Overview** page aggregates the inventory into Risk Distribution, Attack Su
 
 AI-enabled SaaS applications observed across the organization (e.g. ChatGPT, Claude.ai, Gemini, Copilot, Perplexity). Each record includes the application, the browser that reached it, the device, and the user.
 
-**Populated by:** The Runtime **browser extension** deployed to managed browsers. The extension reports the AI SaaS domains users visit back to TrustLens — no prompt or response content is captured, only the tenant-level visit. See [Runtime enforcement surfaces → Browser](/trustgate/overview).
+**Populated by:** The [Shadow AI browser extension](/trustlens/integrations/shadow-extension)
+(`shadow_extension`) deployed to managed Chromium browsers. It reports AI SaaS domains
+users visit — no prompt or response content is captured.
 
 ### IDEs
 

--- a/trustlens/risk-and-findings.mdx
+++ b/trustlens/risk-and-findings.mdx
@@ -146,7 +146,7 @@ Applies to AI-assisted IDEs, browser extensions, agent CLIs, browsers, and AI ru
 
 ### Shadow AI (SaaS)
 
-Applies to AI SaaS usage observed by the [Runtime browser extension](/trustgate/overview).
+Applies to AI SaaS usage observed by the [Shadow AI browser extension](/trustlens/integrations/shadow-extension).
 
 | ID | Name | Category | Weight |
 |---|---|---|---:|


### PR DESCRIPTION
## Summary
- New guide: TrustLens **Shadow AI** Chromium extension (`shadow_extension`) via Google Admin or Intune.
- Clarifies discovery (metadata-only SaaS visits) vs TrustGuard browser collector and Endpoint MDM.
- Fixes inventory / risk / alerts links that pointed at TrustGate overview.
- Redirect: `/extension` → `/trustlens/integrations/shadow-extension`.

## Test plan
- [ ] Nav: TrustLens → Integrations → Shadow AI
- [ ] `/extension` redirects to the new page
- [ ] Inventory SaaS “Populated by” links to the guide


Made with [Cursor](https://cursor.com)