### PR TITLE
docs(trustguard): Runtime tabs, Ask, Claude Code, rewrite overview

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -294,6 +294,7 @@
                 "group": "IDE & coding agents",
                 "pages": [
                   "trustguard/integrations/ide/claude-enterprise",
+                  "trustguard/integrations/ide/claude-code",
                   "trustguard/integrations/ide/cursor",
                   "trustguard/integrations/ide/codex"
                 ]

--- a/trustgate/mcp/claude.mdx
+++ b/trustgate/mcp/claude.mdx
@@ -57,5 +57,6 @@ Private (Hybrid) data plane: also `--header "X-AG-Gateway-Slug: <gateway-slug>"`
 
 ## Related
 
+- [TrustGuard Claude Code hooks](/trustguard/integrations/ide/claude-code)
 - [MCP overview](/trustgate/mcp/overview)
 - [Auth](/trustgate/concepts/auth)

--- a/trustguard/api/evaluate.mdx
+++ b/trustguard/api/evaluate.mdx
@@ -47,7 +47,7 @@ gateway authenticates and calls this endpoint for you.)
 | `protocol` | enum | — | `all` (default) · `llm` · `mcp` · `a2a`. Available as the `protocol` gate/rule condition. |
 | `session_id` | string | — | Conversation/correlation key. Synthesised if omitted. |
 | `consumer_id` | string | — | Actor identifier for per‑consumer policy routing. Gates match it as `consumer.id`. |
-| `attributes` | object | — | Extra dimensions for gate/detector conditions: `consumer.{name,tag,type}`, `model.{name,provider}`, `collector.type`, `source.application`. Nested form: `{ "source": { "application": "claude-code" } }`. |
+| `attributes` | object | — | Extra dimensions for gate/detector conditions: `consumer.{name,tag,type}`, `model.{name,provider}`, `collector.type`, `source.application`, `tool.{name,command,arguments}`. Nested form: `{ "source": { "application": "claude-code-plugin" } }`. For MCP `tools/call`, `tool.name` is read from **`payload.params.name` first** (last segment of `mcp__server__tool`). |
 
 Unknown top‑level fields are rejected with `400` (strict decoding). Do **not**
 send `input`, `metadata`, `collector_id`, or `detector_id` at the top level.
@@ -106,7 +106,7 @@ Always `200` for a detection — TrustGuard never drops traffic.
 
 | Field | Type | Notes |
 |---|---|---|
-| `status` | enum | The reduced verdict: `allow` · `report` · `transform` · `block`, most restrictive wins. |
+| `status` | enum | The reduced verdict: `allow` · `report` · `transform` · `ask` · `block`, most restrictive wins (`block` > `ask` > `transform` > `report` > `allow`). |
 | `transformed_payload` | object \| null | The rewritten payload; `null`/absent unless a Transform rule (mutable detector) changed it. |
 | `findings[]` | array | One entry per gate or detector that fired. |
 | `trace_id` / `request_id` | string | Correlation IDs (also on logs and telemetry). |
@@ -120,9 +120,9 @@ Always `200` for a detection — TrustGuard never drops traffic.
 | `source.plugin` | string | Detector findings — the catalog detector slug (e.g. `prompt_guard`). |
 | `source.detector_id` / `source.detector_name` | string | The detector instance that fired. |
 | `source.policy_id` | string | The policy that produced the finding. |
-| `signal.type` | string | What was detected — e.g. `jailbreak`, `injection`, `pii`, `secret`, `keyreg`, `nt_topic`, a toxicity category, or `gate_block` / `gate_report`. Note: `code_injection` is a **signal** produced by the (hidden) `code_sanitation` detector — not a separate catalog plugin you configure. |
+| `signal.type` | string | What was detected — e.g. `jailbreak`, `injection`, `pii`, `secret`, `keyreg`, `nt_topic`, a toxicity category, or `gate_block` / `gate_report` / `gate_ask`. Note: `code_injection` is a **signal** produced by the (hidden) `code_sanitation` detector — not a separate catalog plugin you configure. |
 | `signal.confidence` | number | Detector‑specific score in `[0, 1]` (optional). |
-| `outcome.action` | enum | `report`, `transform`, or `block` — the action the rule applied (optional on observational runs). |
+| `outcome.action` | enum | `report`, `transform`, `ask`, or `block` — the action the rule applied (optional on observational runs). |
 | `evidence` | object | Free‑form, detector‑specific context (e.g. matched entities, masked count, matched rule). |
 
 ## Status codes
