### PR TITLE
docs: TrustGate files, models, and rerank

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -194,6 +194,9 @@
               "trustgate/routing/model-resolution",
               "trustgate/routing/embeddings",
               "trustgate/routing/images",
+              "trustgate/routing/files",
+              "trustgate/routing/rerank",
+              "trustgate/routing/models",
               "trustgate/routing/smart-routing",
               "trustgate/routing/fallback"
             ]

--- a/trustgate/api/overview.mdx
+++ b/trustgate/api/overview.mdx
@@ -34,7 +34,7 @@ long-running job never depends on someone re-issuing a token by hand.
 ## Resources
 
 | Group | Path | Manages |
-|---|---|---|
+|---|---|
 | System | `/healthz`, `/readyz`, `/__/version` | Probes and build info (no auth). |
 | Gateways | `/v1/gateways` | [Gateways](/trustgate/concepts/gateways). |
 | Registries | `/v1/gateways/{gateway_id}/registries` | [Registries](/trustgate/concepts/registries) + test-connection, tools. |
@@ -49,9 +49,12 @@ long-running job never depends on someone re-issuing a token by hand.
 
 This reference covers the **Admin** API. Runtime traffic goes to the **Proxy** plane
 (`:8081`) on the format-specific routes — `POST /{consumer_slug}/v1/chat/completions`,
-`/v1/messages`, `/v1/responses`, `/v1/embeddings`, `/v1/images/generations` (plus `/edits` and `/variations`), and the Gemini
+`/v1/messages`, `/v1/responses`, `/v1/embeddings`, `/v1/images/generations` (plus `/edits` and `/variations`),
+`/v1/files`, `/v1/rerank`, `/v1/models`, and the Gemini
 `/v1beta/models/{model}:generateContent` — authenticated with the consumer's API key
 (`X-AG-API-Key`, `x-api-key`, or `Authorization: Bearer ag_…`) or an OAuth2/OIDC token,
 not the admin JWT. See [Auth](/trustgate/concepts/auth),
-[Architecture](/trustgate/architecture), [Embeddings](/trustgate/routing/embeddings), [Images](/trustgate/routing/images), and
+[Architecture](/trustgate/architecture), [Embeddings](/trustgate/routing/embeddings),
+[Images](/trustgate/routing/images), [Files](/trustgate/routing/files),
+[Rerank](/trustgate/routing/rerank), [Models](/trustgate/routing/models), and
 the [Quickstart](/trustgate/getting-started/quickstart).

--- a/trustgate/api/overview.mdx
+++ b/trustgate/api/overview.mdx
@@ -34,7 +34,7 @@ long-running job never depends on someone re-issuing a token by hand.
 ## Resources
 
 | Group | Path | Manages |
-|---|---|
+|---|---|---|
 | System | `/healthz`, `/readyz`, `/__/version` | Probes and build info (no auth). |
 | Gateways | `/v1/gateways` | [Gateways](/trustgate/concepts/gateways). |
 | Registries | `/v1/gateways/{gateway_id}/registries` | [Registries](/trustgate/concepts/registries) + test-connection, tools. |

--- a/trustgate/concepts/consumers.mdx
+++ b/trustgate/concepts/consumers.mdx
@@ -11,7 +11,7 @@ Each consumer belongs to one gateway and has a type:
 
 | Type | Traffic |
 |---|---|
-| **LLM** | Chat / Responses / Messages / [embeddings](/trustgate/routing/embeddings) / [images](/trustgate/routing/images) (default). |
+| **LLM** | Chat / Responses / Messages / [embeddings](/trustgate/routing/embeddings) / [images](/trustgate/routing/images) / [files](/trustgate/routing/files) / [rerank](/trustgate/routing/rerank) / [models](/trustgate/routing/models) (default). |
 | **MCP** | MCP tool endpoints. |
 
 ## Consumers list
@@ -105,7 +105,7 @@ Open a consumer → **Connect** for:
 - Consumer slug
 - Auth header examples (`X-AG-API-Key`, and `X-AG-Gateway-Slug` on Private)
 - Language snippets (cURL, Python, Node, …)
-- Same host and key for [embeddings](/trustgate/routing/embeddings) (`POST /{slug}/v1/embeddings`) and [images](/trustgate/routing/images) (`POST /{slug}/v1/images/generations`, plus multipart `/edits` and `/variations`)
+- Same host and key for [embeddings](/trustgate/routing/embeddings), [images](/trustgate/routing/images), [files](/trustgate/routing/files), [rerank](/trustgate/routing/rerank), and [models](/trustgate/routing/models)
 
 The provider credential remains in TrustGate. Keep the consumer API key secret.
 

