### PR TITLE
docs: describe load balancing over (registry, model) routes

### DIFF
--- a/trustgate/api/openapi.json
+++ b/trustgate/api/openapi.json
@@ -34,7 +34,7 @@
     },
     "/healthz": {
       "get": {
-        "description": "Reports whether the process is alive.",
+        "description": "Reports whether the process is alive. Canonical path is /healthz; /health is an alias for load-balancer defaults.",
         "tags": [
           "system"
         ],
@@ -76,6 +76,19 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -94,8 +107,8 @@
         "summary": "List gateways",
         "parameters": [
           {
-            "description": "Filter by name (substring match)",
-            "name": "name",
+            "description": "Filter by slug (substring match)",
+            "name": "slug",
             "in": "query",
             "schema": {
               "type": "string"
@@ -134,7 +147,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -144,7 +157,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -157,7 +170,7 @@
             "BearerAuth": []
           }
         ],
-        "description": "Creates a new gateway.",
+        "description": "Creates a new gateway. Ownership tenant_id is required (JWT claim, or body for platform admins). The slug is optional: when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label and unique. Platform JWT create requires stamped entitlements (tier + caps); tenant JWTs must omit entitlements (422 if sent). With RATE_LIMIT_ENABLED, create returns 409 when the tenant is already at MaxInstances for the effective tier.",
         "tags": [
           "gateways"
         ],
@@ -189,7 +202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -199,7 +212,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -209,7 +222,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -241,8 +264,48 @@
             }
           },
           {
-            "description": "Filter by name (substring match)",
+            "description": "Substring match on name (alias: name)",
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Alias of search",
             "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by auth type (api_key, oauth2, oidc, mtls)",
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by enabled flag",
+            "name": "enabled",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort field (name, created_at, updated_at, type)",
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order (asc, desc)",
+            "name": "order",
             "in": "query",
             "schema": {
               "type": "string"
@@ -281,7 +344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -291,7 +354,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -348,7 +421,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -358,7 +431,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -368,7 +441,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -378,7 +451,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -436,7 +509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -446,7 +519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -456,7 +529,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -523,7 +596,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -533,7 +606,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -543,7 +616,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -553,7 +626,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -602,7 +675,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -612,7 +685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -622,7 +695,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -632,7 +705,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -664,8 +737,57 @@
             }
           },
           {
-            "description": "Filter by name (substring match)",
+            "description": "Substring match on name or slug (alias: name)",
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Alias of search",
             "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by consumer type (LLM, MCP, A2A)",
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by active flag",
+            "name": "active",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter consumers linked to this auth id",
+            "name": "auth_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "description": "Sort field (name, created_at, updated_at, type)",
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order (asc, desc)",
+            "name": "order",
             "in": "query",
             "schema": {
               "type": "string"
@@ -704,7 +826,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -714,7 +836,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -771,7 +903,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -781,7 +913,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -791,7 +923,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -801,7 +933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -859,7 +991,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -869,7 +1001,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -879,7 +1011,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -892,7 +1024,7 @@
             "BearerAuth": []
           }
         ],
-        "description": "Updates an existing consumer.",
+        "description": "Updates an existing consumer. The optional `registries` field replaces the whole registry association set, so switching a role_based consumer to inline routing and attaching its registries happens in a single atomic request.",
         "tags": [
           "consumers"
         ],
@@ -946,7 +1078,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -956,7 +1088,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -966,7 +1098,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -976,7 +1108,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1025,7 +1157,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1035,7 +1167,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1045,7 +1177,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1055,7 +1187,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1116,7 +1248,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1126,7 +1258,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1136,7 +1268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1195,7 +1327,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1205,7 +1337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1215,7 +1347,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1276,7 +1408,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1286,7 +1418,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1296,7 +1428,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1355,7 +1487,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1365,7 +1497,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1375,7 +1507,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1446,7 +1578,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1456,7 +1588,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1466,7 +1598,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1525,7 +1657,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1535,7 +1667,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1545,7 +1677,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1606,7 +1738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1616,7 +1748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1626,7 +1758,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1636,7 +1768,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1695,7 +1827,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1705,7 +1837,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1715,7 +1847,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1747,8 +1879,72 @@
             }
           },
           {
-            "description": "Filter by name (substring match)",
+            "description": "Substring match on name or slug (alias: name)",
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Alias of search",
             "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by enabled flag",
+            "name": "enabled",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter by global flag",
+            "name": "global",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter by mode (enforce, throttle, observe)",
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Catalog category (group type); comma-separated multi",
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Plugin slug (FE type filter); comma-separated multi",
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort field (name, created_at, updated_at, priority)",
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order (asc, desc)",
+            "name": "order",
             "in": "query",
             "schema": {
               "type": "string"
@@ -1787,7 +1983,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1797,7 +1993,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1854,7 +2060,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1864,7 +2070,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1874,7 +2080,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1884,7 +2090,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1942,7 +2148,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1952,7 +2158,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -1962,7 +2168,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2029,7 +2235,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2039,7 +2245,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2049,7 +2255,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2059,7 +2265,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2108,7 +2314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2118,7 +2324,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2128,7 +2334,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2138,7 +2344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2196,7 +2402,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2206,7 +2412,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2216,7 +2422,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2226,7 +2432,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2284,7 +2490,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2294,7 +2500,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2304,7 +2510,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2360,7 +2566,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2370,7 +2576,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2380,7 +2586,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2452,7 +2658,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2462,7 +2668,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2519,7 +2725,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2529,7 +2735,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2539,7 +2745,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2549,7 +2755,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2608,7 +2814,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2618,7 +2824,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2628,7 +2834,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2638,7 +2844,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2696,7 +2902,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2706,7 +2912,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2716,7 +2922,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2783,7 +2989,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2793,7 +2999,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2803,7 +3009,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2813,7 +3019,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2862,7 +3068,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2872,7 +3078,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2882,7 +3088,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2892,7 +3098,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2924,8 +3130,32 @@
             }
           },
           {
-            "description": "Filter by name (substring match)",
+            "description": "Substring match on name (alias: name)",
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Alias of search",
             "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort field (name, created_at, updated_at)",
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort order (asc, desc)",
+            "name": "order",
             "in": "query",
             "schema": {
               "type": "string"
@@ -2964,7 +3194,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -2974,7 +3204,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3031,7 +3271,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3041,7 +3281,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3051,7 +3291,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3061,7 +3301,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3119,7 +3359,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3129,7 +3369,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3139,7 +3379,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3206,7 +3446,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3216,7 +3456,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3226,7 +3466,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3236,7 +3476,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3285,7 +3525,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3295,7 +3535,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3305,7 +3545,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3315,7 +3555,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3376,7 +3616,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3386,7 +3626,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3396,7 +3636,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3455,7 +3695,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3465,7 +3705,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3475,7 +3715,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3485,7 +3725,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3533,7 +3773,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3543,7 +3783,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3553,7 +3793,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3566,7 +3806,7 @@
             "BearerAuth": []
           }
         ],
