### PR TITLE
docs(trustguard): document source.application policy gates

### DIFF
--- a/trustguard/api/evaluate.mdx
+++ b/trustguard/api/evaluate.mdx
@@ -47,7 +47,7 @@ gateway authenticates and calls this endpoint for you.)
 | `protocol` | enum | — | `all` (default) · `llm` · `mcp` · `a2a`. Available as the `protocol` gate/rule condition. |
 | `session_id` | string | — | Conversation/correlation key. Synthesised if omitted. |
 | `consumer_id` | string | — | Actor identifier for per‑consumer policy routing. Gates match it as `consumer.id`. |
-| `attributes` | object | — | Extra dimensions for gate/detector conditions: `consumer.{name,tag,type}`, `model.{name,provider}`, `collector.type`. |
+| `attributes` | object | — | Extra dimensions for gate/detector conditions: `consumer.{name,tag,type}`, `model.{name,provider}`, `collector.type`, `source.application`. Nested form: `{ "source": { "application": "claude-code" } }`. |
 
 Unknown top‑level fields are rejected with `400` (strict decoding). Do **not**
 send `input`, `metadata`, `collector_id`, or `detector_id` at the top level.

--- a/trustguard/concepts/collectors.mdx
+++ b/trustguard/concepts/collectors.mdx
@@ -93,8 +93,8 @@ Each integration should send, when available:
   fingerprint). Used for per‑consumer policy routing.
 - **`session_id`** — which conversation the message belongs to. Synthesised if omitted.
 - **`attributes`** — optional context (`consumer.name`, `consumer.tag`,
-  `consumer.type`, `model.name`, `model.provider`, `collector.type`) that gates
-  and detector rules can match on.
+  `consumer.type`, `model.name`, `model.provider`, `collector.type`,
+  `source.application`) that gates and detector rules can match on.
 
 These attribute findings to the right user and session in the **Activity** view
 and power the stateful detectors. Every integration snippet shows the natural

--- a/trustguard/concepts/policies.mdx
+++ b/trustguard/concepts/policies.mdx
@@ -50,6 +50,7 @@ Conditions target these request attributes:
 | **Consumer** | `consumer.id`, `consumer.name`, `consumer.tag`, `consumer.type` |
 | **Model** | `model.name`, `model.provider` |
 | **Collector** | `collector.id`, `collector.type` |
+| **Source** | `source.application` |
 | **Session** | `session.id` |
 | **Protocol** | `protocol` |
 
@@ -57,9 +58,23 @@ Conditions target these request attributes:
 (`lt`), Contains (`contains`), Does not contain (`not_contains`), In (`in` — a
 comma‑separated list), Matches (`match` — a regular expression).
 
-The `consumer.*`, `model.*` and `collector.type` values come from the guard
-request's `attributes`; `collector.id`, `session.id` and `protocol` are resolved
-by TrustGuard.
+`consumer.*`, `model.*`, `collector.type`, and `source.application` come from
+the request `attributes` object (or are stamped by a dialect such as the
+[Claude Enterprise](/trustguard/integrations/ide/claude-enterprise) inference
+hook). `collector.id`, `session.id`, and `protocol` are resolved by TrustGuard.
+
+#### Example: Claude surface
+
+One Claude Enterprise collector covers chat and Claude Code. Stamp differs by
+`source.application` (`claude-ai`, `claude-code`, …). Gate on it to apply a
+stricter action only on Code:
+
+| Condition | Then |
+|---|---|
+| `source.application` **eq** `claude-code` | **Block** (or **Report**) |
+| (no match) | Continue to detectors |
+
+Or waive chat-only traffic: `source.application` **eq** `claude-ai` → **Skip**.
 
 ## Detectors — run detectors and decide the action
 

--- a/trustguard/integrations/ide/claude-enterprise.mdx
+++ b/trustguard/integrations/ide/claude-enterprise.mdx
@@ -39,10 +39,33 @@ TrustGuard outage does not block the org’s Claude usage.
 | `claude-ai` | Claude chat |
 | `claude-code` | Claude Code |
 | (Cowork when Anthropic emits it) | Claude Cowork |
+| `config-test` | Anthropic **Test connection** |
 
-Use policy gates on `source.application` if you need different rules per surface.
+TrustGuard copies the frame’s `source.application` into the gate attribute map
+on every delivery. Unknown values are accepted as-is (open string).
+
+## Policy gates per surface
+
+Keep **one** collector and **one** default policy. Differentiate with a
+[gate](/trustguard/concepts/policies#gates-match-before-you-detect) on
+`source.application` (Policies → **Gates** → attribute **Source application**):
+
+| Goal | Condition | Then |
+| --- | --- | --- |
+| Stricter on Claude Code only | `source.application` **eq** `claude-code` | **Block** or **Report** |
+| Waive chat (detectors still run after Skip) | `source.application` **eq** `claude-ai` | **Skip** |
+| Several products | `source.application` **in** `claude-code,cowork-when-emitted` | **Block** |
+
+Gates run **before** detectors. In **Report** policy mode, Block is recorded
+only. Test the condition on the policy **Test** tab with
+`source.application = claude-code` (or the surface you care about).
+
+Also available on the same hook deliveries: `collector.type` =
+`anthropic_inference_hook`, `model.provider` = `anthropic`, `consumer.id` from
+the actor email/id.
 
 ## Related
 
+- [Policies — Gates](/trustguard/concepts/policies#gates-match-before-you-detect)
 - [Collectors](/trustguard/concepts/collectors)
 - [Evaluate API](/trustguard/api/evaluate)


### PR DESCRIPTION
Add the Source application gate attribute to policies, evaluate, and collectors docs, with Claude Enterprise per-surface gate examples.