--- a/trustgate/concepts/registries.mdx
+++ b/trustgate/concepts/registries.mdx
@@ -6,8 +6,8 @@ description: "A registry is an upstream backend — an LLM provider or an MCP se
 A **registry** is a single upstream backend that a gateway can route to. There are two kinds:
 
 | Type | Points at | Used by |
-|---|---|---|
-| **LLM** | A model provider endpoint (OpenAI, Anthropic, Bedrock, …). | Chat / Responses / Messages / [embeddings](/trustgate/routing/embeddings) / [images](/trustgate/routing/images). |
+|---|---|
+| **LLM** | A model provider endpoint (OpenAI, Anthropic, Bedrock, …). | Chat / Responses / Messages / [embeddings](/trustgate/routing/embeddings) / [images](/trustgate/routing/images) / [files](/trustgate/routing/files) / [rerank](/trustgate/routing/rerank). |
 | **MCP** | A Model Context Protocol server. | The [MCP plane](/trustgate/mcp/overview). |
 
 [Consumers](/trustgate/concepts/consumers) and [roles](/trustgate/concepts/roles) select

--- a/trustgate/concepts/registries.mdx
+++ b/trustgate/concepts/registries.mdx
@@ -6,7 +6,7 @@ description: "A registry is an upstream backend — an LLM provider or an MCP se
 A **registry** is a single upstream backend that a gateway can route to. There are two kinds:
 
 | Type | Points at | Used by |
-|---|---|
+|---|---|---|
 | **LLM** | A model provider endpoint (OpenAI, Anthropic, Bedrock, …). | Chat / Responses / Messages / [embeddings](/trustgate/routing/embeddings) / [images](/trustgate/routing/images) / [files](/trustgate/routing/files) / [rerank](/trustgate/routing/rerank). |
 | **MCP** | A Model Context Protocol server. | The [MCP plane](/trustgate/mcp/overview). |
 

--- a/trustgate/getting-started/quickstart.mdx
+++ b/trustgate/getting-started/quickstart.mdx
@@ -143,6 +143,35 @@ curl -X POST "https://<gateway-host>/<consumer-slug>/v1/images/generations" \
 
 Providers and multipart edits/variations: [Images](/trustgate/routing/images).
 
+Files use the same host, consumer slug, and key:
+
+```bash
+curl -X POST "https://<gateway-host>/<consumer-slug>/v1/files" \
+  -H "X-AG-API-Key: <your-api-key>" \
+  -F purpose=assistants \
+  -F file=@notes.txt
+```
+
+Providers and list/get/content/delete: [Files](/trustgate/routing/files).
+
+Rerank (Cohere v2 body) and model discovery:
+
+```bash
+curl -X POST "https://<gateway-host>/<consumer-slug>/v1/rerank" \
+  -H "X-AG-API-Key: <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "rerank-english-v3.0",
+    "query": "What is TrustGate?",
+    "documents": ["TrustGate is an LLM gateway"]
+  }'
+
+curl "https://<gateway-host>/<consumer-slug>/v1/models" \
+  -H "X-AG-API-Key: <your-api-key>"
+```
+
+[Rerank](/trustgate/routing/rerank) · [Models](/trustgate/routing/models).
+
 ## Next steps
 
 From Getting started **What's next**, open **Playground**, **Consumer**, or **Security**

--- a/trustgate/overview.mdx
+++ b/trustgate/overview.mdx
@@ -20,7 +20,9 @@ Putting TrustGate between your apps and your model providers gives you one contr
 - **Multi-provider access** — first-class adapters for OpenAI, Anthropic, Azure OpenAI,
   AWS Bedrock, Google Gemini, Vertex AI, Groq, Mistral, and DeepSeek (plus any
   OpenAI-compatible endpoint), behind one OpenAI-compatible surface. Chat, Responses,
-  Messages, [embeddings](/trustgate/routing/embeddings), and [images](/trustgate/routing/images) share the same consumer.
+  Messages, [embeddings](/trustgate/routing/embeddings), [images](/trustgate/routing/images),
+  [files](/trustgate/routing/files), and [rerank](/trustgate/routing/rerank) share the same
+  consumer. [Model discovery](/trustgate/routing/models) is `GET /{consumer}/v1/models`.
 - **Smart routing & load balancing** — simple routing, fallback chains, round-robin,
   weighted, least-connections, random, and **smart routing** by complexity label
   (**Simple** / **Medium** / **Hard**).
