### PR TITLE
docs: 24h machine token lifetime and revocation window (ENG-1212)

### DIFF
--- a/trustgate/api/machine-credentials.mdx
+++ b/trustgate/api/machine-credentials.mdx
@@ -71,8 +71,8 @@ curl https://<gateway-admin-host>/v1/gateways/$GATEWAY_ID/consumers \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
-The token is valid for five minutes. Cache it and refresh on expiry (or on a `401`) rather
-than minting one per request.
+The token is valid for 24 hours. Cache it and refresh on expiry (or on a `401`) rather than
+minting one per request.
 
 TrustGate rejects the request with `403` when the `gateway_id` in the path is not the
 gateway the credential is bound to, or when the operation needs a scope the credential does
@@ -85,9 +85,10 @@ never reveals whether it exists.
 secret first if your automation cannot tolerate a failed token request; access tokens
 already issued keep working until they expire.
 
-**Revoke** stops new tokens from being issued at once. Because tokens live five minutes, a
-revoked credential loses all access within that window — there is no remote introspection on
-each admin request.
+**Revoke** stops new tokens from being issued at once. An access token the credential already
+holds keeps working until it expires: TrustGate verifies tokens offline, with no introspection
+call on each admin request, so the token lifetime is also the revocation window. Shorten
+`ADMIN_M2M_MAX_TOKEN_TTL` if your deployment needs revocation to take effect sooner.
 
 Both actions are recorded in the audit log, along with every token issued or denied, keyed
 by credential ID. Secrets and tokens are never logged.

--- a/trustgate/operate/configuration.mdx
+++ b/trustgate/operate/configuration.mdx
@@ -22,7 +22,7 @@ with safe defaults.
 | `ADMIN_M2M_ISSUER` | — | Expected `iss` on RS256 [machine tokens](/trustgate/api/machine-credentials). Unset disables them. |
 | `ADMIN_M2M_AUDIENCE` | `trustgate-admin` | Expected `aud` on machine tokens. |
 | `ADMIN_M2M_PUBLIC_KEYS` | — | RSA public key as base64-encoded PEM (one line). For rotation, a JSON array of `{"kid","pem"}` entries instead. |
-| `ADMIN_M2M_MAX_TOKEN_TTL` | `15m` | Rejects machine tokens whose `exp - iat` exceeds this. |
+| `ADMIN_M2M_MAX_TOKEN_TTL` | `24h` | Rejects machine tokens whose `exp - iat` exceeds this. Also the revocation window, since verification is offline. |
 | `ADMIN_PLATFORM_CLAIM_REQUIRED` | `false` | Require an explicit `platform_admin` claim for cross-tenant access. |
 | `GATEWAY_BASE_DOMAIN` | `llm.neuraltrust.ai` | Proxy host suffix (`{slug}.<domain>`). |
 | `MCP_BASE_DOMAIN` | `mcp.neuraltrust.ai` | MCP host suffix. |


### PR DESCRIPTION
## Summary

Machine tokens now live 24 hours instead of five minutes.

- `ADMIN_M2M_MAX_TOKEN_TTL` default updated to `24h`.
- The revoke section no longer claims a revoked credential "loses all access within that window" in minutes. It explains that verification is offline, so the token lifetime *is* the revocation window, and points at the setting to shorten it.

Follows NeuralTrust/TrustGate#489 and NeuralTrust/app#3339.

## Test plan

- [ ] Docs preview renders `trustgate/api/machine-credentials` and `trustgate/operate/configuration`

Linear: https://linear.app/neuraltrust/issue/ENG-1212

Made with [Cursor](https://cursor.com)