### PR TITLE
docs(platform): clarify manual role edits vs group-mapping sync

### DIFF
--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -241,6 +241,10 @@ After creating mappings:
 Users are assigned the role from the **first matching group mapping**. If a user belongs to multiple mapped groups, they receive the role from the highest-priority mapping (based on creation order).
 </Note>
 
+<Note>
+**Manual role edits and re-sync.** If you change a synced user's role by hand in **User & Roles**, that change persists until the next sync. Running **Sync Now** again re-applies the mapped role and overwrites a manual edit if it no longer matches the group mapping — sync is on-demand here, so this only happens when you trigger it.
+</Note>
+
 ### Role Mapping Table Reference
 
 | Column | Description |

--- a/platform/user-sync.mdx
+++ b/platform/user-sync.mdx
@@ -86,6 +86,10 @@ If no groups appear in the dropdown, verify that your app registration has `Grou
 | User removed from Azure group | **Not automatically removed** — use SCIM for auto-deprovisioning |
 | User in multiple mapped groups | Gets role from first matching mapping |
 
+<Note>
+A manual role change made in **User & Roles** stays in place until you run sync again. Because Manual Sync only runs when you click **Sync Now**, a manual edit is only overwritten by the mapped group role at that point — not automatically in between.
+</Note>
+
 ---
 
 ## Part 3: View Imported Users


### PR DESCRIPTION
## Summary
- Entra ID's "Role Mapping" (sso.mdx Part 4) and "Group Mapping" (user-sync.mdx) are the same underlying group→role table, just documented under two names — this was causing confusion about whether it's a one-off sync or continuous enforcement.
- Adds a short note in both pages clarifying that a manually edited role in **User & Roles** persists until the next sync, and is only overwritten when **Sync Now** is run again (Manual Sync is on-demand, not automatic).
- No changes to Generic OIDC's `generic-oidc-sso.mdx` — that page already documents its own (different, claim-based, per-login) role mapping behavior and the "Sync Team Role from IdP on Login" toggle in detail.

## Test plan
- [ ] Docs preview renders both `<Note>` blocks correctly (Mintlify build)
- [ ] Wording double-checked against actual product behavior (role overwritten only on next manual/SCIM sync, not live)

Made with [Cursor](https://cursor.com)