### PR TITLE
docs: document the response headers that name the served route

### DIFF
--- a/trustgate/routing/load-balancing.mdx
+++ b/trustgate/routing/load-balancing.mdx
@@ -121,6 +121,25 @@ When the gateway has [session affinity](/trustgate/concepts/gateways#session-aff
 enabled, requests carrying a session id are pinned to the same selection across a
 conversation.
 
+## Which route served a request
+
+Every proxied response advertises the route that answered, so callers never have to infer it:
+
+| Header | Value |
+| --- | --- |
+| `X-Selected-Provider` | Provider of the registry that served the request (`openai`, `anthropic`, …). |
+| `X-Selected-Registry` | Id of that registry, which tells apart two registries of the same provider. |
+| `X-Selected-Model` | Model the gateway sent upstream, after `auto` and pool resolution. |
+
+They are also set on streamed responses, before the first chunk, and on upstream errors, so a
+failing route is identifiable from the response alone.
+
+<Note>
+  Read the served model from `X-Selected-Model` rather than from the response body: some
+  providers echo no model at all, and with `model: "auto"` the client never sent the name the
+  pool resolved to.
+</Note>
+
 ## Observability
 
 Every attempt records the model of the route that served it (`route_model`), so activity data

--- a/trustgate/routing/model-resolution.mdx
+++ b/trustgate/routing/model-resolution.mdx
@@ -66,6 +66,9 @@ participates in `auto` when the pool pins one.
 If nothing reachable by the consumer resolves to a model, the request is rejected with
 `auto routing requires at least one registry with a default model`.
 
+Because the client never names the model, read the one that ran from the
+[`X-Selected-Model` response header](/trustgate/routing/load-balancing#which-route-served-a-request).
+
 ## Model policies
 
 [Consumers](/trustgate/concepts/consumers) and [roles](/trustgate/concepts/roles) can


### PR DESCRIPTION
## Summary

Adds a **Which route served a request** section to the load-balancing page covering the three proxy response headers — `X-Selected-Provider`, `X-Selected-Registry` and `X-Selected-Model` — and a pointer from the `auto` section of model resolution, since that is the case where the client never names the model that runs.

Pairs with NeuralTrust/TrustGate#414, which adds the registry and model headers. `X-Selected-Provider` already existed but was undocumented.

## Test plan

- [ ] Preview renders the new table and `<Note>` on `/trustgate/routing/load-balancing`
- [ ] The anchor link from `/trustgate/routing/model-resolution#auto` resolves to `#which-route-served-a-request`

Made with [Cursor](https://cursor.com)