### PR TITLE
docs: simplify TrustGate load balancing docs (drop named pools)

### DIFF
--- a/trustgate/architecture.mdx
+++ b/trustgate/architecture.mdx
@@ -32,7 +32,7 @@ the **data plane** (your traffic flows through them).
    **consumer** (from the URL `slug`), and the applicable **policies**.
 3. The applicable **policies** run at their **stages** — rate limit, LLM budget,
    request size, semantic cache, guardrails — sequentially or in parallel.
-4. The **load balancer** picks a healthy registry from the consumer's pool (round-robin,
+4. The **load balancer** picks a healthy registry from the consumer's registries (round-robin,
    weighted, least-connections, random, or semantic), with fallback.
 5. The request is forwarded to the selected **provider adapter** (OpenAI, Anthropic,
    Bedrock, …), streaming when the client asked for it.

--- a/trustgate/concepts/consumers.mdx
+++ b/trustgate/concepts/consumers.mdx
@@ -36,7 +36,7 @@ Inline consumers own their routing directly:
 |---|---|
 | `registry_ids` | The [registries](/trustgate/concepts/registries) this consumer may use. |
 | `registry_weights` | Per-registry weight (`1..100`) for weighted load balancing. |
-| `lb_config` | Named load-balancing pool (overrides simple `registry_ids`) — see [Load balancing](/trustgate/routing/load-balancing). |
+| `lb_config` | Load-balancing algorithm and members — see [Load balancing](/trustgate/routing/load-balancing). |
 | `fallback` | Ordered retry chain across registries — see [Fallback](/trustgate/routing/fallback). |
 | `model_policies` | Per-registry allow-list and default model — see [Model resolution](/trustgate/routing/model-resolution). |
 