-        "description": "Updates an existing gateway.",
+        "description": "Updates an existing gateway. Tenant JWTs may not send entitlements (422). Platform tier downgrades that would leave the tenant over the new MaxInstances return 409 — delete excess gateways first.",
         "tags": [
           "gateways"
         ],
@@ -3610,7 +3850,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3620,7 +3860,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3630,7 +3870,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3640,7 +3880,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3679,7 +3929,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3689,7 +3939,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3699,7 +3949,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3735,7 +3985,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3750,7 +4000,7 @@
             "BearerAuth": []
           }
         ],
-        "description": "Returns the catalog of supported models, optionally filtered by provider.",
+        "description": "Returns the catalog of supported models, optionally filtered by provider. When gateway_id and registry_id are supplied for an AWS Bedrock registry, the list is narrowed to the models those credentials can invoke serverless (on-demand base models and system-defined inference profiles), excluding Bedrock Marketplace, Provisioned Throughput and custom models. Malformed ids and unreachable AWS endpoints are ignored and yield the full catalog.",
         "tags": [
           "catalog"
         ],
@@ -3762,6 +4012,24 @@
             "in": "query",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Gateway of the registry to scope availability to",
+            "name": "gateway_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "description": "Registry whose credentials decide model availability",
+            "name": "registry_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -3787,7 +4055,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3834,7 +4102,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3844,7 +4112,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3854,7 +4122,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3890,7 +4158,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3932,7 +4200,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -3942,7 +4210,7 @@
     },
     "/{consumer_slug}/v1/chat/completions": {
       "post": {
-        "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or Authorization: Bearer ag_\u2026.",
+        "description": "Forwards an OpenAI Chat Completions request to the selected provider. Proxy plane route: /{consumer_slug}/v1/chat/completions. Other fixed routes include /v1/messages (Anthropic) and /v1/responses (OpenAI Responses). Inline consumers may authenticate with an api key via X-AG-API-Key, x-api-key, or Authorization: Bearer ag_….",
         "tags": [
           "proxy"
         ],
@@ -3974,7 +4242,7 @@
             }
           },
           {
-            "description": "Bearer ag_\u2026 for inline api-key auth, or Bearer JWT for OAuth2/OIDC consumers",
+            "description": "Bearer ag_… for inline api-key auth, or Bearer JWT for OAuth2/OIDC consumers",
             "name": "Authorization",
             "in": "header",
             "schema": {
@@ -4018,7 +4286,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -4028,7 +4296,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -4038,7 +4306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -4048,7 +4316,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -4058,7 +4326,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody"
+                  "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody"
                 }
               }
             }
