### PR TITLE
docs: Anthropic Files is a first-class TrustGate provider

### DIFF
--- a/trustgate/routing/files.mdx
+++ b/trustgate/routing/files.mdx
@@ -56,12 +56,17 @@ OpenAI SDKs use the same consumer base URL: `client.files.create()`, `list()`,
 | **OpenRouter** | `https://openrouter.ai/api/v1/files` (query passthrough, including `provider=`) |
 | **xAI** | `https://api.x.ai/v1/files` |
 | **Mistral** | `{base_url or https://api.mistral.ai/v1}/files` |
+| **Anthropic** | `{base_url or https://api.anthropic.com/v1}/files` (`x-api-key`, `anthropic-version: 2023-06-01`) |
 
-Custom / OpenAI-compatible, Groq, Anthropic, Gemini / Vertex, Bedrock, Cohere, and other
-chat-only providers do not expose an OpenAI-shaped Files store. They are left out of the
-candidate pool.
+Custom / OpenAI-compatible, Groq, Gemini / Vertex, Bedrock, Cohere, and other chat-only
+providers do not expose a Files store. They are left out of the candidate pool.
 
-Anthropic Files and Gemini `files.upload` use a different wire format and are out of scope.
+Anthropic Files is GA on the Claude API — TrustGate does not send the old
+`files-api-2025-04-14` beta header. The response is Anthropic-shaped (`type`, `mime_type`,
+`size_bytes`); it is not rewritten to OpenAI `object` / `purpose`. `purpose` is optional.
+Claude Files is **not** available on Bedrock or Vertex.
+
+Gemini `files.upload` uses a different wire format and is out of scope.
 
 A JSON `model` field (including `@provider/model`) is used only to pin a registry. Upload
 itself is multipart and has no model rewrite.


### PR DESCRIPTION
Corrects the Files page: Anthropic has a GA `/v1/files` API (upload, list, retrieve, delete, content).

TrustGate now proxies it (draft [TrustGate #526](https://github.com/NeuralTrust/TrustGate/pull/526)): `x-api-key` + `anthropic-version: 2023-06-01`, no beta header. Response stays Anthropic-shaped. Not available on Bedrock or Vertex.

Do not merge from automation.