@@ -143,6 +143,7 @@ TrustGuard is advisory. Your collector inspects the `status` and decides:
 
 ```text
 status == "block"                    → block / 4xx the original request
+status == "ask"                      → IDE permission prompt (input only)
 status == "transform"                → forward transformed_payload instead
 status == "report"                   → forward unchanged, record the finding
 status == "allow"                    → forward unchanged

--- a/trustguard/concepts/collectors.mdx
+++ b/trustguard/concepts/collectors.mdx
@@ -9,8 +9,23 @@ browser extension, an IDE plugin, or an edge/WAF worker — that calls
 [`POST /v1/evaluate`](/trustguard/api/evaluate) (or the Claude dialect) on every
 request it wants inspected.
 
-You create and manage collectors in the console's **Collectors** screen. Each
-collector owns:
+You create and manage collectors under **Runtime → Collectors**. The page has two
+tabs:
+
+| Tab | What it is |
+|---|---|
+| **Collectors** | Installed taps and their policy counts. |
+| **Catalog** | Providers grouped as Gateway, Application, **IDE & coding agents**, Browser, WAF. **Add collector** opens the create flow. |
+
+Opening a collector is a side panel with:
+
+| Tab | What it is |
+|---|---|
+| **Connection** | Provider instructions and snippet. Claude Enterprise also has Inference Hook URL + `whsec_`. |
+| **Auth** | Collector API keys (`tgk_…`). Shown **once** at creation. TrustGate collectors skip this. |
+| **Policies** | Default policy and per‑consumer overrides. |
+
+Each collector owns:
 
 1. **Authentication** — [TrustGate](/trustguard/integrations/gateway/trustgate) is
    native (no customer API key; the gateway authenticates via the platform). Other
@@ -26,18 +41,16 @@ integration determines the setup snippet you get and where enforcement happens.
 | Group | Examples | Where it runs |
 |---|---|---|
 | **Gateway** | [TrustGate](/trustguard/integrations/gateway/trustgate), [Portkey](/trustguard/integrations/gateway/portkey), [LiteLLM](/trustguard/integrations/gateway/litellm), [Kong](/trustguard/integrations/gateway/kong), [Apigee](/trustguard/integrations/gateway/apigee), [Azure APIM](/trustguard/integrations/gateway/azure-apim) | AI gateway path |
-| **IDE & coding agents** | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise), [Cursor](/trustguard/integrations/ide/cursor), [Codex](/trustguard/integrations/ide/codex) | Developer machines / Anthropic org hooks |
+| **IDE & coding agents** | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise), [Claude Code](/trustguard/integrations/ide/claude-code), [Cursor](/trustguard/integrations/ide/cursor), [Codex](/trustguard/integrations/ide/codex) | Org Inference Hooks / developer-machine plugins |
 | **Application** | [Python](/trustguard/integrations/application/python-sdk), [Node](/trustguard/integrations/application/node-sdk), [REST](/trustguard/integrations/application/rest), [Python middleware](/trustguard/integrations/application/python-middleware), [Node middleware](/trustguard/integrations/application/node-middleware) | Around model calls |
 | **Browser** | [Chrome](/trustguard/integrations/browser/chrome), [Edge](/trustguard/integrations/browser/edge), [Firefox](/trustguard/integrations/browser/firefox) | AI web apps |
 | **WAF / Edge** | [Cloudflare](/trustguard/integrations/edge-waf/cloudflare), [CloudFront](/trustguard/integrations/edge-waf/aws-cloudfront), [Fastly](/trustguard/integrations/edge-waf/fastly), [Akamai](/trustguard/integrations/edge-waf/akamai) | CDN edge |
 
 See [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise) (`POST /v1/evaluate/claude`),
-[Cursor](/trustguard/integrations/ide/cursor), and [Codex](/trustguard/integrations/ide/codex)
-(`POST /v1/evaluate` with a shared org API key).
+and [Claude Code](/trustguard/integrations/ide/claude-code), [Cursor](/trustguard/integrations/ide/cursor),
+[Codex](/trustguard/integrations/ide/codex) (`POST /v1/evaluate` with a `tgk_…` key).
 
-When you create or open a collector, the side panel shows step‑by‑step
-instructions and a ready‑to‑paste snippet for the chosen integration. See
-[Integrations](/trustguard/integrations/overview) for all of them.
+See [Integrations](/trustguard/integrations/overview) for every provider.
 
 <Note>
 **TrustGate is native.** Bind a TrustGate collector to the gateway, assign a
@@ -95,6 +108,7 @@ Each integration should send, when available:
 - **`attributes`** — optional context (`consumer.name`, `consumer.tag`,
   `consumer.type`, `model.name`, `model.provider`, `collector.type`,
   `source.application`) that gates and detector rules can match on.
+  MCP **`tool.name`** is taken from `payload.params.name`, not from attributes.
 
 These attribute findings to the right user and session in the **Activity** view
 and power the stateful detectors. Every integration snippet shows the natural

--- a/trustguard/concepts/detectors.mdx
+++ b/trustguard/concepts/detectors.mdx
@@ -66,7 +66,7 @@ detector from a [policy](/trustguard/concepts/policies):
 3. Add a rule that selects the detector and an **action** — **Monitor**
    (record a finding only), **Block**, or **Transform** (mutable detectors).
 4. Optionally add **conditions** so the rule only runs for certain consumers,
-   models, collectors, protocols, or sessions.
+   models, collectors, protocols, sessions, directions, or tools.
 
 Then attach the policy to a [collector](/trustguard/concepts/collectors) so its
 traffic is evaluated.

--- a/trustguard/concepts/policies.mdx
+++ b/trustguard/concepts/policies.mdx
@@ -143,7 +143,7 @@ Test does not emit **Activity** and does not consume the `/v1/evaluate` plan rat
 
 ## History
 
-Created / updated / deleted events for the policy, gates, detector rules, and collector routing.
+Created / updated / deleted events for the policy, its gates, detector rules, and collector routing.
 
 ## Collectors tab
 

--- a/trustguard/concepts/policies.mdx
+++ b/trustguard/concepts/policies.mdx
@@ -1,152 +1,156 @@
 ---
 title: "Policies"
-description: "A policy is where enforcement lives: gates that match request attributes before detection, detector rules that run detectors and decide the action, and a policy-wide Report/Enforce switch."
+description: "A policy is where enforcement lives: gates that match request attributes before detection, detector rules that run detectors and decide the action, and a policy-wide Observe/Enforce switch."
 ---
 
 A **policy** turns detection into a decision. [Detectors](/trustguard/concepts/detectors)
 say *what* is in the traffic; a policy says *what to do about it*. You build
-policies in the console's **Policies** screen, then attach them to
+policies under **Runtime → Policies**, then attach them to
 [collectors](/trustguard/concepts/collectors).
 
-A policy has five tabs: **Gates**, **Detectors**, **Collectors**, **Test**, and
-**History** — plus a policy-wide **Enforcement mode**.
+Opening a policy opens a side panel with six tabs:
 
-## Enforcement mode — Report vs Enforce
-
-A single switch controls whether the policy can act:
-
-| Mode | Effect |
+| Tab | What it is |
 |---|---|
-| **Report** | Every gate and detector action is downgraded to a non-blocking record. Nothing is blocked or transformed. Use it to measure signal and false positives before turning on enforcement. |
-| **Enforce** | Actions apply as configured — gates can block, detector rules can block or transform. |
+| **Basics** | Name and **Enforcement mode**. |
+| **Gates** | Attribute matchers that run *before* detectors. |
+| **Detectors** | Detector rules, split by **Input** / **Output**. |
+| **Collectors** | Which collectors send traffic here, and how. |
+| **Test** | Sandbox against the **last saved** policy. |
+| **History** | Change log for the policy, gates, detector rules, and routing. |
 
-Report mode maps to the API's `report_only` flag. A typical rollout runs a new
-policy in **Report** first, reviews findings, then flips to **Enforce**.
+The list columns **Gates**, **Detectors**, and **Collectors** count what’s on those tabs. **Mode** is Observe or Enforcing.
 
-## Gates: match before you detect
+## Enforcement mode — Observe vs Enforce
 
-**Gates** are evaluated **before** any detector runs. A gate matches on request
-**attributes** (not content) and takes an action. Because they run first, gates
-are how you cheaply allow, block, or waive traffic without spending detection.
+The switch is on **Basics** (and in the panel header):
 
-Each gate is a set of **conditions** joined by **And**/**Or**, and a **Then**
-action:
+| Console | API | Effect |
+|---|---|---|
+| **Observe** | `report_only: true` | Every gate and detector action is recorded only. Nothing is blocked, asked, or transformed. |
+| **Enforce** | `report_only: false` | Actions apply as configured. |
 
-| Gate action | Effect |
+Run a new policy in **Observe**, check **Activity** and **Test**, then switch to **Enforce**.
+
+## Gates
+
+**Gates** match request **attributes** (not prompt text) and run **before** any detector.
+
+Each gate is a name, **And**/**Or** conditions, and a **Then** action:
+
+| Action | Effect |
 |---|---|
-| **Block** | Block the request immediately; **detectors are skipped**. (In Report mode this is recorded, not enforced.) |
+| **Block** | Stop immediately; **detectors are skipped**. In Observe this is recorded, not enforced. |
 | **Report** | Record a finding and continue to detection. |
-| **Skip** | Stop gate evaluation and proceed to detectors — no finding. Use it to waive specific traffic. |
+| **Skip** | Stop remaining gates and go to detectors — no finding. Use it to waive traffic. |
+| **Ask** | Ask the user to confirm in the IDE. **Input only** (missing `direction` counts as input). On **output** the gate does not match. Detectors are skipped. |
 
-All gates are evaluated and the **most restrictive** outcome wins; if any gate
-blocks, the request is blocked and detection is skipped.
+Block, Skip, and Ask end the gate chain. Report continues. If any matching gate **Blocks**, detection does not run.
+
+IDE plugins map **Ask** to a permission prompt. The copy is always
+`A TrustGuard policy needs your approval to continue.` — not the gate name.
+[Codex](/trustguard/integrations/ide/codex) has no Ask dialog; it allows the call
+and injects that sentence as extra context.
 
 ### Condition attributes
 
-Conditions target these request attributes:
-
-| Group | Attributes |
+| Group (console) | Attributes |
 |---|---|
 | **Consumer** | `consumer.id`, `consumer.name`, `consumer.tag`, `consumer.type` |
 | **Model** | `model.name`, `model.provider` |
 | **Collector** | `collector.id`, `collector.type` |
 | **Source** | `source.application` |
 | **Session** | `session.id` |
-| **Protocol** | `protocol` |
+| **Protocol** | `protocol` (`llm` / `mcp` / `a2a`; API also accepts `all`) |
+| **Direction** | `direction` (`input` / `output`) |
+| **Tool** | `tool.name`, `tool.command`, `tool.arguments` |
 
-**Operators:** Equals (`eq`), Not equals (`neq`), Greater than (`gt`), Less than
-(`lt`), Contains (`contains`), Does not contain (`not_contains`), In (`in` — a
-comma‑separated list), Matches (`match` — a regular expression).
+**Operators:** Equals, Not equals, Greater than, Less than, Contains, Does not contain, In (list), Matches (regex).
 
 `consumer.*`, `model.*`, `collector.type`, and `source.application` come from
-the request `attributes` object (or are stamped by a dialect such as the
-[Claude Enterprise](/trustguard/integrations/ide/claude-enterprise) inference
-hook). `collector.id`, `session.id`, and `protocol` are resolved by TrustGuard.
+the request `attributes` object, or are stamped by an integration.
+`collector.id`, `session.id`, `protocol`, and `direction` are resolved by
+TrustGuard.
 
-#### Example: Claude surface
+**`tool.name`** for MCP `tools/call` is read from **`payload.params.name`**, not
+from `attributes.tool`. Hosts that expose tools as `mcp__<server>__<tool>` send
+the last segment (`search_threads`). Gate on that short name.
+`tool.command` is the shell line for Bash / Shell.
 
-One Claude Enterprise collector covers chat and Claude Code. Stamp differs by
-`source.application` (`claude-ai`, `claude-code`, …). Gate on it to apply a
-stricter action only on Code:
+Do not put `name` inside `{ "input": "…" }` when `protocol` is `all` — that
+body is rejected (`400`).
 
-| Condition | Then |
+#### `source.application` (Claude)
+
+| Value | Path |
 |---|---|
-| `source.application` **eq** `claude-code` | **Block** (or **Report**) |
-| (no match) | Continue to detectors |
+| `claude-ai` | [Inference Hooks](/trustguard/integrations/ide/claude-enterprise) — claude.ai chat |
+| `claude-code` | Inference Hooks — Claude Code (org hook, not the laptop plugin) |
+| `claude-code-plugin` | [Claude Code plugin](/trustguard/integrations/ide/claude-code) — local lifecycle hooks |
+| `cursor-plugin` | [Cursor plugin](/trustguard/integrations/ide/cursor) |
+| `config-test` | Anthropic **Test connection** |
 
-Or waive chat-only traffic: `source.application` **eq** `claude-ai` → **Skip**.
+A gate on `claude-code` does **not** match the laptop plugin (`claude-code-plugin`).
 
-## Detectors — run detectors and decide the action
+## Detectors
 
-The policy's **Detectors** tab holds its detector rules, split by **evaluation
-phase**:
+The **Detectors** tab is split by **evaluation phase**:
 
-- **Input** — evaluate the prompt/request.
-- **Output** — evaluate the completion/response.
+- **Input** — prompt / tool call.
+- **Output** — completion / tool result.
 
-At runtime TrustGuard only runs the rules for the phase that matches the
-request's **`direction`** (`input` or `output`). The phase you configure here
-and the `direction` on each `/v1/evaluate` call must line up — otherwise those
-detectors never fire.
+TrustGuard only runs the phase that matches the request `direction`. If the
+caller never sends `output`, Output rules never run.
 
 <Note>
 **Who sets `direction`?**
 
-- **[TrustGate](/trustguard/integrations/gateway/trustgate)** sets it for you (`input` on
+- **[TrustGate](/trustguard/integrations/gateway/trustgate)** sets it (`input` on
   the request path, `output` on the response path).
-- **Any other collector** (SDK, REST, browser, edge/WAF) must send `direction`
-  explicitly on each call — typically **two** evaluates per turn (prompt then
-  completion). Omitting it defaults to `input`, so Output-phase rules never run.
-
-See the [Python SDK](/trustguard/integrations/application/python-sdk) or [REST](/trustguard/integrations/application/rest) for SDK/REST
-examples, [Integrations overview](/trustguard/integrations/overview) for the
-shared call shape, and [How it works](/trustguard/how-it-works) for how rules are
-filtered by direction.
+- **IDE plugins** set it per hook (prompt and `preToolUse` → input; `postToolUse` → output).
+- **SDK / REST / browser / edge** must send it on every call. Omitting it defaults to `input`.
 </Note>
 
-Each rule references one [detector](/trustguard/concepts/detectors), an
-**action**, and optional **conditions** (same attribute model as gates):
+Each rule picks a [detector](/trustguard/concepts/detectors), an **action**, and
+optional **conditions** (same attributes as gates):
 
-| Action | Console label | Effect | Rewrites payload |
+| Action | Console | Effect | Rewrites payload |
 |---|---|---|---|
 | `report` | **Monitor** | Record a finding only. | — |
-| `block` | **Block** | Flag the request for blocking; stops the remaining detector chain. | — |
-| `transform` | **Transform** | Mask/rewrite the payload. Only valid for a **mutable** detector (`data_loss_prevention`). | ✅ |
-
-All matching rules for the phase are evaluated. A **`block`** finding **cuts
-the detection chain** — the remaining detector rules in that phase are
-skipped. Otherwise, the completed rules reduce to the **most restrictive**
-action.
+| `block` | **Block** | Flag for blocking; stops the remaining detector chain. | — |
+| `transform` | **Transform** | Mask/rewrite. Only valid for **`data_loss_prevention`**. | Yes |
 
 ## Verdict precedence
 
-TrustGuard reduces everything that fired into one top‑level `status`, from most
-to least restrictive:
-
 ```text