@@ -4154,6 +4422,9 @@
               "type": "string"
             }
           },
+          "authorize_url": {
+            "type": "string"
+          },
           "client_id": {
             "type": "string"
           },
@@ -4179,6 +4450,9 @@
             "type": "boolean"
           },
           "subject_claim": {
+            "type": "string"
+          },
+          "token_url": {
             "type": "string"
           },
           "userinfo_url": {
@@ -4261,6 +4535,13 @@
             "type": "string"
           },
           "id": {
+            "type": "string"
+          },
+          "key_prefix": {
+            "description": "Non-secret recognition hint for api_key auths (e.g. \"ag_3dlXk\" + \"Rv8Q\").",
+            "type": "string"
+          },
+          "key_suffix": {
             "type": "string"
           },
           "name": {
@@ -4349,6 +4630,9 @@
               "type": "string"
             }
           },
+          "authorize_url": {
+            "type": "string"
+          },
           "client_id": {
             "type": "string"
           },
@@ -4374,6 +4658,9 @@
             "type": "boolean"
           },
           "subject_claim": {
+            "type": "string"
+          },
+          "token_url": {
             "type": "string"
           },
           "userinfo_url": {
@@ -4441,16 +4728,33 @@
           "id": {
             "type": "string"
           },
+          "input_modalities": {
+            "description": "InputModalities and OutputModalities list the accepted/produced content\ntypes (e.g. \"text\", \"image\", \"audio\").",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "input_price": {
             "type": "string"
           },
           "max_output": {
             "type": "integer"
           },
+          "output_modalities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "output_price": {
             "type": "string"
           },
           "provider_id": {
+            "type": "string"
+          },
+          "release_date": {
+            "description": "ReleaseDate is the provider release date (\"YYYY-MM-DD\"); empty when unknown.\nModels are returned most-recent release first.",
             "type": "string"
           },
           "slug": {
@@ -4494,6 +4798,40 @@
           },
           "wire_format": {
             "type": "string"
+          }
+        }
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_configsync_response.ConnectionResponse": {
+        "type": "object",
+        "properties": {
+          "applied_version": {
+            "type": "string"
+          },
+          "first_seen": {
+            "type": "string"
+          },
+          "instance_id": {
+            "type": "string"
+          },
+          "last_seen": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        }
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_configsync_response.ListConnectionsResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_configsync_response.ConnectionResponse"
+            }
           }
         }
       },
