### PR TITLE
docs(trustgate): document Proxy embeddings, files, images, and audio …

### DIFF
--- a/trustgate/api/overview.mdx
+++ b/trustgate/api/overview.mdx
@@ -149,15 +149,67 @@ Read-only platform catalogs (interactive identity required):
 |---|---|---|
 | `GET` | `/v1/config-sync/connections` | List data-plane configuration-sync connections |
 
-### proxy (sample)
+### proxy
 
-Documented for reference only. These run on the **Proxy** plane with **consumer** credentials, not admin tokens:
+These run on the **Proxy** plane (`:8081`) with **consumer** credentials, not admin tokens. Every path is `/{consumer_slug}/{fixed_route}`. Unknown shapes return **404** — the Proxy is not an open reverse proxy.
+
+Consumer auth: `X-AG-API-Key`, `x-api-key`, or `Authorization: Bearer ag_…` (and OAuth/OIDC when configured). On Private deployments, also send `X-AG-Gateway-Slug` unless the host already scopes the gateway. See [Quickstart](/trustgate/getting-started/quickstart) and [Auth](/trustgate/concepts/auth).
+
+#### Chat and completions
+
+| Method | Path | Client format |
+|---|---|---|
+| `POST` | `/{consumer_slug}/v1/chat/completions` | OpenAI Chat Completions |
+| `POST` | `/{consumer_slug}/v1/messages` | Anthropic Messages |
+| `POST` | `/{consumer_slug}/v1/responses` | OpenAI Responses |
+| `POST` | `/{consumer_slug}/v2/chat` | Cohere Chat |
+| `POST` | `/{consumer_slug}/v1beta/models/{model}:generateContent` | Gemini generateContent |
+| `POST` | `/{consumer_slug}/v1beta/models/{model}:streamGenerateContent` | Gemini streamGenerateContent |
+
+#### Embeddings and rerank
+
+| Method | Path | Client format |
+|---|---|---|
+| `POST` | `/{consumer_slug}/v1/embeddings` | OpenAI Embeddings |
+| `POST` | `/{consumer_slug}/v1/rerank` | Cohere Rerank |
+
+#### Files
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/{consumer_slug}/v1/chat/completions` | OpenAI Chat Completions sample |
+| `GET` | `/{consumer_slug}/v1/files` | List files |
+| `POST` | `/{consumer_slug}/v1/files` | Upload file |
+| `GET` | `/{consumer_slug}/v1/files/{id}` | Get file |
+| `DELETE` | `/{consumer_slug}/v1/files/{id}` | Delete file |
+| `GET` | `/{consumer_slug}/v1/files/{id}/content` | Download file content |
 
-Other fixed proxy routes (not all expanded in OpenAPI) include Anthropic `/v1/messages` and OpenAI Responses `/v1/responses` under the consumer slug.
+#### Images
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/{consumer_slug}/v1/images/generations` | Image generation |
+| `POST` | `/{consumer_slug}/v1/images/edits` | Image edit |
+| `POST` | `/{consumer_slug}/v1/images/variations` | Image variation |
+
+#### Audio
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/{consumer_slug}/v1/audio/speech` | Text-to-speech |
+| `POST` | `/{consumer_slug}/v1/audio/transcriptions` | Speech-to-text |
+
+`/v1/audio/translations` is not supported.
+
+#### Models
+
+Gateway-local listing for the consumer (not a full upstream models passthrough). Only `GET`:
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/{consumer_slug}/v1/models` | List models allowed for this consumer |
+| `GET` | `/{consumer_slug}/v1/models/{id}` | Get one model card |
+
+These Proxy routes are not fully expanded in the Admin OpenAPI sidebar; the table above matches the TrustGate Proxy path resolver.
 
 ## Admin plane vs Proxy plane
 
@@ -165,7 +217,7 @@ Other fixed proxy routes (not all expanded in OpenAPI) include Anthropic `/v1/me
 |---|---|---|
 | Who calls it | Console, operators, automation | Your applications |
 | Auth | Admin JWT or [Authentication](/trustgate/api/credentials) | Consumer API key / OAuth (`X-AG-API-Key`, `x-api-key`, `Authorization: Bearer ag_…`) |
-| Typical paths | `/v1/gateways/...` | `/{consumer_slug}/v1/chat/completions`, MCP tools, … |
+| Typical paths | `/v1/gateways/...` | `/{consumer_slug}/v1/chat/completions`, `/v1/embeddings`, `/v1/files`, … |
 
 For client connect snippets and `model: "auto"`, use the consumer **Connect** tab or
 [Quickstart](/trustgate/getting-started/quickstart) — not the Admin plane.


### PR DESCRIPTION
…routes

Expand the Proxy section in the Admin API overview with the fixed consumer-slug paths from the path resolver.