-block  →  transform  →  report  →  allow
+block  →  ask  →  transform  →  report  →  allow
 ```
 
-`allow` means nothing fired (or everything was waived). The caller enforces the
-verdict — see the [Evaluate API](/trustguard/api/evaluate).
+`allow` means nothing fired, or everything was waived. The caller enforces the
+verdict — see the [Evaluate API](/trustguard/api/evaluate). In **Observe**, the
+status never goes past `report`.
 
-## Test and History
+## Test
 
-- **Test** runs a sample input or output through the **last saved** version of
-  the policy and shows the decision (Blocked / Transformed / Reported / Allowed)
-  and every finding — without touching production or emitting telemetry.
-- **History** is the policy's change log: created/updated/deleted events for the
-  policy, its gates, its detector rules, and collector routing.
+**Test** evaluates the **saved** policy (unsaved Gates/Detectors do not apply).
 
-## Routing: attaching policies to collectors
+1. **Test direction** — Input or Output (must match the Detectors phase you care about).
+2. **Sample** — paste text, pick a preset, or **Upload file** (forces protocol **LLM**).
+3. **Extra parameters** — same attributes as Gates. Skip, Block, and Ask only match when these are set (for example **Tool name** = `search_threads`, or **Source application** = `claude-code-plugin`).
+4. **Run test** — Decision is Blocked / Transformed / Reported / Allowed, plus findings.
 
-A policy runs when a [collector](/trustguard/concepts/collectors) routes traffic
-to it. On the policy's **Collectors** tab you attach collectors with a routing
-mode:
+Test does not emit **Activity** and does not consume the `/v1/evaluate` plan rate limit.
 
-- **Default** — the collector's fallback policy for all its traffic.
-- **Consumer ID** — the policy only applies to requests from a specific
-  consumer, letting one collector send different consumers to different policies.
+## History
 
-If a collector has no policy for a request, that request is **unguarded** (no
-gates, no detectors) and returns `status: "allow"` with no findings.
+Created / updated / deleted events for the policy, gates, detector rules, and collector routing.
+
+## Collectors tab
+
+Attach collectors with a routing mode:
+
+- **Default** — fallback for all of that collector’s traffic.
+- **Consumer ID** — only requests with that `consumer_id`.
+
+You can also bind routing from the collector’s **Policies** tab. A collector
+with no matching policy leaves that request **unguarded** (`status: "allow"`, no findings).

--- a/trustguard/how-it-works.mdx
+++ b/trustguard/how-it-works.mdx
@@ -25,22 +25,23 @@ TrustGuard picks the [policy](/trustguard/concepts/policies) for this request:
 
 If the collector has no matching policy, the request is **unguarded**: TrustGuard
 returns `status: "allow"` with no findings. The policy's **Enforcement mode**
-(Report vs Enforce) is read here — in **Report** mode every action below is
+(Observe vs Enforce) is read here — in **Observe** every action below is
 downgraded to a non‑blocking record.
 
 ## 3. Run gates
 
-[Gates](/trustguard/concepts/policies#gates-match-before-you-detect) are
-evaluated **before** any detector. Each gate matches request **attributes**
-(consumer, model, collector, protocol, session) and takes an action:
+[Gates](/trustguard/concepts/policies#gates) are evaluated **before** any
+detector. Each gate matches request **attributes** (consumer, model, collector,
+protocol, direction, tool, session, source) and takes an action:
 
 | Gate action | Effect |
 |---|---|
-| **Block** | The request is blocked and **detectors are skipped**. Returns `status: "block"`. |
+| **Block** | Detectors skipped. Returns `status: "block"`. |
 | **Report** | Records a finding and continues to detection. |
-| **Skip** | Stops gate evaluation and proceeds to detection — no finding. |
+| **Skip** | Stops remaining gates and proceeds to detection — no finding. |
+| **Ask** | Detectors skipped. Returns `status: "ask"`. Matches **input** only (empty `direction` counts as input); ignored on output. |
 
-All gates are evaluated and the most restrictive outcome wins.
+Block, Skip, and Ask end the gate chain. Report continues.
 
 ## 4. Run the detector rules
 
@@ -75,10 +76,10 @@ Everything that fired is reduced to one top‑level `status`, most to least
 restrictive:
 
 ```text