@@ -4657,12 +4995,19 @@
           },
           "pool_alias": {
             "type": "string"
+          },
+          "smart_routing": {
+            "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest"
           }
         }
       },
       "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.LBPoolMemberRequest": {
         "type": "object",
         "properties": {
+          "model": {
+            "description": "Model pins this pool entry to a single model, which is what allows the same\nregistry to appear several times as independently balanced routes.",
+            "type": "string"
+          },
           "models": {
             "type": "array",
             "items": {
@@ -4671,6 +5016,13 @@
           },
           "registry_id": {
             "type": "string"
+          },
+          "weight": {
+            "description": "Weight is the relative weighted-round-robin share of this route on a 1..100\nscale, defaulting to the consumer's registry weight.",
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 1,
+            "example": 1
           }
         }
       },
@@ -4719,6 +5071,32 @@
             }
           },
           "default": {
+            "type": "string"
+          }
+        }
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingConfigRequest": {
+        "type": "object",
+        "properties": {
+          "tiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest"
+            }
+          }
+        }
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.SmartRoutingTierRequest": {
+        "type": "object",
+        "properties": {
+          "min_score": {
+            "type": "number"
+          },
+          "model": {
+            "description": "Model selects which route of the registry this tier targets. It is required\nwhen the pool declares the registry more than once.",
+            "type": "string"
+          },
+          "registry_id": {
             "type": "string"
           }
         }
@@ -4772,6 +5150,13 @@
           },
           "name": {
             "type": "string"
+          },
+          "registries": {
+            "description": "Registries replaces the whole registry association set: registries absent\nfrom the list are detached. Omit the field to leave the associations as\nthey are; send an empty list to detach every registry.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_request.RegistryBindingRequest"
+            }
           },
           "routing_mode": {
             "type": "string"
@@ -4962,12 +5347,18 @@
           },
           "pool_alias": {
             "type": "string"
+          },
+          "smart_routing": {
+            "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse"
           }
         }
       },
       "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.LBPoolMemberResponse": {
         "type": "object",
         "properties": {
+          "model": {
+            "type": "string"
+          },
           "models": {
             "type": "array",
             "items": {
@@ -4976,6 +5367,9 @@
           },
           "registry_id": {
             "type": "string"
+          },
+          "weight": {
+            "type": "integer"
           }
         }
       },
@@ -5027,6 +5421,31 @@
           }
         }
       },
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingConfigResponse": {
+        "type": "object",
+        "properties": {
+          "tiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse"
+            }
+          }
+        }
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.SmartRoutingTierResponse": {
+        "type": "object",
+        "properties": {
+          "min_score": {
+            "type": "number"
+          },
+          "model": {
+            "type": "string"
+          },
+          "registry_id": {
+            "type": "string"
+          }
+        }
+      },
       "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_consumer_response.ToolkitEntryResponse": {
         "type": "object",
         "properties": {
@@ -5056,23 +5475,34 @@
           "domain": {
             "type": "string"
           },
+          "entitlements": {
+            "description": "Entitlements is required for platform (empty JWT tenant) create and must include full stamped caps.\nTenant callers must omit it (422 if sent). When a tenant omits it, the gateway defaults to free\nor inherits the highest sibling tier.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+              }
+            ]
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
           },
-          "name": {
-            "type": "string"
-          },
           "session_config": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig"
           },
           "slug": {
-            "type": "string"
+            "description": "Slug is optional; when omitted the server generates a unique random slug. If provided it must be a lowercase DNS label.",
+            "type": "string",
+            "example": "acme-prod"
           },
           "telemetry": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.Telemetry"
+          },
+          "tenant_id": {
+            "description": "TenantID is required ownership for platform (empty JWT) create-for-tenant; tenant JWTs may match or omit it (JWT wins).",
+            "type": "string"
           }
         }
       },
