### PR TITLE
docs(trustgate): document proxy API key auth headers

### DIFF
--- a/trustgate/api/openapi.json
+++ b/trustgate/api/openapi.json
@@ -3942,7 +3942,7 @@
     },
     "/{consumer_slug}/v1/chat/completions": {
       "post": {
-        "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses).",
+        "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or Authorization: Bearer ag_\u2026.",
         "tags": [
           "proxy"
         ],
@@ -3966,7 +3966,15 @@
             }
           },
           {
-            "description": "Bearer token for OAuth2 or OIDC consumers",
+            "description": "API key for inline consumers (Anthropic-compatible clients)",
+            "name": "x-api-key",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Bearer ag_\u2026 for inline api-key auth, or Bearer JWT for OAuth2/OIDC consumers",
             "name": "Authorization",
             "in": "header",
             "schema": {

--- a/trustgate/api/overview.mdx
+++ b/trustgate/api/overview.mdx
@@ -41,6 +41,7 @@ through.
 This reference covers the **Admin** API. Runtime traffic goes to the **Proxy** plane
 (`:8081`) on the format-specific routes — `POST /{consumer_slug}/v1/chat/completions`,
 `/v1/messages`, `/v1/responses`, and the Gemini `/v1beta/models/{model}:generateContent` —
-authenticated with the consumer's `X-AG-API-Key` (or an OAuth2/OIDC token), not the admin
-JWT. See [Architecture](/trustgate/architecture) and the
+authenticated with the consumer's API key (`X-AG-API-Key`, `x-api-key`, or
+`Authorization: Bearer ag_…`) or an OAuth2/OIDC token, not the admin JWT. See
+[Auth](/trustgate/concepts/auth), [Architecture](/trustgate/architecture), and the
 [Quickstart](/trustgate/getting-started/quickstart).

--- a/trustgate/concepts/auth.mdx
+++ b/trustgate/concepts/auth.mdx
@@ -19,7 +19,7 @@ which is how TrustGate authenticates to the **upstream provider**.
 
 | `type` | How the client authenticates | Routing mode |
 |---|---|---|
-| **`api_key`** | `X-AG-API-Key: ag_…` header | inline |
+| **`api_key`** | `X-AG-API-Key`, `x-api-key`, or `Authorization: Bearer ag_…` | inline |
 | **`oauth2`** | `Authorization: Bearer <jwt>` (or opaque token + introspection) validated against an OAuth2 provider | inline or role_based |
 | **`oidc`** | `Authorization: Bearer <jwt>` from your IdP; claims select a [role](/trustgate/concepts/roles) | inline or role_based |
 | **`mtls`** | Client certificate (or a trusted `X-Forwarded-Client-Cert` header) | inline |
@@ -36,6 +36,17 @@ A `role_based` LLM consumer carries exactly one identity credential — `oauth2`
 API keys are prefixed **`ag_`**. The raw secret is returned **once**, at creation — store
 it then. TrustGate only persists a SHA-256 hash; at request time it hashes the inbound key
 and compares, so the secret is never recoverable from the gateway.
+
+On the **proxy** plane, send the key in any of these headers (first match wins):
+
+| Header | Example | Typical clients |
+|---|---|---|
+| `X-AG-API-Key` | `X-AG-API-Key: ag_…` | TrustGate snippets, custom apps |
+| `x-api-key` | `x-api-key: ag_…` | Anthropic-compatible SDKs |
+| `Authorization` | `Authorization: Bearer ag_…` | OpenAI-compatible clients that only set an API key (e.g. Cursor, Claude Desktop-style base URL + key) |
+
+`Authorization: Bearer` with a value that does **not** start with `ag_` is treated as an
+OAuth2/OIDC JWT, not an API key. Prefer `X-AG-API-Key` when you control both headers.
 
 ```bash
 # create → returns api_key (cleartext) once

--- a/trustgate/getting-started/quickstart.mdx
+++ b/trustgate/getting-started/quickstart.mdx
@@ -106,6 +106,13 @@ curl -X POST "<configured-llm-url>/<consumer-slug>/v1/chat/completions" \
   }'
 ```
 
+<Note>
+Clients that only support a base URL plus an API key (OpenAI- or Anthropic-compatible
+SDKs, Cursor, Claude Desktop-style setups) can send the same `ag_…` key as
+`Authorization: Bearer ag_…` or `x-api-key: ag_…` instead of `X-AG-API-Key`. See
+[Auth](/trustgate/concepts/auth#api-keys).
+</Note>
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/trustgate/overview.mdx
+++ b/trustgate/overview.mdx
@@ -58,7 +58,8 @@ then send traffic to the proxy. Six objects make up a gateway:
 
 ```text
 client ──▶ /{consumer_slug}/v1/chat/completions
-              │  X-AG-API-Key  or  Authorization: Bearer (OAuth2/OIDC)
+              │  API key: X-AG-API-Key | x-api-key | Authorization: Bearer ag_…
+              │  or OAuth2/OIDC: Authorization: Bearer <jwt>
               │  X-AG-Gateway-Slug (Private only; SaaS uses subdomain)
               ├─ resolve gateway + consumer + policies
               ├─ apply policies (rate limit, budget, cache, guardrails, …)


### PR DESCRIPTION
## Summary
- Document that TrustGate proxy accepts consumer API keys via `X-AG-API-Key`, `x-api-key`, or `Authorization: Bearer ag_…` (precedence: first header present).
- Update Auth, Overview, Admin API overview, Quickstart, and the embedded OpenAPI proxy route to match TrustGate PR #364.

## Test plan
- [ ] Preview with `mintlify dev` — Auth page shows the three headers and precedence note
- [ ] Quickstart Note links to Auth#api-keys
- [ ] Overview request-flow diagram mentions all API-key sources
- [ ] OpenAPI proxy chat-completions params include `x-api-key` and updated Authorization description


Made with [Cursor](https://cursor.com)