### PR TITLE
docs: document policies:write and registries:write scopes (ENG-1212)

### DIFF
--- a/trustgate/api/machine-credentials.mdx
+++ b/trustgate/api/machine-credentials.mdx
@@ -35,7 +35,7 @@ credential to get a new one.
 | `consumers:read` / `consumers:write` | List and manage [consumers](/trustgate/concepts/consumers). |
 | `auths:read` / `auths:write` | Manage [auth credentials](/trustgate/concepts/auth). |
 | `roles:read` / `roles:write` | Manage [roles](/trustgate/concepts/roles). |
-| `registries:read` | Read [registries](/trustgate/concepts/registries). |
+| `registries:read` / `registries:write` | Manage [registries](/trustgate/concepts/registries). |
 | `policies:read` / `policies:write` | Manage [policies](/trustgate/policies/overview). |
 
 Creating and deleting gateways stays a console-only operation. Grant the narrowest set that

--- a/trustgate/api/machine-credentials.mdx
+++ b/trustgate/api/machine-credentials.mdx
@@ -36,7 +36,7 @@ credential to get a new one.
 | `auths:read` / `auths:write` | Manage [auth credentials](/trustgate/concepts/auth). |
 | `roles:read` / `roles:write` | Manage [roles](/trustgate/concepts/roles). |
 | `registries:read` | Read [registries](/trustgate/concepts/registries). |
-| `policies:read` | Read [policies](/trustgate/policies/overview). |
+| `policies:read` / `policies:write` | Manage [policies](/trustgate/policies/overview). |
 
 Creating and deleting gateways stays a console-only operation. Grant the narrowest set that
 makes your automation work.


### PR DESCRIPTION
## Summary

Updates the machine credentials scope table now that credentials can write policies and registries, not just read them.

Follows NeuralTrust/app#3335.

## Test plan

- [ ] Docs preview renders `trustgate/api/machine-credentials`

Linear: https://linear.app/neuraltrust/issue/ENG-1212

Made with [Cursor](https://cursor.com)