@@ -5085,14 +5515,19 @@
           "domain": {
             "type": "string"
           },
+          "entitlements": {
+            "description": "Entitlements is optional; only platform admins may set it (tenant callers get 422).\nWhen omitted the gateway's entitlements are left unchanged. Downgrading when the tenant already\nhas more gateways than the new MaxInstances returns 409 — delete excess first.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+              }
+            ]
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
-          },
-          "name": {
-            "type": "string"
           },
           "session_config": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig"
@@ -5131,6 +5566,9 @@
           "domain": {
             "type": "string"
           },
+          "entitlements": {
+            "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements"
+          },
           "hosts": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_api_handler_http_gateway_response.GatewayHosts"
           },
@@ -5142,9 +5580,6 @@
             "additionalProperties": {
               "type": "string"
             }
-          },
-          "name": {
-            "type": "string"
           },
           "session_config": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig"
@@ -5186,7 +5621,7 @@
           }
         }
       },
-      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_helpers.ErrorBody": {
+      "github_com_NeuralTrust_TrustGate_pkg_api_handler_http_httpio.ErrorBody": {
         "type": "object",
         "properties": {
           "error": {
@@ -6333,6 +6768,12 @@
               "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_domain_policy.Mode"
             }
           },
+          "supported_protocols": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_app_plugins.Protocol"
+            }
+          },
           "supported_stages": {
             "type": "array",
             "items": {
@@ -6446,6 +6887,19 @@
           "FieldTypeObject",
           "FieldTypeArray",
           "FieldTypeMap"
+        ]
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_app_plugins.Protocol": {
+        "type": "string",
+        "enum": [
+          "LLM",
+          "MCP",
+          "A2A"
+        ],
+        "x-enum-varnames": [
+          "ProtocolLLM",
+          "ProtocolMCP",
+          "ProtocolA2A"
         ]
       },
       "github_com_NeuralTrust_TrustGate_pkg_app_plugins.SettingsSchema": {
@@ -6670,6 +7124,23 @@
           }
         }
       },
+      "github_com_NeuralTrust_TrustGate_pkg_domain_gateway.Entitlements": {
+        "type": "object",
+        "properties": {
+          "burst_per_min": {
+            "type": "integer"
+          },
+          "max_instances": {
+            "type": "integer"
+          },
+          "quota_per_month": {
+            "type": "integer"
+          },
+          "tier": {
+            "type": "string"
+          }
+        }
+      },
       "github_com_NeuralTrust_TrustGate_pkg_domain_gateway.SessionConfig": {
         "type": "object",
         "properties": {
@@ -6731,12 +7202,23 @@
       "github_com_NeuralTrust_TrustGate_pkg_domain_telemetry.ExporterConfig": {
         "type": "object",
         "properties": {
+          "class": {
+            "description": "Class binds the exporter to a data class, set from the group it is declared\nunder in the defaults file. Empty for per-gateway configs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass"
+              }
+            ]
+          },
           "name": {
             "type": "string"
           },
           "settings": {
             "type": "object",
             "additionalProperties": true
+          },
+          "type": {
+            "type": "string"
           }
         }
       },
@@ -6895,7 +7377,7 @@
           "status": {
             "$ref": "#/components/schemas/github_com_NeuralTrust_TrustGate_pkg_infra_metrics_events.Status"
           },
-          "team_id": {
+          "tenant_id": {
             "type": "string"
           },
           "timestamp": {
@@ -6975,7 +7457,7 @@
             "type": "integer"
           },
           "upstream_status": {
-            "type": "string"
+            "type": "integer"
           },
           "upstream_tool": {
             "type": "string"
@@ -7133,6 +7615,17 @@
             "type": "integer"
           }
         }