-block  →  transform  →  report  →  allow
+block  →  ask  →  transform  →  report  →  allow
 ```
 
-In **Report** mode, blocks and transforms are downgraded, so the status never
+In **Observe**, blocks, asks, and transforms are downgraded, so the status never
 exceeds `report`.
 
 ## 6. The response
@@ -102,7 +103,7 @@ exceeds `report`.
 
 | Field | Meaning |
 |---|---|
-| `status` | `allow` · `report` · `transform` · `block` — the reduced verdict. Advisory: the caller enforces. |
+| `status` | `allow` · `report` · `transform` · `ask` · `block` — the reduced verdict. Advisory: the caller enforces. |
 | `transformed_payload` | The rewritten payload, or absent/`null` if no Transform rule changed anything. |
 | `findings[]` | One entry per gate or detector that fired. See the [Evaluate API](/trustguard/api/evaluate) for the full shape. |
 | `trace_id` / `request_id` | Correlation IDs propagated through logs and telemetry. |

--- a/trustguard/integrations/ide/claude-code.mdx
+++ b/trustguard/integrations/ide/claude-code.mdx
@@ -1,0 +1,143 @@
+---
+title: "Claude Code"
+description: "Local TrustGuard lifecycle hooks on Claude Code — plugin, binary, and collector key. TrustGate MCP stays on org Connectors."
+---
+
+The [TrustGuard Claude Code plugin](https://github.com/NeuralTrust/trustguard-claude-code-plugin)
+adds **lifecycle hooks** on the developer machine. It calls
+[`POST /v1/evaluate`](/trustguard/api/evaluate) with a collector `tgk_…` key.
+
+This is **not** [Claude Enterprise Inference Hooks](/trustguard/integrations/ide/claude-enterprise)
+(`POST /v1/evaluate/claude`, `source.application = claude-code`). The plugin stamps
+`source.application = claude-code-plugin`. Gate the two paths separately.
+
+**TrustGate MCP is not this plugin.** Org-wide MCP (claude.ai, Desktop, Cowork,
+Claude Code) is an [organization connector](/trustgate/mcp/claude). Do not put
+the collector `tgk_…` on the connector, and do not put the MCP URL in the
+plugin (`pluginConfigs` / `mcpServers`).
+
+## Three pieces
+
+Hooks fire only when all three are present:
+
+| Piece | What | If missing |
+|---|---|---|
+| **Plugin** `trustguard@neuraltrust` | Registers `hooks.json` | Claude Code never calls bootstrap |
+| **Binary** `trustguard-claude-code` | Kandji `/Library/Application Support/TrustGuard/bin/` or `~/.trustguard/bin` | Bootstrap fail-opens (`{}`) |
+| **Collector key** `tgk_…` | `claude-code.json` | Binary runs and **allows without evaluate** |
+
+`claude plugin list` showing the plugin **installed** is not enough. **Status
+must be enabled.** `Scope: managed` only means the marketplace installed it.
+
+## Console setup
+
+1. **Runtime → Collectors → Catalog → IDE & coding agents → Claude Code** (or the Claude Code collector type your workspace lists).
+2. **Auth** — mint a `tgk_…` key (shown once).
+3. **Policies** — assign a default [policy](/trustguard/concepts/policies). Gate **Ask** / **Block** on `source.application` **eq** `claude-code-plugin` if this collector also receives other traffic.
+
+## Enable the plugin
+
+Server-managed settings (claude.ai **Admin → Claude Code → Managed settings**) or
+`/Library/Application Support/ClaudeCode/managed-settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "neuraltrust": {
+      "source": {
+        "source": "github",
+        "repo": "NeuralTrust/trustguard-claude-code-plugin"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "trustguard@neuraltrust": true
+  }
+}
+```
+
+No `pluginConfigs`. No MCP URL.
+
+`enabledPlugins: true` in the admin JSON does **not** always flip the CLI to
+enabled. Claude Code skips server-managed settings when
+`ANTHROPIC_BASE_URL` or `CLAUDE_CODE_USE_*` is set (including a TrustGate LLM
+proxy). In that case deploy the **file** path above (Kandji:
+`TRUSTGUARD_DEPLOY_CLAUDE_MANAGED_SETTINGS=1`).
+
+Check on the laptop:
+
+```bash
+# Inside `claude`: /status  →  Enterprise managed settings: remote  (or file)
+claude plugin list          # Status: enabled
+claude plugin enable trustguard@neuraltrust   # if still disabled
+```
+
+Then start a **new** Claude Code session so `hooks.json` loads.
+
+## Collector config + binary (MDM)
+
+```json
+{
+  "data_url": "https://<your-trustguard-host>",
+  "api_key": "tgk_…",
+  "fail_mode": "open"
+}
+```
+
+| OS | Config | Binary (optional pin) |
+|---|---|---|
+| macOS | `/Library/Application Support/TrustGuard/claude-code.json` | `…/TrustGuard/bin/trustguard-claude-code` |
+| Linux | `/etc/trustguard/claude-code.json` | `~/.trustguard/bin/` |
+| Windows | `%ProgramData%\TrustGuard\claude-code.json` | `%ProgramData%\TrustGuard\bin\` |
+
+If the managed file has `api_key`, that key, `data_url`, and `fail_mode` are
+locked. Missing `~/.trustguard/bin` is fine when the MDM binary exists.
+
+Private GitHub repo: bootstrap `curl` of Releases **404s** without a token
+(fail-open). Kandji install can set `TRUSTGUARD_GITHUB_TOKEN` and pin the
+release version.
+
+`fail_mode: open` + an empty hook body `{}` means **allow**. That is also the
+response when evaluate returns `allow`.
+
+## What is evaluated
+
+| Claude Code event | Protocol | Direction | Notes |
+|---|---|---|---|
+| `UserPromptSubmit` | `llm` | input | Block / Ask on the prompt |
+| `PreToolUse` (`Bash` / `Shell`) | `all` (`{ "input": "<command>" }`) | input | `tool.command` is the line; `tool.name` is `Bash` |
+| `PreToolUse` (MCP and other tools) | `mcp` `tools/call` | input | `tool.name` = `payload.params.name` (last segment of `mcp__server__tool`) |
+| `PostToolUse` | `mcp` result | output | Ask gates do not match |
+
+Ask on PreToolUse shows Claude Code’s permission dialog. The **subtitle** is
+the generic TrustGuard sentence above. The **title** (tool name) is Claude
+Code’s; the plugin cannot change it.
+
+## Verify
+
+```bash
+ls -l "/Library/Application Support/TrustGuard/bin/trustguard-claude-code"
+cat "/Library/Application Support/TrustGuard/claude-code.json"   # data_url + tgk_ prefix only
+
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo hi"},"session_id":"pilot"}' \
+  | trustguard-claude-code hook
+```
+
+A manual probe that shows up in **Activity** with
+`source.application = claude-code-plugin` means the binary and key work. If
+Claude Code still never evaluates, the plugin is disabled or hooks did not
+reload.
+
+Remote SSH / WSL: hooks run on the **remote** host. A Kandji binary on the Mac
+does not cover that session.
+
+claude.ai / Desktop: no lifecycle hooks. Use Inference Hooks and/or org
+Connectors, not this plugin.
+
+## Related
+
+- [Claude Enterprise (Inference Hooks)](/trustguard/integrations/ide/claude-enterprise)
+- [Policies — Gates](/trustguard/concepts/policies#gates)
+- [Evaluate API](/trustguard/api/evaluate)
+- [Plugin repo](https://github.com/NeuralTrust/trustguard-claude-code-plugin)

--- a/trustguard/integrations/ide/claude-enterprise.mdx
+++ b/trustguard/integrations/ide/claude-enterprise.mdx
@@ -7,6 +7,11 @@ One Anthropic organization endpoint maps to **one** TrustGuard collector. Claude
 Claude Code, and Claude Cowork share that hook; TrustGuard stamps
 `source.application` so policies can target a surface without separate collectors.
 
+This path does **not** install Claude Code lifecycle hooks. For laptop hooks
+(`source.application = claude-code-plugin`), see
+[Claude Code](/trustguard/integrations/ide/claude-code). Do not put this
+collector's `tgk_…` on a TrustGate MCP connector.
+
 ## Setup
 
 1. In TrustGuard, create a **Claude Enterprise** collector (Catalog → IDE & coding agents).
@@ -29,7 +34,8 @@ Anthropic → POST /v1/evaluate/claude
 ```
 
 This is **not** the generic [`POST /v1/evaluate`](/trustguard/api/evaluate) path. The
