### PR TITLE
docs: document Admin API machine credentials (ENG-1212)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -244,7 +244,8 @@
             "group": "Admin API",
             "icon": "code",
             "pages": [
-              "trustgate/api/overview"
+              "trustgate/api/overview",
+              "trustgate/api/machine-credentials"
             ]
           },
           {

--- a/trustgate/api/machine-credentials.mdx
+++ b/trustgate/api/machine-credentials.mdx
@@ -1,0 +1,93 @@
+---
+title: "Machine credentials"
+description: "Run automation against the Admin API without a person re-issuing tokens: exchange a client ID and secret for a short-lived, gateway-scoped access token."
+---
+
+A console-minted admin JWT expires and nobody renews it, which is fine for a script you run
+by hand and useless for automation that has to keep working next week. Machine credentials
+solve that: your automation holds a long-lived `client_id` / `client_secret` pair and
+exchanges it for a short-lived access token whenever it needs one.
+
+Each credential is bound to **one gateway** and carries an explicit set of scopes. A
+credential issued for gateway A cannot read or change anything in gateway B, even when both
+belong to the same team.
+
+<Note>
+Machine credentials are issued by the NeuralTrust platform (SaaS and Hybrid). Self-hosted
+open-source TrustGate has no credential store — mint admin JWTs yourself as described in
+[Server security](/trustgate/operate/server-security#admin-authentication).
+</Note>
+
+## Create a credential
+
+In the console, open **Settings → Agent Gateway → Credentials**, click **New credential**,
+name it after the system that will use it, and pick the scopes it needs.
+
+The client secret is displayed **once**. Copy it into your secret manager before closing the
+dialog — it is stored only as a hash and cannot be shown again. If you lose it, rotate the
+credential to get a new one.
+
+### Scopes
+
+| Scope | Grants |
+|---|---|
+| `gateways:read` | Read the bound gateway. |
+| `consumers:read` / `consumers:write` | List and manage [consumers](/trustgate/concepts/consumers). |
+| `auths:read` / `auths:write` | Manage [auth credentials](/trustgate/concepts/auth). |
+| `roles:read` / `roles:write` | Manage [roles](/trustgate/concepts/roles). |
+| `registries:read` | Read [registries](/trustgate/concepts/registries). |
+| `policies:read` | Read [policies](/trustgate/policies/overview). |
+
+Creating and deleting gateways stays a console-only operation. Grant the narrowest set that
+makes your automation work.
+
+## Exchange the credential for a token
+
+The token endpoint implements the OAuth2 `client_credentials` grant. Credentials go in an
+HTTP Basic header, or as form fields if your client cannot set one.
+
+```bash
+curl -X POST https://app.neuraltrust.ai/api/gateway/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d grant_type=client_credentials
+```
+
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6...",
+  "token_type": "Bearer",
+  "expires_in": 300,
+  "scope": "gateways:read consumers:read consumers:write"
+}
+```
+
+Invalid credentials always return the same generic `invalid_client` error, so the endpoint
+cannot be used to discover which client IDs exist.
+
+## Call the Admin API
+
+```bash
+curl https://<gateway-admin-host>/v1/gateways/$GATEWAY_ID/consumers \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+The token is valid for five minutes. Cache it and refresh on expiry (or on a `401`) rather
+than minting one per request.
+
+TrustGate rejects the request with `403` when the `gateway_id` in the path is not the
+gateway the credential is bound to, or when the operation needs a scope the credential does
+not hold. Reading a gateway that belongs to another tenant returns `404`, so the response
+never reveals whether it exists.
+
+## Rotate and revoke
+
+**Rotate** issues a new secret and invalidates the old one immediately. Deploy the new
+secret first if your automation cannot tolerate a failed token request; access tokens
+already issued keep working until they expire.
+
+**Revoke** stops new tokens from being issued at once. Because tokens live five minutes, a
+revoked credential loses all access within that window — there is no remote introspection on
+each admin request.
+
+Both actions are recorded in the audit log, along with every token issued or denied, keyed
+by credential ID. Secrets and tokens are never logged.

--- a/trustgate/api/overview.mdx
+++ b/trustgate/api/overview.mdx
@@ -26,6 +26,11 @@ See [Server security](/trustgate/operate/server-security#admin-authentication) f
 mint one. For a console-first walkthrough (no admin JWT), start with the
 [Quickstart](/trustgate/getting-started/quickstart).
 
+On NeuralTrust SaaS and Hybrid, automation should use
+[machine credentials](/trustgate/api/machine-credentials) instead: a `client_id` /
+`client_secret` pair scoped to one gateway, exchanged for a short-lived access token, so a
+long-running job never depends on someone re-issuing a token by hand.
+
 ## Resources
 
 | Group | Path | Manages |

--- a/trustgate/operate/configuration.mdx
+++ b/trustgate/operate/configuration.mdx
@@ -19,6 +19,11 @@ with safe defaults.
 | `SERVER_READ_TIMEOUT` / `SERVER_WRITE_TIMEOUT` | `60s` | HTTP timeouts. |
 | `SERVER_IDLE_TIMEOUT` | `120s` | Idle connection timeout. |
 | `SERVER_SECRET_KEY` | *(required)* | HS256 secret for admin JWTs. |
+| `ADMIN_M2M_ISSUER` | — | Expected `iss` on RS256 [machine tokens](/trustgate/api/machine-credentials). Unset disables them. |
+| `ADMIN_M2M_AUDIENCE` | `trustgate-admin` | Expected `aud` on machine tokens. |
+| `ADMIN_M2M_PUBLIC_KEYS` | — | JSON array of `{"kid","pem"}` RSA public keys. Two entries allow key rotation. |
+| `ADMIN_M2M_MAX_TOKEN_TTL` | `15m` | Rejects machine tokens whose `exp - iat` exceeds this. |
+| `ADMIN_PLATFORM_CLAIM_REQUIRED` | `false` | Require an explicit `platform_admin` claim for cross-tenant access. |
 | `GATEWAY_BASE_DOMAIN` | `llm.neuraltrust.ai` | Proxy host suffix (`{slug}.<domain>`). |
 | `MCP_BASE_DOMAIN` | `mcp.neuraltrust.ai` | MCP host suffix. |
 | `GATEWAY_DISCOVERY_MODE` | `header` | `header` or `subdomain` (see [Architecture](/trustgate/architecture#gateway-discovery)). |

--- a/trustgate/operate/server-security.mdx
+++ b/trustgate/operate/server-security.mdx
@@ -26,6 +26,14 @@ Keep `SERVER_SECRET_KEY` secret and rotate it like any signing key — anyone wh
 token with it can administer every gateway. Mint short-lived tokens for automation and
 self-hosted control-plane access.
 
+TrustGate also accepts RS256 tokens issued by a trusted platform for machine-to-machine
+access. These are verified against the public keys in `ADMIN_M2M_PUBLIC_KEYS` (matched by
+`kid`), must carry `token_use=admin_m2m`, the configured `ADMIN_M2M_ISSUER` and
+`ADMIN_M2M_AUDIENCE`, an explicit `gateway_id`, and scopes; their lifetime is capped by
+`ADMIN_M2M_MAX_TOKEN_TTL`. Each one can only act on the gateway named in its claims. On
+NeuralTrust SaaS and Hybrid these are issued from
+[machine credentials](/trustgate/api/machine-credentials).
+
 For **Private** and self-hosted data planes, restrict deployment secrets to your platform
 team — see [Configuration](/trustgate/operate/configuration) and
 [Deployment](/trustgate/operate/deployment).


### PR DESCRIPTION
## Summary

New page **TrustGate → Admin API → Machine credentials** covering the `client_credentials` flow for Agent Factory and any other automation:

- Why it exists (a console JWT expires and nobody renews it), and that a credential is bound to one gateway.
- Creating a credential, the scope table, and the fact that the secret is shown once.
- Exchanging it at the token endpoint, calling the Admin API, and what `403` vs `404` mean.
- Rotation and revocation semantics, including why an already-issued token survives for its five minutes.

Also documents the `ADMIN_M2M_*` verification settings in Configuration and Server security, and links the new page from the Admin API overview.

Ships with NeuralTrust/TrustGate#482 and NeuralTrust/app#3332.

## Test plan

- [x] `docs.json` parses and the page is in the Admin API group
- [ ] Mintlify preview renders the page and all cross-links resolve

Linear: https://linear.app/neuraltrust/issue/ENG-1212

Made with [Cursor](https://cursor.com)