--- a/trustgate/routing/fallback.mdx
+++ b/trustgate/routing/fallback.mdx
@@ -9,7 +9,7 @@ an error to the client. It is configured per [consumer](/trustgate/concepts/cons
 
 Requests that name a concrete model (`gpt-4o-mini` or `@openai/gpt-4o`) are pinned to one
 registry and are **not** retried elsewhere, even with fallback enabled — use `model: "auto"`
-or a pool reference to get failover. See
+to get failover. See
 [Model resolution](/trustgate/routing/model-resolution#pinning-which-forms-load-balance).
 
 ```json

--- a/trustgate/routing/load-balancing.mdx
+++ b/trustgate/routing/load-balancing.mdx
@@ -5,12 +5,12 @@ description: "Distribute traffic across a consumer's registries with round-robin
 
 When a [consumer](/trustgate/concepts/consumers) can reach more than one
 [registry](/trustgate/concepts/registries), the load balancer picks which one serves each
-request. The simplest setup just lists `registry_ids`; for explicit control, define a
-named pool with `lb_config`.
+request. List the registries on the consumer with `registry_ids`, then choose how traffic is
+distributed with `lb_config`.
 
-The load balancer only runs when the request leaves the choice open — `model: "auto"` or
-`pool:<alias>`. A request naming a concrete model (`gpt-4o-mini` or `@openai/gpt-4o`) is
-pinned to the first registry that allows it and bypasses the balancer entirely; see
+The load balancer only runs when the request leaves the choice open — `model: "auto"`. A
+request naming a concrete model (`gpt-4o-mini` or `@openai/gpt-4o`) is pinned to the first
+registry that allows it and bypasses the balancer entirely; see
 [Model resolution](/trustgate/routing/model-resolution#pinning-which-forms-load-balance).
 
 ## Strategies
@@ -35,15 +35,14 @@ POST /v1/gateways/{gateway_id}/consumers/{id}/registries/{registry_id}
 
 A registry at weight 70 receives roughly 70% of the share of one at weight 30.
 
-## Named pools (`lb_config`)
+## Configuration (`lb_config`)
 
-For more than a flat list, define a pool:
+Enable the balancer and pick its algorithm on the consumer:
 
 ```json
 "lb_config": {
   "enabled": true,
   "algorithm": "weighted-round-robin",
-  "pool_alias": "prod-pool",
   "members": [
     { "registry_id": "<openai>",    "models": ["gpt-4o"] },
     { "registry_id": "<anthropic>", "models": ["claude-3-5-sonnet"] }
@@ -51,9 +50,9 @@ For more than a flat list, define a pool:
 }
 ```
 
-- `pool_alias` is referenced from a request via the `pool:<alias>` model reference (see
-  [Model resolution](/trustgate/routing/model-resolution)).
-- `members` scope which models each registry serves within the pool.
+- `members` must already be attached to the consumer, and each one needs an entry in
+  `model_policies`.
+- A member's `models` scopes which models that registry serves.
 - The `semantic` algorithm additionally needs an `embedding_config`.
 
 ## Health checks

--- a/trustgate/routing/model-resolution.mdx
+++ b/trustgate/routing/model-resolution.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Model resolution"
-description: "How the model field in a request selects a registry — auto, short pass-through, provider-qualified, or pool reference — and how model policies constrain it."
+description: "How the model field in a request selects a registry — auto, short pass-through, or provider-qualified — and how model policies constrain it."
 ---
 
 A client never names a provider URL — it names a **model**, and TrustGate resolves which
-[registry](/trustgate/concepts/registries) to use. The `model` field accepts four forms.
+[registry](/trustgate/concepts/registries) to use. The `model` field accepts three forms.
 
 ## Model reference syntax
 
@@ -13,10 +13,9 @@ A client never names a provider URL — it names a **model**, and TrustGate reso
 | **Auto** | `auto` | Let TrustGate choose. The [load balancer](/trustgate/routing/load-balancing) picks among the registries that have a default model, and each registry receives its own default. |
 | **Short** (pass-through) | `gpt-4o-mini` | Pins the **first** registry whose policy allows that model, and sends the name as-is. |
 | **Provider-qualified** | `@openai/gpt-4o` | Pins the **first** registry of provider `openai` whose policy allows that model. |
-| **Pool reference** | `pool:my-pool` | Route via the consumer's enabled load-balancing pool whose `pool_alias` matches, across the pool's members. Inline routing only. |
 
-`auto` and the `pool:` prefix are case-insensitive; the provider in a qualified reference is
-lowercased and must consist of `a-z`, `0-9`, `_`, or `-`.
+`auto` is case-insensitive; the provider in a qualified reference is lowercased and must
+consist of `a-z`, `0-9`, `_`, or `-`.
 
 A bare `provider/model` **without** the `@` (for example `anthropic/claude-sonnet-4`) is not
 routing syntax. It is treated as a short reference and forwarded verbatim as a native model
@@ -33,7 +32,6 @@ identifier — useful for providers like OpenRouter whose model ids contain a sl
 | One consumer, one obvious model per registry, balanced traffic | `auto` |
 | A specific model, wherever it lives | `gpt-4o-mini` |
 | A specific model on a specific provider (multi-registry consumers) | `@openai/gpt-4o` |
-| A named group of registries with its own algorithm | `pool:my-pool` |
 
 ## Pinning: which forms load-balance
 
@@ -42,14 +40,12 @@ This is the part that most often surprises people:
 | Form | Load balanced | Falls back on failure |
 |---|---|---|
 | `auto` | Yes | Yes |
-| `pool:<alias>` | Yes (pool algorithm) | Yes |
 | `gpt-4o-mini` | **No** — pinned to the first matching registry | **No** |
 | `@openai/gpt-4o` | **No** — pinned to the first matching registry | **No** |
 
 Naming a concrete model is an explicit instruction, so TrustGate honours it literally: the
 request is pinned to that registry and is **not** retried elsewhere, even when
-[fallback](/trustgate/routing/fallback) is enabled. If you want resilience, use `auto` or a
-pool.
+[fallback](/trustgate/routing/fallback) is enabled. If you want resilience, use `auto`.
 
 "First matching registry" follows the consumer's `registry_ids` order, then its fallback
 backends. For `role_based` consumers it follows the order of the matched roles and each
@@ -86,19 +82,20 @@ constrain which models are reachable per registry with `model_policies`:
 
 A request for a model outside the allow-list is rejected before it reaches the provider.
 
-Inside a pool, a member's `models` list overrides the registry's `allowed` list. The member's
-effective default is the policy `default` when that model is one of the member's `models`,
-otherwise the first entry of `models`.
+When [load balancing](/trustgate/routing/load-balancing) is enabled, a member's `models` list
+overrides the registry's `allowed` list. The member's effective default is the policy
+`default` when that model is one of the member's `models`, otherwise the first entry of
+`models`.
 
 ## Resolution order
 
-1. Parse the `model` reference (auto / short / qualified / pool).
-2. Build the candidate registries — the consumer's `registry_ids` plus fallback backends, the
-   pool's members, or the matched roles' `registry_ids`.
+1. Parse the `model` reference (auto / short / qualified).
+2. Build the candidate registries — the consumer's `registry_ids` plus fallback backends, or
+   the matched roles' `registry_ids`.
 3. Narrow them: by default model for `auto`, by provider and allow-list for qualified refs, by
    allow-list for short refs.
 4. Pin the first candidate (short, qualified) or hand the candidates to the
-   [load balancer](/trustgate/routing/load-balancing) (`auto`, pool), with
+   [load balancer](/trustgate/routing/load-balancing) (`auto`), with
    [fallback](/trustgate/routing/fallback) on failure where the form allows it.
 
 ## Rejections
@@ -111,7 +108,6 @@ TrustGate rejects these **before** calling any provider:
 | `model "x" is not allowed for provider "p"` | The provider is reachable, but the model is not in its allow-list. |
 | `provider "p" is not available for this consumer` | No registry of that provider is reachable. |
 | `auto routing requires at least one registry with a default model` | `auto` with no default configured anywhere. |
-| `pool "p" is not configured for this consumer` | Unknown or disabled `pool_alias` — also returned for `role_based` consumers, which cannot use pools. |
 | `"@x" must use the @provider/model syntax` | Malformed qualified reference (missing `/`, empty provider, or empty model). |
 
 Anything else comes from the upstream. If the model name is allowed by policy but does not


### PR DESCRIPTION
## Summary

Named load-balancing pools (`pool_alias` + `pool:<alias>` model reference) cannot be created from the app, so the docs described a routing form readers had no way to use. This removes them and leaves the simpler story that matches the product.

- **Load balancing** — "Named pools" becomes "Configuration (`lb_config`)": enable the balancer, pick the algorithm, list members. No `pool_alias`.
- **Model resolution** — the `model` field now documents **three** forms (`auto`, short pass-through, `@provider/model`) instead of four; removed the pool row from the syntax, "choosing a form", and pinning tables, plus the `pool "p" is not configured for this consumer` rejection.
- **Fallback / Consumers / Architecture** — dropped the leftover pool references so `auto` reads as the single way to get load balancing and failover.

No product behaviour changes: `pool:<alias>` still works over the Admin API and remains in the generated `openapi.json`. This is a documentation-scope change only.

## Test plan

- [ ] `mintlify dev` renders the four routing pages without broken links
- [ ] No remaining references to `pool_alias` or `pool:<alias>` outside the generated `trustgate/api/openapi.json`

Made with [Cursor](https://cursor.com)