### PR TITLE
docs: single-line M2M public key for the TrustGate Admin API (ENG-1212)

### DIFF
--- a/trustgate/operate/configuration.mdx
+++ b/trustgate/operate/configuration.mdx
@@ -21,7 +21,7 @@ with safe defaults.
 | `SERVER_SECRET_KEY` | *(required)* | HS256 secret for admin JWTs. |
 | `ADMIN_M2M_ISSUER` | — | Expected `iss` on RS256 [machine tokens](/trustgate/api/machine-credentials). Unset disables them. |
 | `ADMIN_M2M_AUDIENCE` | `trustgate-admin` | Expected `aud` on machine tokens. |
-| `ADMIN_M2M_PUBLIC_KEYS` | — | JSON array of `{"kid","pem"}` RSA public keys. Two entries allow key rotation. |
+| `ADMIN_M2M_PUBLIC_KEYS` | — | RSA public key as base64-encoded PEM (one line). For rotation, a JSON array of `{"kid","pem"}` entries instead. |
 | `ADMIN_M2M_MAX_TOKEN_TTL` | `15m` | Rejects machine tokens whose `exp - iat` exceeds this. |
 | `ADMIN_PLATFORM_CLAIM_REQUIRED` | `false` | Require an explicit `platform_admin` claim for cross-tenant access. |
 | `GATEWAY_BASE_DOMAIN` | `llm.neuraltrust.ai` | Proxy host suffix (`{slug}.<domain>`). |

--- a/trustgate/operate/server-security.mdx
+++ b/trustgate/operate/server-security.mdx
@@ -34,6 +34,16 @@ access. These are verified against the public keys in `ADMIN_M2M_PUBLIC_KEYS` (m
 NeuralTrust SaaS and Hybrid these are issued from
 [machine credentials](/trustgate/api/machine-credentials).
 
+Only the public half reaches TrustGate, so it can verify tokens but never mint one. Set it as
+a base64-encoded PEM, which keeps the whole value on a single line in your secret store:
+
+```bash
+ADMIN_M2M_PUBLIC_KEYS=$(openssl rsa -in m2m.key -pubout | base64)
+```
+
+To rotate, pass a JSON array of `{"kid","pem"}` entries instead and keep both keys live while
+the issuer switches over.
+
 For **Private** and self-hosted data planes, restrict deployment secrets to your platform
 team — see [Configuration](/trustgate/operate/configuration) and
 [Deployment](/trustgate/operate/deployment).


### PR DESCRIPTION
## Summary

Documents that `ADMIN_M2M_PUBLIC_KEYS` takes the RSA public key as a base64-encoded PEM on a single line, with the JSON array reserved for key rotation.

Follows NeuralTrust/TrustGate#487.

## Test plan

- [ ] Docs preview renders `trustgate/operate/configuration` and `trustgate/operate/server-security`

Linear: https://linear.app/neuraltrust/issue/ENG-1212

Made with [Cursor](https://cursor.com)