-Claude dialect returns only **allow** or **deny**. Failures degrade to allow so a
+Claude dialect returns only **allow** or **deny**. **Ask** is not a permission
+prompt here (no IDE dialog) — it degrades to allow. Failures degrade to allow so a
 TrustGuard outage does not block the org’s Claude usage.
 
 ## Surfaces
@@ -47,7 +53,7 @@ on every delivery. Unknown values are accepted as-is (open string).
 ## Policy gates per surface
 
 Keep **one** collector and **one** default policy. Differentiate with a
-[gate](/trustguard/concepts/policies#gates-match-before-you-detect) on
+[gate](/trustguard/concepts/policies#gates) on
 `source.application` (Policies → **Gates** → attribute **Source application**):
 
 | Goal | Condition | Then |
@@ -56,9 +62,11 @@ Keep **one** collector and **one** default policy. Differentiate with a
 | Waive chat (detectors still run after Skip) | `source.application` **eq** `claude-ai` | **Skip** |
 | Several products | `source.application` **in** `claude-code,cowork-when-emitted` | **Block** |
 
-Gates run **before** detectors. In **Report** policy mode, Block is recorded
-only. Test the condition on the policy **Test** tab with
-`source.application = claude-code` (or the surface you care about).
+Gates run **before** detectors. In **Observe** policy mode, Block is recorded
+only. Test the condition on the policy **Test** tab with Extra parameter
+**Source application** = `claude-code` (or the surface you care about).
+A gate on `claude-code` does **not** match the [laptop plugin](/trustguard/integrations/ide/claude-code)
+(`claude-code-plugin`).
 
 Also available on the same hook deliveries: `collector.type` =
 `anthropic_inference_hook`, `model.provider` = `anthropic`, `consumer.id` from
@@ -66,6 +74,7 @@ the actor email/id.
 
 ## Related
 
-- [Policies — Gates](/trustguard/concepts/policies#gates-match-before-you-detect)
+- [Claude Code plugin (local hooks)](/trustguard/integrations/ide/claude-code)
+- [Policies — Gates](/trustguard/concepts/policies#gates)
 - [Collectors](/trustguard/concepts/collectors)
 - [Evaluate API](/trustguard/api/evaluate)

--- a/trustguard/integrations/ide/codex.mdx
+++ b/trustguard/integrations/ide/codex.mdx
@@ -90,7 +90,7 @@ allow_managed_hooks_only = true
 
 [hooks]
 managed_dir = "/Library/Application Support/TrustGuard/codex-hooks"
-windows_managed_dir = 'C:\ProgramData\TrustGuard\codex-hooks'
+windows_managed_dir = 'C:\\ProgramData\\TrustGuard\\codex-hooks'
 
 [[hooks.UserPromptSubmit]]
 [[hooks.UserPromptSubmit.hooks]]
@@ -109,6 +109,11 @@ in the plugin repo. Exact keys can vary by Codex version — confirm against
 
 With `allow_managed_hooks_only = true`, developers cannot disable managed hooks from
 `/hooks`.
+
+Codex has **no Ask permission dialog**. A gate **Ask** (and transform-as-ask)
+becomes **allow** plus `additionalContext`:
+`A TrustGuard policy needs your approval to continue.` Use **Block** when you
+need a hard stop.
 
 ## Verify
 
@@ -131,16 +136,20 @@ echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command"
 | --- | --- | --- | --- |
 | `UserPromptSubmit` | `llm` | input | Block with `decision: "block"` |
 | `PreToolUse` (`Bash` / `apply_patch`) | `all` | input | Deny with `permissionDecision: "deny"` |
-| `PreToolUse` (MCP / other tools) | `mcp` tools/call | input | Same deny shape |
+| `PreToolUse` (MCP / other tools) | `mcp` tools/call | input | `params.name` = last MCP segment |
 | `PostToolUse` | `mcp` result | output | `decision: "block"` replaces the tool result for the model |
 
 ## Attributes
 
 - `attributes.collector.type = "ide"`
+- `attributes.source.application = "codex-plugin"`
 - `attributes.codex.event`, cwd, model, turn
 - `consumer_id` prefixed `codex:` (email from payload when present, else configured / OS fallback)
+
+Gate on `tool.name` from `payload.params.name` for MCP. Ask is context-only (see above).
 
 ## Related
 
 - [Plugin README](https://github.com/NeuralTrust/trustguard-codex-plugin)
+- [Policies — Gates](/trustguard/concepts/policies#gates)
 - [Evaluate API](/trustguard/api/evaluate)

--- a/trustguard/integrations/ide/codex.mdx
+++ b/trustguard/integrations/ide/codex.mdx
@@ -90,7 +90,7 @@ allow_managed_hooks_only = true
 
 [hooks]
 managed_dir = "/Library/Application Support/TrustGuard/codex-hooks"
-windows_managed_dir = 'C:\\ProgramData\\TrustGuard\\codex-hooks'
+windows_managed_dir = 'C:\ProgramData\TrustGuard\codex-hooks'
 
 [[hooks.UserPromptSubmit]]
 [[hooks.UserPromptSubmit.hooks]]

--- a/trustguard/integrations/ide/cursor.mdx
+++ b/trustguard/integrations/ide/cursor.mdx
@@ -108,6 +108,11 @@ OAuth consumers need only the URL — Cursor runs the login flow on first tool u
 Team admins can set variables once for Team Marketplace installs.
 
 MCP tool calls still pass through TrustGuard hooks (`preToolUse` / `postToolUse`).
+`tool.name` is `payload.params.name`: for Cursor’s `mcp__<server>__<tool>` that is
+the last segment. Gate on that short name, not the full hook `tool_name`.
+
+Ask on `preToolUse` shows Cursor’s permission dialog with
+`A TrustGuard policy needs your approval to continue.` (not the gate name).
 
 ## Verify
 
@@ -134,20 +139,24 @@ echo '{"hook_event_name":"preToolUse","tool_name":"Shell","tool_input":{"command
 | Cursor hook | TrustGuard |
 | --- | --- |
 | `beforeSubmitPrompt` | `protocol: llm`, `direction: input` |
-| `preToolUse` (Shell) | `protocol: all`, `direction: input` |
-| `preToolUse` (other tools, including TrustGate MCP) | `protocol: mcp`, tools/call |
-| `postToolUse` | `protocol: mcp`, tool result / output |
+| `preToolUse` (Shell) | `protocol: all`, `{ "input": "<command>" }`, `direction: input` |
+| `preToolUse` (other tools, including TrustGate MCP) | `protocol: mcp`, `tools/call` (`params.name` = last MCP segment) |
+| `postToolUse` | `protocol: mcp`, tool result, `direction: output` |
 
 ## Attributes
 
 - `attributes.collector.type = "ide"`
+- `attributes.source.application = "cursor-plugin"`
 - `attributes.cursor.event`, workspace, and related fields
 - `consumer_id` typically `cursor:<email>`
 
-Gate policies on `collector.type` and/or `cursor.*` as needed.
+Gate on `source.application` and/or `tool.name` / `tool.command`. Do not rely on
+`attributes.tool` for MCP `preToolUse` — the name is on the payload.
 
 ## Related
 
 - [Plugin README](https://github.com/NeuralTrust/trustguard-cursor-plugin)
+- [Policies — Gates](/trustguard/concepts/policies#gates)
 - [Evaluate API](/trustguard/api/evaluate)
+- [TrustGate MCP in Cursor](/trustgate/mcp/cursor)
 - [TrustGate auth](/trustgate/concepts/auth)

--- a/trustguard/integrations/overview.mdx
+++ b/trustguard/integrations/overview.mdx
@@ -23,8 +23,9 @@ collector side panel has the steps and snippet for the integration you pick.
 | | |
 | --- | --- |
 | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise) | Inference Hooks → `/v1/evaluate/claude` |
-| [Cursor](/trustguard/integrations/ide/cursor) | Plugin from GitHub · MDM config only → `/v1/evaluate` |
-| [Codex](/trustguard/integrations/ide/codex) | Plugin from GitHub · MDM config only → `/v1/evaluate` |
+| [Claude Code](/trustguard/integrations/ide/claude-code) | Plugin + MDM binary/`tgk_…` → `/v1/evaluate` |
+| [Cursor](/trustguard/integrations/ide/cursor) | Plugin from GitHub · MDM config → `/v1/evaluate` |
+| [Codex](/trustguard/integrations/ide/codex) | Plugin from GitHub · MDM hooks + config → `/v1/evaluate` |
 
 ## Application
 
@@ -70,7 +71,7 @@ Content-Type: application/json
 ```
 
 ```text
-block → deny · transform → forward transformed_payload · else → forward
+block → deny · ask → IDE prompt · transform → forward transformed_payload · else → forward
 ```
 
 Call with `direction: "input"` before the model and `"output"` after, unless TrustGate

--- a/trustguard/overview.mdx
+++ b/trustguard/overview.mdx
@@ -45,7 +45,7 @@ TrustGuard has four building blocks. You compose them once, then send traffic.
 | Concept | What it is |
 |---|---|
 | **[Detector](/trustguard/concepts/detectors)** | A reusable, named detection you create from the [catalog](/trustguard/detectors/overview) — a catalog detector (e.g. `prompt_guard`, `data_loss_prevention`) plus its `settings` (thresholds, entity lists, …). Detection‑only — it decides *what* it finds, not what to do. |
-| **[Policy](/trustguard/concepts/policies)** | Where enforcement lives: **gates** (match request attributes before detection) + **detector rules** (run detectors with a Monitor / Block / Transform action), plus a **Report / Enforce** switch. |
+| **[Policy](/trustguard/concepts/policies)** | Where enforcement lives: **gates** (match request attributes before detection) + **detector rules** (Monitor / Block / Transform), plus **Observe / Enforce**. |
 | **[Collector](/trustguard/concepts/collectors)** | A traffic tap (gateway, SDK, browser, WAF) authenticated by an API key. It routes each request to a policy. |
 | **Finding** | What a gate or detector reported — its `source`, `signal`, `outcome`, and `evidence`. |
 
@@ -78,7 +78,7 @@ Traffic with **no matching policy** is **unguarded**: TrustGuard returns `status
   model API is down), TrustGuard either drops that detector's result and continues
   (fail-open) or returns `500` so you can hold traffic (fail-closed). The mode is **configured per deployment** (ask NeuralTrust if unsure). A structured block decision always applies.
 - **Enforcement is the caller's choice.** The response `status`
-  (`allow` / `report` / `transform` / `block`) is advisory. Your collector
+  (`allow` / `report` / `transform` / `ask` / `block`) is advisory. Your collector
   decides what to do with it.
 
 ## Get started
@@ -87,8 +87,8 @@ Traffic with **no matching policy** is **unguarded**: TrustGuard returns `status
 2. Create detectors from the [catalog](/trustguard/detectors/overview).
 3. Create a [policy](/trustguard/concepts/policies) with **Input** and **Output** detectors chained and configure rules if needed.
 4. Attach the policy to the collector created (default and/or per-consumer).
-5. Test in playground.
-6. Verify traffic in **Activity**.
+5. Run a sample on the policy **Test** tab.
+6. Verify live traffic in **Activity**.
 
 ## Where to go next
 
@@ -100,7 +100,7 @@ Traffic with **no matching policy** is **unguarded**: TrustGuard returns `status
     Detectors, policies, and collectors.
   </Card>
   <Card title="Policies" icon="shield-check" href="/trustguard/concepts/policies">
-    Gates, detector rules, and the Report / Enforce switch.
+    Gates, detector rules, and the Observe / Enforce switch.
   </Card>
   <Card title="Detector catalog" icon="list" href="/trustguard/detectors/overview">
     Every built-in detection and its settings.


### PR DESCRIPTION
## Summary

TrustGuard console docs now match the Runtime UI, including Ask and the Claude Code laptop-hooks path.

- **Policies** panel tabs: Basics, Gates, Detectors, Collectors, Test, History. Mode is Observe / Enforce (`report_only`). Gate actions include **Ask** (input only). Attribute groups include Direction and Tool.
- **Collectors** page tabs: Collectors | Catalog. Collector panel: Connection | Auth | Policies.
- Verdict chain: `block → ask → transform → report → allow`. Observe never goes past `report`.
- MCP **`tool.name`** comes from `payload.params.name` (last segment of `mcp__server__tool`), not `attributes.tool`.
- New **Claude Code** page: plugin must be **enabled**, plus binary + `tgk_…`. Distinct from Inference Hooks (`claude-code`) and from TrustGate MCP (org Connectors). Stamps `claude-code-plugin`.
- Cursor / Codex Ask copy: `A TrustGuard policy needs your approval to continue.` Codex has no dialog — allow + `additionalContext`; use Block for a hard stop.
- Inference Hooks dialect stays allow/deny; Ask degrades to allow.
- **Overview rewrite:** drop “never drops traffic / never takes the app down”, the “43 PII” count, and the duplicate secrets card. Collectors are not all API-key gateways. Add **IDE & coding agents** (Claude Enterprise vs Claude Code / Cursor / Codex) and Observe vs Enforce as the enforcement story.
- Nav: TrustGuard group **Core concepts** → **Resources** (Detectors, Policies, Collectors). TrustTest **Core Concepts** unchanged.

## Test plan

- [ ] Mintlify nav: TrustGuard → **Resources** (not Core concepts) → Detectors / Policies / Collectors
- [ ] Mintlify nav: TrustGuard → Integrations → IDE → Claude Code sits after Claude Enterprise
- [ ] `/trustguard/overview` no longer claims TrustGuard never blocks or that a timeout cannot take the app down
- [ ] Overview lists IDE & coding agents and distinguishes Inference Hooks vs laptop plugins vs TrustGate MCP
- [ ] Policies page labels match Runtime → Policies tabs and Observe/Enforce
- [ ] Collectors page labels match Collectors | Catalog and Connection | Auth | Policies
- [ ] Claude Code vs Claude Enterprise vs `/trustgate/mcp/claude` links are distinct and resolve
- [ ] Evaluate API documents `ask` and `tool.name` from `payload.params.name`