@@ -57,6 +59,8 @@ Configure everything in the console under **TrustGate**. Six objects make up a g
 client ──▶ /{consumer_slug}/v1/chat/completions
            or /{consumer_slug}/v1/embeddings
            or /{consumer_slug}/v1/images/generations
+           or /{consumer_slug}/v1/files
+           or /{consumer_slug}/v1/models
               │  X-AG-API-Key
               │  X-AG-Gateway-Slug (Private only)
               ├─ resolve gateway + consumer + policies

--- a/trustgate/routing/embeddings.mdx
+++ b/trustgate/routing/embeddings.mdx
@@ -51,4 +51,7 @@ pool is fine: chat still uses every chat-capable member; embeddings skip the res
 
 - [Registries](/trustgate/concepts/registries)
 - [Consumers](/trustgate/concepts/consumers) — Connect tab
+- [Rerank](/trustgate/routing/rerank)
+- [Files](/trustgate/routing/files)
+- [Models](/trustgate/routing/models)
 - [Quickstart](/trustgate/getting-started/quickstart)

--- a/trustgate/routing/files.mdx
+++ b/trustgate/routing/files.mdx
@@ -1,0 +1,86 @@
+---
+title: "Files"
+description: "Call /{consumer}/v1/files to upload, list, retrieve, delete, and download content. TrustGate routes only to registries that expose a Files store."
+---
+
+Clients send the same OpenAI Files requests they would send to OpenAI. Auth and the
+consumer slug are the same as [chat](/trustgate/getting-started/quickstart#call-from-your-application).
+
+```bash
+curl -X POST "https://<gateway-host>/<consumer-slug>/v1/files" \
+  -H "X-AG-API-Key: <your-api-key>" \
+  -F purpose=assistants \
+  -F file=@notes.txt
+```
+
+List, retrieve, download, and delete use the same host and key:
+
+```bash
+curl "https://<gateway-host>/<consumer-slug>/v1/files?purpose=assistants" \
+  -H "X-AG-API-Key: <your-api-key>"
+
+curl "https://<gateway-host>/<consumer-slug>/v1/files/<file-id>" \
+  -H "X-AG-API-Key: <your-api-key>"
+
+curl "https://<gateway-host>/<consumer-slug>/v1/files/<file-id>/content" \
+  -H "X-AG-API-Key: <your-api-key>"
+
+curl -X DELETE "https://<gateway-host>/<consumer-slug>/v1/files/<file-id>" \
+  -H "X-AG-API-Key: <your-api-key>"
+```
+
+On a Private data plane, add `X-AG-Gateway-Slug` as in the chat snippets.
+
+| Method | Path | Result |
+|---|---|---|
+| `POST` | `/v1/files` | Multipart upload, forwarded as-is |
+| `GET` | `/v1/files` | List (query string passed through, including `purpose`) |
+| `GET` | `/v1/files/{id}` | Retrieve metadata |
+| `GET` | `/v1/files/{id}/content` | Download bytes; upstream `Content-Type` is kept |
+| `DELETE` | `/v1/files/{id}` | Delete |
+
+Wrong methods are **400**. Extra path tails (`/files/{id}/other`) are **404**.
+
+TrustGate does **not** rewrite the multipart body and does not own file identity or
+retention — upstream file IDs are returned as-is.
+
+OpenAI SDKs use the same consumer base URL: `client.files.create()`, `list()`,
+`retrieve()`, `content()`, and `delete()`.
+
+## Providers
+
+| Registry | Upstream |
+|---|---|
+| **OpenAI** | `{base_url or https://api.openai.com/v1}/files…` |
+| **Azure OpenAI** | `{endpoint}/openai/files…?api-version=…` (not deployment-scoped) |
+| **OpenRouter** | `https://openrouter.ai/api/v1/files` (query passthrough, including `provider=`) |
+| **xAI** | `https://api.x.ai/v1/files` |
+| **Mistral** | `{base_url or https://api.mistral.ai/v1}/files` |
+
+Custom / OpenAI-compatible, Groq, Anthropic, Gemini / Vertex, Bedrock, Cohere, and other
+chat-only providers do not expose an OpenAI-shaped Files store. They are left out of the
+candidate pool.
+
+Anthropic Files and Gemini `files.upload` use a different wire format and are out of scope.
+
+A JSON `model` field (including `@provider/model`) is used only to pin a registry. Upload
+itself is multipart and has no model rewrite.
+
+## Routing
+
+1. The consumer's registries are filtered to those that advertise files.
+2. [Model resolution](/trustgate/routing/model-resolution) and
+   [load balancing](/trustgate/routing/load-balancing) run on that pool.
+3. Pinning a registry that cannot store files is a **400**, not a failover.
+4. An empty capable pool is a **503**.
+
+Attach at least one files-capable registry to the consumer. A mixed chat + files pool is
+fine: chat still uses every chat-capable member; files skip the rest.
+
+## Related
+
+- [Registries](/trustgate/concepts/registries)
+- [Consumers](/trustgate/concepts/consumers) — Connect tab
+- [Models](/trustgate/routing/models) — discovery does not list file ids
+- [Images](/trustgate/routing/images)
+- [Quickstart](/trustgate/getting-started/quickstart)

--- a/trustgate/routing/images.mdx
+++ b/trustgate/routing/images.mdx
@@ -76,4 +76,6 @@ fine: chat still uses every chat-capable member; images skip the rest.
 - [Registries](/trustgate/concepts/registries)
 - [Consumers](/trustgate/concepts/consumers) — Connect tab
 - [Embeddings](/trustgate/routing/embeddings)
+- [Files](/trustgate/routing/files)
+- [Models](/trustgate/routing/models)
 - [Quickstart](/trustgate/getting-started/quickstart)

--- a/trustgate/routing/model-resolution.mdx
+++ b/trustgate/routing/model-resolution.mdx
@@ -58,3 +58,6 @@ member without `model` uses the policy `default` when that model is one of the m
 - [Load balancing](/trustgate/routing/load-balancing) · [Smart routing](/trustgate/routing/smart-routing)
 - [Embeddings](/trustgate/routing/embeddings) — candidate pool is embeddings-capable registries only
 - [Images](/trustgate/routing/images) — candidate pool is images-capable registries only; multipart `model` also pins
+- [Files](/trustgate/routing/files) — candidate pool is files-capable registries only
+- [Rerank](/trustgate/routing/rerank) — candidate pool is rerank-capable registries only
+- [Models](/trustgate/routing/models) — gateway-owned `GET /v1/models`, not a pin target

--- a/trustgate/routing/models.mdx
+++ b/trustgate/routing/models.mdx
@@ -1,0 +1,50 @@
+---
+title: "Models"
+description: "Call GET /{consumer}/v1/models to list the native model ids this consumer can actually call. This is gateway-owned discovery, not an upstream passthrough."
+---
+
+Clients that probe `client.models.list()` against an OpenAI-compatible `base_url` hit
+this route. Auth and the consumer slug are the same as
+[chat](/trustgate/getting-started/quickstart#call-from-your-application).
+
+```bash
+curl "https://<gateway-host>/<consumer-slug>/v1/models" \
+  -H "X-AG-API-Key: <your-api-key>"
+
+curl "https://<gateway-host>/<consumer-slug>/v1/models/gpt-4o-mini" \
+  -H "X-AG-API-Key: <your-api-key>"
+```
+
+On a Private data plane, add `X-AG-Gateway-Slug` as in the chat snippets.
+
+`GET /v1/models` returns `{ "object": "list", "data": [{ "id", "object": "model", "owned_by" }] }`.
+`GET /v1/models/{id}` is **200** when that id is in the list, otherwise **404**.
+Non-`GET` methods are **400**. Extra path tails (`/models/{id}/extra`) are **404**.
+
+This is **not** a forward of the provider's `/v1/models` and **not** the admin models
+catalog. The list is the union of native slugs the consumer can actually call.
+
+## What is listed
+
+For each bound registry (plus fallbacks, role policies, and load-balancing member models):
+
+1. If the consumer (or role) has an allow-list, those ids are candidates.
+2. If the policy is open, TrustGate expands from the provider catalog.
+3. Only **native** slugs are kept — no `auto`, no `@provider/…`, no `pool:…`.
+4. A slug is kept only when the registry's provider supports that modality (chat always;
+   [embeddings](/trustgate/routing/embeddings) / [rerank](/trustgate/routing/rerank) only
+   when the provider advertises them). Catalog flags win; otherwise the slug is inferred
+   (`embed` → embeddings, `rerank` → rerank, else chat).
+
+`owned_by` is the registry **provider** (for example `openai` or `anthropic`).
+
+[Files](/trustgate/routing/files) have no model ids and are not listed.
+[Images](/trustgate/routing/images) ids appear only when the catalog (or allow-list) includes
+them and the consumer has an images-capable registry.
+
+## Related
+
+- [Model resolution](/trustgate/routing/model-resolution)
+- [Consumers](/trustgate/concepts/consumers) — Connect tab
+- [Registries](/trustgate/concepts/registries)
+- [Quickstart](/trustgate/getting-started/quickstart)

--- a/trustgate/routing/rerank.mdx
+++ b/trustgate/routing/rerank.mdx
@@ -1,0 +1,53 @@
+---
+title: "Rerank"
+description: "Call POST /{consumer}/v1/rerank with a Cohere v2 body. TrustGate routes only to registries that can rerank."
+---
+
+Clients send the same JSON they would send to Cohere `/v2/rerank`. Auth and the
+consumer slug are the same as [chat](/trustgate/getting-started/quickstart#call-from-your-application).
+
+```bash
+curl -X POST "https://<gateway-host>/<consumer-slug>/v1/rerank" \
+  -H "X-AG-API-Key: <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "rerank-english-v3.0",
+    "query": "What is TrustGate?",
+    "documents": ["TrustGate is an LLM gateway", "Unrelated text"]
+  }'
+```
+
+On a Private data plane, add `X-AG-Gateway-Slug` as in the chat snippets.
+
+The gateway speaks the Cohere v2 rerank shape on this path. It is not an OpenAI Chat
+Completions route.
+
+## Providers
+
+| Registry | Upstream |
+|---|---|
+| **Cohere** | Cohere `/v2/rerank` |
+
+OpenAI, Azure, Anthropic, Gemini / Vertex, Bedrock, Groq, Mistral, OpenRouter, and other
+chat-only providers do not expose rerank. They are left out of the candidate pool.
+
+The `model` field is allowlisted as usual and can pin with `@provider/model`.
+
+## Routing
+
+1. The consumer's registries are filtered to those that advertise rerank.
+2. [Model resolution](/trustgate/routing/model-resolution) and
+   [load balancing](/trustgate/routing/load-balancing) run on that pool.
+3. Pinning a registry that cannot rerank is a **400**, not a failover.
+4. An empty capable pool is a **503**.
+
+Attach at least one Cohere registry to the consumer. A mixed chat + rerank pool is fine:
+chat still uses every chat-capable member; rerank skips the rest.
+
+## Related
+
+- [Registries](/trustgate/concepts/registries)
+- [Consumers](/trustgate/concepts/consumers) — Connect tab
+- [Embeddings](/trustgate/routing/embeddings)
+- [Models](/trustgate/routing/models)
+- [Quickstart](/trustgate/getting-started/quickstart)


### PR DESCRIPTION
Public docs for the remaining shipped TrustGate proxy surfaces.

Images is already on `main` from #166. This PR adds Files, Rerank, and Models, plus pointers from the pages that already mention Images.

## Files

New [Files](https://docs.neuraltrust.ai/trustgate/routing/files) page: `POST/GET /{consumer}/v1/files`, `GET/DELETE /{consumer}/v1/files/{id}`, `GET …/content`. Passthrough to OpenAI, Azure (`/openai/files?api-version=`), OpenRouter, xAI, and Mistral. `openai_compatible` is not files-capable. Pin incapable → 400; empty pool → 503. Complements TrustGate #522 / #504.

## Rerank

New [Rerank](https://docs.neuraltrust.ai/trustgate/routing/rerank) page: `POST /{consumer}/v1/rerank` with the Cohere v2 body. Cohere only.

## Models

New [Models](https://docs.neuraltrust.ai/trustgate/routing/models) page: gateway-owned `GET /{consumer}/v1/models` and `GET /{consumer}/v1/models/{id}` (not an upstream passthrough). Complements TrustGate #524 / #506.

Pointers on overview, quickstart, consumers, registries, admin proxy routes, embeddings, images, and model resolution.

`docs.json` adds Files, Rerank, and Models under TrustGate → Routing (after Images).

Audio / video generation / chat vision are not shipped yet and are not documented as live routes.

Do not merge from automation.