+      },
+      "github_com_NeuralTrust_TrustGate_pkg_metrics.DataClass": {
+        "type": "string",
+        "enum": [
+          "metadata",
+          "raw"
+        ],
+        "x-enum-varnames": [
+          "Metadata",
+          "Raw"
+        ]
       },
       "github_com_NeuralTrust_TrustGate_pkg_version.Info": {
         "type": "object",

--- a/trustgate/concepts/consumers.mdx
+++ b/trustgate/concepts/consumers.mdx
@@ -35,8 +35,8 @@ Inline consumers own their routing directly:
 | Field | Meaning |
 |---|---|
 | `registry_ids` | The [registries](/trustgate/concepts/registries) this consumer may use. |
-| `registry_weights` | Per-registry weight (`1..100`) for weighted load balancing. |
-| `lb_config` | Load-balancing algorithm and members — see [Load balancing](/trustgate/routing/load-balancing). |
+| `registry_weights` | Per-registry weight (`1..100`) for weighted load balancing, used when a pool member declares none. |
+| `lb_config` | Load-balancing algorithm and members — one member per `(registry, model)` route, so a registry can appear several times. See [Load balancing](/trustgate/routing/load-balancing). |
 | `fallback` | Ordered retry chain across registries — see [Fallback](/trustgate/routing/fallback). |
 | `model_policies` | Per-registry allow-list and default model — see [Model resolution](/trustgate/routing/model-resolution). |
 

--- a/trustgate/routing/load-balancing.mdx
+++ b/trustgate/routing/load-balancing.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Load balancing"
-description: "Distribute traffic across a consumer's registries with round-robin, weighted, least-connections, random, or semantic strategies — with health checks and weights."
+description: "Distribute traffic across a consumer's routes — one registry and model pair per member — with round-robin, weighted, least-connections, random, semantic, or smart-routing strategies."
 ---
 
 When a [consumer](/trustgate/concepts/consumers) can reach more than one
 [registry](/trustgate/concepts/registries), the load balancer picks which one serves each
 request. List the registries on the consumer with `registry_ids`, then choose how traffic is
 distributed with `lb_config`.
+
+What the balancer distributes over is a **route**: the pair of a registry and the model that
+route serves. A member without a `model` is the registry's single route and uses the default
+from `model_policies`; a member with a `model` pins that route, which is what lets the same
+registry appear several times in one pool with different models.
 
 The load balancer only runs when the request leaves the choice open — `model: "auto"`. A
 request naming a concrete model (`gpt-4o-mini` or `@openai/gpt-4o`) is pinned to the first
@@ -17,43 +22,93 @@ registry that allows it and bypasses the balancer entirely; see
 
 | Algorithm | How it picks |
 |---|---|
-| `round-robin` | Rotates through registries in order. |
-| `weighted-round-robin` | Interlaces picks by per-registry weight (`1..100`). |
-| `least-connections` | Picks the registry with the fewest in-flight requests. |
+| `round-robin` | Rotates through routes in order. |
+| `weighted-round-robin` | Interlaces picks by route weight (`1..100`). |
+| `least-connections` | Picks the route with the fewest in-flight requests. |
 | `random` | Uniform random pick. |
 | `semantic` | Embeds the prompt and routes to the registry whose description is the closest cosine match — requires an embedding config. |
-
-## Weights
-
-For weighted round-robin, each registry carries a weight from **1 to 100**, set when you
-attach it to the consumer:
-
-```bash
-POST /v1/gateways/{gateway_id}/consumers/{id}/registries/{registry_id}
-{ "weight": 70 }
-```
-
-A registry at weight 70 receives roughly 70% of the share of one at weight 30.
+| `smart-routing` | Scores the prompt's complexity and sends it to the route configured for that score — see [Smart routing](#smart-routing). |
 
 ## Configuration (`lb_config`)
 
-Enable the balancer and pick its algorithm on the consumer:
+Enable the balancer, pick its algorithm, and declare one member per route:
 
 ```json
 "lb_config": {
   "enabled": true,
   "algorithm": "weighted-round-robin",
   "members": [
-    { "registry_id": "<openai>",    "models": ["gpt-4o"] },
-    { "registry_id": "<anthropic>", "models": ["claude-3-5-sonnet"] }
+    { "registry_id": "<openai>", "model": "gpt-4o",      "weight": 70 },
+    { "registry_id": "<openai>", "model": "gpt-4o-mini", "weight": 30 },
+    { "registry_id": "<anthropic>" }
   ]
 }
 ```
 
-- `members` must already be attached to the consumer, and each one needs an entry in
-  `model_policies`.
-- A member's `models` scopes which models that registry serves.
-- The `semantic` algorithm additionally needs an `embedding_config`.
+That pool has three routes: two on the OpenAI registry — one per model, with 70/30 of the
+share between them — and one on the Anthropic registry serving its policy default.
+
+| Field | Meaning |
+|---|---|
+| `registry_id` | The registry this route sends to. Must already be attached to the consumer and have an entry in `model_policies`. |
+| `model` | Pins the route to one model. Required on **every** member that shares a registry with another member. |
+| `models` | Scopes which models this member serves, narrowing the registry's `allowed` list. |
+| `weight` | Relative share for `weighted-round-robin`, `1..100`. Defaults to the registry's weight on the consumer. |
+
+Rules enforced when you save the consumer:
+
+- Every `(registry_id, model)` pair must be unique — two members cannot describe the same route.
+- A registry that appears more than once requires a `model` on each of its members.
+- `model` must be in that member's `models` when it lists any, and allowed by `model_policies`.
+- The `semantic` algorithm additionally needs an `embedding_config`, and `smart-routing` a
+  `smart_routing` block. Neither is valid for the other algorithms.
+
+## Weights
+
+For weighted round-robin, each route carries a weight from **1 to 100** in `lb_config`. A
+route at weight 70 receives roughly 70% of the share of one at weight 30.
+
+When a member omits `weight`, the route inherits the weight of its registry on the consumer,
+set when you attach it:
+
+```bash
+POST /v1/gateways/{gateway_id}/consumers/{id}/registries/{registry_id}
+{ "weight": 70 }
+```
+
+Use the attach weight for one route per registry; when a registry serves several routes, give
+each member its own `weight`, since a per-registry weight cannot tell them apart.
+
+## Smart routing
+
+Smart routing asks the firewall to score the prompt's complexity between `0` and `1`, then
+sends the request to the route whose tier covers that score. Each tier declares the lowest
+score it accepts, and the highest matching tier wins:
+
+```json
+"lb_config": {
+  "enabled": true,
+  "algorithm": "smart-routing",
+  "members": [
+    { "registry_id": "<openai>", "model": "gpt-4o-mini" },
+    { "registry_id": "<openai>", "model": "gpt-4o" }
+  ],
+  "smart_routing": {
+    "tiers": [
+      { "min_score": 0,   "registry_id": "<openai>", "model": "gpt-4o-mini" },
+      { "min_score": 0.5, "registry_id": "<openai>", "model": "gpt-4o" }
+    ]
+  }
+}
+```
+
+Cheap prompts go to `gpt-4o-mini`; anything scoring `0.5` or above goes to `gpt-4o` on the
+same registry.
+
+- Each tier must target a registry that is a pool member.
+- `model` selects which route of that registry the tier means. It is **required** when the
+  pool declares that registry more than once, and must match one of its routes.
+- Cover the bottom of the range with a `min_score: 0` tier so every request has a route.
 
 ## Health checks
 
@@ -66,5 +121,10 @@ When the gateway has [session affinity](/trustgate/concepts/gateways#session-aff
 enabled, requests carrying a session id are pinned to the same selection across a
 conversation.
 
+## Observability
+
+Every attempt records the model of the route that served it (`route_model`), so activity data
+distinguishes two routes of the same registry.
+
 Pair load balancing with [fallback](/trustgate/routing/fallback) so a failed pick retries
-the next registry instead of erroring.
+the next route instead of erroring.

--- a/trustgate/routing/model-resolution.mdx
+++ b/trustgate/routing/model-resolution.mdx
@@ -10,7 +10,7 @@ A client never names a provider URL — it names a **model**, and TrustGate reso
 
 | Form | Example | Meaning |
 |---|---|---|
-| **Auto** | `auto` | Let TrustGate choose. The [load balancer](/trustgate/routing/load-balancing) picks among the registries that have a default model, and each registry receives its own default. |
+| **Auto** | `auto` | Let TrustGate choose. The [load balancer](/trustgate/routing/load-balancing) picks among the routes that have a model, and each route sends its own. |
 | **Short** (pass-through) | `gpt-4o-mini` | Pins the **first** registry whose policy allows that model, and sends the name as-is. |
 | **Provider-qualified** | `@openai/gpt-4o` | Pins the **first** registry of provider `openai` whose policy allows that model. |
 
@@ -53,13 +53,18 @@ role's `registry_ids`.
 
 ## Auto
 
-With `model: "auto"`, TrustGate keeps only the registries that have a `default` model in
-their policy, removes the `model` field from the request body, and lets the load balancer
-pick. The selected registry then applies its own default — so the same request can run on
-`gpt-4o-mini` on one registry and `claude-sonnet-4` on another.
+With `model: "auto"`, TrustGate keeps only the candidates that resolve to a model, removes the
+`model` field from the request body, and lets the load balancer pick. The selected route then
+applies its own model — so the same request can run on `gpt-4o-mini` on one route and
+`claude-sonnet-4` on another.
 
-If no registry reachable by the consumer defines a default model, the request is rejected
-with `auto routing requires at least one registry with a default model`.
+A candidate resolves to a model through its policy `default`, or through the `model` pinned by
+its [load-balancing member](/trustgate/routing/load-balancing#configuration-lb_config) — a
+pinned member model is enough on its own, so a registry with no policy default still
+participates in `auto` when the pool pins one.
+
+If nothing reachable by the consumer resolves to a model, the request is rejected with
+`auto routing requires at least one registry with a default model`.
 
 ## Model policies
 
@@ -83,9 +88,9 @@ constrain which models are reachable per registry with `model_policies`:
 A request for a model outside the allow-list is rejected before it reaches the provider.
 
 When [load balancing](/trustgate/routing/load-balancing) is enabled, a member's `models` list
-overrides the registry's `allowed` list. The member's effective default is the policy
-`default` when that model is one of the member's `models`, otherwise the first entry of
-`models`.
+overrides the registry's `allowed` list, and a member's `model` pins the route outright. A
+member without `model` uses the policy `default` when that model is one of the member's
+`models`, otherwise the first entry of `models`.
 
 ## Resolution order
 


### PR DESCRIPTION
## Summary

- Rewrites `trustgate/routing/load-balancing.mdx` around the new unit of balancing: a **route**, the `(registry, model)` pair. Documents the `members` fields (`model`, `models`, `weight`), the validation rules the gateway enforces, a `smart-routing` section with tier models, and how per-route weights relate to the registry attach weight.
- Adds notes to `model-resolution.mdx` (a model pinned by a pool member is enough for `auto`, even with no policy default) and to `concepts/consumers.mdx` (`lb_config` holds one member per route).
- Refreshes `trustgate/api/openapi.json` from the generated Admin API spec, keeping the published `servers` block.

Pairs with TrustGate [#412](https://github.com/NeuralTrust/TrustGate/pull/412) (`refactor: balance load across (registry, model) routes`) — **merge this after that one**, since it documents fields that ship with it.

## Notes for the reviewer

- The published spec was several releases stale; most of the `openapi.json` diff is that catch-up, not route-aware fields.
- The generated spec also exposes `/health` and `/v1/config-sync/connections`, which were not published before. I left both out of this refresh — say the word if you want them documented.

## Test plan

- [ ] `mint dev` renders the routing pages with no broken links or anchors
- [ ] `/trustgate/routing/model-resolution` link to `#configuration-lb_config` resolves

Made with [Cursor](https://cursor.com)