### PR TITLE
docs: document auto model routing and pinning behaviour

### DIFF
--- a/trustgate/routing/fallback.mdx
+++ b/trustgate/routing/fallback.mdx
@@ -7,6 +7,11 @@ description: "Retry across registries when an upstream fails — configurable tr
 an error to the client. It is configured per [consumer](/trustgate/concepts/consumers)
 (inline routing) and engages when a forward fails with a matching trigger.
 
+Requests that name a concrete model (`gpt-4o-mini` or `@openai/gpt-4o`) are pinned to one
+registry and are **not** retried elsewhere, even with fallback enabled — use `model: "auto"`
+or a pool reference to get failover. See
+[Model resolution](/trustgate/routing/model-resolution#pinning-which-forms-load-balance).
+
 ```json
 "fallback": {
   "enabled": true,

--- a/trustgate/routing/load-balancing.mdx
+++ b/trustgate/routing/load-balancing.mdx
@@ -8,6 +8,11 @@ When a [consumer](/trustgate/concepts/consumers) can reach more than one
 request. The simplest setup just lists `registry_ids`; for explicit control, define a
 named pool with `lb_config`.
 
+The load balancer only runs when the request leaves the choice open — `model: "auto"` or
+`pool:<alias>`. A request naming a concrete model (`gpt-4o-mini` or `@openai/gpt-4o`) is
+pinned to the first registry that allows it and bypasses the balancer entirely; see
+[Model resolution](/trustgate/routing/model-resolution#pinning-which-forms-load-balance).
+
 ## Strategies
 
 | Algorithm | How it picks |

--- a/trustgate/routing/model-resolution.mdx
+++ b/trustgate/routing/model-resolution.mdx
@@ -1,18 +1,69 @@
 ---
 title: "Model resolution"
-description: "How the model field in a request selects a registry — short pass-through, provider-qualified, or pool reference — and how model policies constrain it."
+description: "How the model field in a request selects a registry — auto, short pass-through, provider-qualified, or pool reference — and how model policies constrain it."
 ---
 
 A client never names a provider URL — it names a **model**, and TrustGate resolves which
-[registry](/trustgate/concepts/registries) to use. The `model` field accepts three forms.
+[registry](/trustgate/concepts/registries) to use. The `model` field accepts four forms.
 
 ## Model reference syntax
 
 | Form | Example | Meaning |
 |---|---|---|
-| **Short** (pass-through) | `gpt-4o-mini` | Sent as-is to the selected registry. The [load balancer](/trustgate/routing/load-balancing) picks among the consumer's registries. |
-| **Provider-qualified** | `@openai/gpt-4o` | Restrict routing to registries of provider `openai`, then pick. |
-| **Pool reference** | `pool:my-pool` | Route via the consumer's enabled load-balancing pool whose `pool_alias` matches (case-insensitive), across the pool's members. Inline routing only. |
+| **Auto** | `auto` | Let TrustGate choose. The [load balancer](/trustgate/routing/load-balancing) picks among the registries that have a default model, and each registry receives its own default. |
+| **Short** (pass-through) | `gpt-4o-mini` | Pins the **first** registry whose policy allows that model, and sends the name as-is. |
+| **Provider-qualified** | `@openai/gpt-4o` | Pins the **first** registry of provider `openai` whose policy allows that model. |
+| **Pool reference** | `pool:my-pool` | Route via the consumer's enabled load-balancing pool whose `pool_alias` matches, across the pool's members. Inline routing only. |
+
+`auto` and the `pool:` prefix are case-insensitive; the provider in a qualified reference is
+lowercased and must consist of `a-z`, `0-9`, `_`, or `-`.
+
+A bare `provider/model` **without** the `@` (for example `anthropic/claude-sonnet-4`) is not
+routing syntax. It is treated as a short reference and forwarded verbatim as a native model
+identifier — useful for providers like OpenRouter whose model ids contain a slash.
+
+> Gemini-format clients carry the model in the URL path rather than the body; TrustGate reads
+> it from the path and applies the same rules. The `modelId` field is not supported — use
+> `model`.
+
+## Choosing a form
+
+| You want | Use |
+|---|---|
+| One consumer, one obvious model per registry, balanced traffic | `auto` |
+| A specific model, wherever it lives | `gpt-4o-mini` |
+| A specific model on a specific provider (multi-registry consumers) | `@openai/gpt-4o` |
+| A named group of registries with its own algorithm | `pool:my-pool` |
+
+## Pinning: which forms load-balance
+
+This is the part that most often surprises people:
+
+| Form | Load balanced | Falls back on failure |
+|---|---|---|
+| `auto` | Yes | Yes |
+| `pool:<alias>` | Yes (pool algorithm) | Yes |
+| `gpt-4o-mini` | **No** — pinned to the first matching registry | **No** |
+| `@openai/gpt-4o` | **No** — pinned to the first matching registry | **No** |
+
+Naming a concrete model is an explicit instruction, so TrustGate honours it literally: the
+request is pinned to that registry and is **not** retried elsewhere, even when
+[fallback](/trustgate/routing/fallback) is enabled. If you want resilience, use `auto` or a
+pool.
+
+"First matching registry" follows the consumer's `registry_ids` order, then its fallback
+backends. For `role_based` consumers it follows the order of the matched roles and each
+role's `registry_ids`.
+
+## Auto
+
+With `model: "auto"`, TrustGate keeps only the registries that have a `default` model in
+their policy, removes the `model` field from the request body, and lets the load balancer
+pick. The selected registry then applies its own default — so the same request can run on
+`gpt-4o-mini` on one registry and `claude-sonnet-4` on another.
+
+If no registry reachable by the consumer defines a default model, the request is rejected
+with `auto routing requires at least one registry with a default model`.
 
 ## Model policies
 
@@ -30,16 +81,39 @@ constrain which models are reachable per registry with `model_policies`:
 
 - **`allowed`** — the allow-list of models for that registry. Empty/omitted means all
   models are permitted.
-- **`default`** — used when the request names no model; it must be a member of `allowed`.
+- **`default`** — used by `auto` and when the request names no model; it must be a member of
+  `allowed`.
 
 A request for a model outside the allow-list is rejected before it reaches the provider.
 
+Inside a pool, a member's `models` list overrides the registry's `allowed` list. The member's
+effective default is the policy `default` when that model is one of the member's `models`,
+otherwise the first entry of `models`.
+
 ## Resolution order
 
-1. Parse the `model` reference (short / qualified / pool).
-2. Narrow the candidate registries (the consumer's `registry_ids` or the pool members,
-   filtered by provider for qualified refs).
-3. Apply `model_policies` — reject disallowed models; fill in the `default` when none was
-   given.
-4. Hand the candidates to the [load balancer](/trustgate/routing/load-balancing) to pick
-   one, with [fallback](/trustgate/routing/fallback) on failure.
+1. Parse the `model` reference (auto / short / qualified / pool).
+2. Build the candidate registries — the consumer's `registry_ids` plus fallback backends, the
+   pool's members, or the matched roles' `registry_ids`.
+3. Narrow them: by default model for `auto`, by provider and allow-list for qualified refs, by
+   allow-list for short refs.
+4. Pin the first candidate (short, qualified) or hand the candidates to the
+   [load balancer](/trustgate/routing/load-balancing) (`auto`, pool), with
+   [fallback](/trustgate/routing/fallback) on failure where the form allows it.
+
+## Rejections
+
+TrustGate rejects these **before** calling any provider:
+
+| Message | Cause |
+|---|---|
+| `model "x" is not allowed for this consumer` | Short reference outside every reachable allow-list. |
+| `model "x" is not allowed for provider "p"` | The provider is reachable, but the model is not in its allow-list. |
+| `provider "p" is not available for this consumer` | No registry of that provider is reachable. |
+| `auto routing requires at least one registry with a default model` | `auto` with no default configured anywhere. |
+| `pool "p" is not configured for this consumer` | Unknown or disabled `pool_alias` — also returned for `role_based` consumers, which cannot use pools. |
+| `"@x" must use the @provider/model syntax` | Malformed qualified reference (missing `/`, empty provider, or empty model). |
+
+Anything else comes from the upstream. If the model name is allowed by policy but does not
+exist at the provider, TrustGate forwards the provider's own error response verbatim — it does
+not rewrite provider errors.


### PR DESCRIPTION
## Summary

The Model resolution page was both incomplete and wrong about how the `model` field routes:

- **`auto` was undocumented.** It is a supported reference form (`ParseModelRef` in `pkg/domain/routing/intent.go`): it keeps only the registries that define a default model, strips `model` from the body, and lets the load balancer pick so each registry applies its own default.
- **Short and provider-qualified references were described as load balanced. They are not.** `routeBackend` pins `candidates.Candidates()[0]` and sets `pinned: true`, which also skips fallback (`TestForward_QualifiedPinSkipsFallback`). Only `auto` and `pool:<alias>` go through the balancer.

This came out of a support thread where a `model_not_found` from the provider was mistaken for a TrustGate error, so the page now also states which rejections are ours and which are passthrough.

## Changes

- `trustgate/routing/model-resolution.mdx`
  - `auto` added as the fourth reference form, with its own section.
  - New "Pinning: which forms load-balance" section correcting the load-balancing claim, plus how "first matching registry" is ordered.
  - Bare `provider/model` (no `@`) documented as a pass-through native identifier.
  - "Choosing a form" quick table, and a "Rejections" table of the errors TrustGate returns before calling a provider — ending with an explicit note that provider errors are forwarded verbatim.
  - Pool member `models` override and effective default documented.
  - Gemini path-based model and unsupported `modelId` noted.
- `trustgate/routing/load-balancing.mdx` and `trustgate/routing/fallback.mdx` — short notes so they no longer contradict the corrected pinning behaviour.

## Test plan

- [ ] `mint dev` renders the three pages without MDX errors
- [ ] The `#pinning-which-forms-load-balance` anchor resolves from both load-balancing and fallback

Made with [Cursor](https://cursor.com)