### PR TITLE
docs(sso): add Google Workspace guide and align SSO docs with the Beta

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -75,6 +75,7 @@
                   "platform/break-glass"
                 ]
               },
+              "platform/role-provisioning",
               "platform/scim",
               "platform/user-sync"
             ]

--- a/docs.json
+++ b/docs.json
@@ -70,6 +70,7 @@
                 "group": "SSO Configuration",
                 "pages": [
                   "platform/sso",
+                  "platform/google-workspace-sso",
                   "platform/generic-oidc-sso",
                   "platform/break-glass"
                 ]

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -143,7 +143,14 @@ Only enable Trust Identity Provider if you fully trust the IdP to authenticate a
 **UI label:** Role Mapping from IdP  
 **Default:** disabled
 
-Automatically assign **Admin** or **Member** team roles during OIDC login based on token claims.
+Automatically assign platform roles during OIDC login based on token claims.
+
+<Note>
+Group-to-role mapping across every provider is consolidated in
+[Role Provisioning](/platform/role-provisioning), which also sets a **Default Access** role
+and the **enforcement** mode. A user who matches **several** mapped groups gets the
+**highest-privilege** role among them.
+</Note>
 
 ### Setup Steps
 
@@ -361,7 +368,7 @@ Exceptions:
   **magic link**, even when Enforce SSO is on.
 
 **Prerequisites:** Add at least one break-the-glass account under
-[User & Roles](/platform/users) and configure your **Email Domain** first.
+[Users & groups](/platform/users) and configure your **Email Domain** first.
 </Note>
 
 <Warning>

--- a/platform/generic-oidc-sso.mdx
+++ b/platform/generic-oidc-sso.mdx
@@ -394,6 +394,12 @@ account for IdP outages. External-domain guests continue to use magic link.
   </Accordion>
 
   <Accordion title="Google Workspace">
+    <Note>
+    Google Workspace has a **dedicated provider** with directory group sync — use
+    [Google Workspace SSO](/platform/google-workspace-sso) for the full setup. Configure
+    it as generic OIDC below only if you specifically want the OIDC path without directory
+    sync.
+    </Note>
     1. Go to <a href="https://console.cloud.google.com/" target="_blank">Google Cloud Console</a> → **APIs & Services** → **Credentials**
     2. Create **OAuth 2.0 Client ID** (Web application)
     3. Add **Authorized redirect URI**: Use the callback URL from the in-app setup guide (production: `https://app.neuraltrust.ai/api/auth/callback/oidc`)

--- a/platform/google-workspace-sso.mdx
+++ b/platform/google-workspace-sso.mdx
@@ -1,0 +1,291 @@
+---
+title: Google Workspace SSO
+description: "Step-by-step guide to configure Google Workspace Single Sign-On for NeuralTrust, including optional directory group sync via a service account."
+---
+
+# Google Workspace Single Sign-On
+
+Single Sign-On (SSO) lets your organization members sign in to NeuralTrust with their
+Google Workspace accounts instead of a separate password. NeuralTrust has a **dedicated
+Google Workspace provider** — you no longer need to configure it as a generic OIDC
+provider — which adds **directory group sync**: NeuralTrust reads your Workspace groups
+and their members to drive platform roles and gateway access.
+
+<Note>
+**Using a different identity provider?** For Microsoft, see [Microsoft Entra ID SSO](/platform/sso).
+For Okta, Auth0, PingIdentity, or any other OIDC provider, see
+[Generic OIDC SSO](/platform/generic-oidc-sso).
+</Note>
+
+## What you get
+
+- **Login** — a **Sign in with Google** button on the NeuralTrust login page (OAuth 2.0).
+- **Directory group sync (optional)** — NeuralTrust pulls your Workspace groups and
+  members from the Admin SDK Directory API, so you can map groups to roles and gateway
+  access. Without it, login still works; only group-based governance is unavailable.
+
+<Note>
+The two halves use **different Google credentials**. Login uses an **OAuth client**.
+Directory sync uses a **service account with domain-wide delegation**. You configure
+both in NeuralTrust, but they are set up separately in Google.
+</Note>
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- A Google Workspace organization
+- **Super Admin** access to the [Google Admin console](https://admin.google.com) (only a
+  super admin can authorize directory access org-wide)
+- Access to a [Google Cloud](https://console.cloud.google.com) project
+- Owner or Admin role in NeuralTrust
+
+---
+
+## Part 1: Create the OAuth client (login)
+
+### Step 1: Configure the OAuth consent screen
+
+1. Go to <a href="https://console.cloud.google.com/apis/credentials/consent" target="_blank">Google Cloud Console → APIs &amp; Services → OAuth consent screen</a>
+2. Set **User type** to **Internal** (only your Workspace users can sign in)
+3. Fill in the app name (e.g. `NeuralTrust`), support email, and developer contact
+4. Save
+
+### Step 2: Create the OAuth client ID
+
+1. Go to <a href="https://console.cloud.google.com/apis/credentials" target="_blank">APIs &amp; Services → Credentials</a>
+2. Click **+ Create Credentials** → **OAuth client ID**
+3. **Application type**: **Web application**
+4. **Name**: `NeuralTrust SSO`
+5. Under **Authorized redirect URIs**, add:
+   ```
+   https://app.neuraltrust.ai/api/auth/callback/google-workspace
+   ```
+6. Click **Create**
+
+### Step 3: Copy your credentials
+
+Copy the **Client ID** and **Client secret** shown after creation — you'll enter them in
+NeuralTrust. The login flow requests the standard `openid email profile` scopes only.
+
+<Warning>
+The redirect URI must match **exactly**, including the path
+`/api/auth/callback/google-workspace`. A mismatch causes a `redirect_uri_mismatch` error.
+</Warning>
+
+---
+
+## Part 2: Enable directory group sync (optional)
+
+Skip this part if you only want login. Complete it to map Google groups to NeuralTrust
+roles and gateway access.
+
+### Step 1: Enable the Admin SDK API
+
+1. In your Google Cloud project, go to <a href="https://console.cloud.google.com/apis/library/admin.googleapis.com" target="_blank">APIs &amp; Services → Library</a>
+2. Search for **Admin SDK API** and click **Enable**
+
+### Step 2: Create a service account and key
+
+1. Go to <a href="https://console.cloud.google.com/iam-admin/serviceaccounts" target="_blank">IAM &amp; Admin → Service Accounts</a>
+2. Click **+ Create Service Account**, name it `neuraltrust-directory`, and create it
+3. Open the service account → **Keys** → **Add key** → **Create new key** → **JSON**
+4. A JSON key file downloads. Keep it safe — you'll paste its contents into NeuralTrust
+5. On the service account's **Details** page, copy its **Unique ID (Client ID)** — a long
+   numeric value you'll need in the next step
+
+### Step 3: Authorize domain-wide delegation
+
+1. Go to <a href="https://admin.google.com/ac/owl/domainwidedelegation" target="_blank">Google Admin console → Security → Access and data control → API controls → Domain-wide delegation</a>
+2. Click **Add new**
+3. **Client ID**: the service account's numeric Client ID from the previous step
+4. **OAuth scopes**: paste these three, comma-separated (read-only):
+   ```
+   https://www.googleapis.com/auth/admin.directory.group.readonly,
+   https://www.googleapis.com/auth/admin.directory.group.member.readonly,
+   https://www.googleapis.com/auth/admin.directory.user.readonly
+   ```
+5. Click **Authorize**
+
+<Note>
+Directory access is granted by **impersonating an admin**. In NeuralTrust you provide a
+**delegation subject** — the email of a Google Workspace admin the service account acts
+as when reading the directory.
+</Note>
+
+---
+
+## Part 3: Configure NeuralTrust
+
+### Step 1: Open SSO settings
+
+1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
+2. Open the sidebar gear → **Platform settings → SSO Configuration**
+3. Select **Google Workspace**
+
+### Step 2: Enter your credentials
+
+| Field | Value |
+|-------|-------|
+| **Client ID** | The OAuth client ID from Part 1 |
+| **Client Secret** | The OAuth client secret from Part 1 (paste to set or rotate) |
+| **Service account JSON** | The full JSON key from Part 2, Step 2 |
+| **Delegation subject** | A Google Workspace **admin email** for domain-wide delegation |
+
+<Note>
+**Login only?** You can leave the service account JSON and delegation subject empty.
+Login works with just the OAuth client; directory group sync stays off until you add them.
+</Note>
+
+<Note>
+**Rotating the service account.** When editing an existing connection, leave the service
+account JSON blank to keep the stored value. Paste a new JSON only to rotate it.
+</Note>
+
+### Step 3: Test and save
+
+1. Click **Test Connection** — this validates the OAuth client and, if provided, the
+   service account and delegation
+2. On success, click **Save**
+
+---
+
+## Part 4: Verify your email domain
+
+Domain verification ensures only members of your organization's domain can use SSO.
+
+1. Open **Platform settings → SSO Configuration → Domains**
+2. Click **Add Domain** and enter your company domain (e.g. `yourcompany.com`)
+3. Copy the verification token (e.g. `neuraltrust-verify-abc123-def456`)
+4. In your DNS provider, add a **TXT** record with the token as its value (Name `@`, TTL default)
+5. Back in NeuralTrust, click **Verify**
+
+<Note>
+DNS changes can take up to 48 hours to propagate. If verification fails immediately, try
+again later.
+</Note>
+
+---
+
+## Part 5: Map Google groups to roles
+
+Role mapping assigns NeuralTrust roles automatically from Google Workspace group
+membership. It requires directory group sync (Part 2) to be configured.
+
+### Step 1: Add group mappings
+
+1. Go to **Platform settings → SSO Configuration → Users & groups**
+2. Click **Add Group Mapping**
+3. Select a Google group and choose the NeuralTrust role to assign:
+
+| Role | Access Level |
+|------|--------------|
+| **Global Admin** | Full admin across products and platform settings; billing visibility |
+| **Admin** | Manage members, most settings |
+| **Editor** / **Viewer** | Product permission levels — see [User &amp; Roles](/platform/users) |
+
+<Note>
+Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization;
+transfer ownership in [User &amp; Roles](/platform/users) instead.
+</Note>
+
+4. For Editor / Viewer mappings, set **Product Access** — which products the group can use
+5. Enable **Auto Sync** to include the group in synchronization
+6. Click **Save**
+
+### Step 2: Review synced groups
+
+The **Groups** tab under **Users & groups** lists every group in your unified directory
+with its **source** (SCIM, directory, or login) and **member count**, so you can confirm
+the sync is working before you rely on a mapping.
+
+<Note>
+Users are assigned the role from the **first matching group mapping**. If a user belongs
+to multiple mapped groups, the highest-priority mapping (by creation order) wins.
+</Note>
+
+---
+
+## Part 6: How directory sync stays fresh
+
+Once configured, group membership is kept current from three sources, so a mapping always
+reflects reality:
+
+| When | What happens |
+|------|--------------|
+| **On login** | The signing-in user's group membership is resolved from the Directory API and applied immediately. |
+| **Scheduled** | A background job refreshes every team's directory (groups + members) on a schedule, so membership for **all** users stays fresh between logins. |
+| **On demand** | An admin can trigger a sync from the settings UI. |
+
+<Note>
+A Google Workspace user's login token does **not** carry group claims. NeuralTrust resolves
+groups from the Directory API instead — which is why directory sync (Part 2) is required
+for any group-based access, including [gateway and MCP](/trustgate/concepts/roles) role
+gates.
+</Note>
+
+<Warning>
+Directory sync **never grants more than the directory says**. If the directory is
+temporarily unreachable, group-based access **fails closed** (denied), never open, and a
+role that depends on an unknown group stays denied.
+</Warning>
+
+---
+
+## Part 7: Enforce SSO-only mode (optional)
+
+1. Open **Platform settings → SSO Configuration**
+2. Toggle **Enforce SSO** to ON and confirm
+
+<Note>
+When enabled, members on a **verified** domain must authenticate through Google.
+Exceptions:
+
+- **Break the Glass** accounts sign in with **password only**.
+- **External-domain guests** (an invited email whose domain is *not* verified) sign in
+  with a **magic link**, even when Enforce SSO is on.
+
+**Prerequisites:** add at least one [Break the Glass](/platform/break-glass) account and
+configure your **Email Domain** first.
+</Note>
+
+---
+
+## User experience
+
+Once configured, users see a **Sign in with Google** button on the login page. After
+clicking it they are redirected to Google, authenticate, and return signed in. For new
+users on a verified domain, accounts are created automatically on first login.
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `redirect_uri_mismatch` | Redirect URI doesn't match | Ensure the OAuth client lists `https://app.neuraltrust.ai/api/auth/callback/google-workspace` exactly |
+| `access_denied` / `admin_policy_enforced` | Consent screen or app blocked | Set the consent screen to **Internal**; confirm the app is allowed for your org |
+| "Directory not connected" | Service account or delegation missing | Add the **Service account JSON** and **Delegation subject** in NeuralTrust |
+| "Directory not authorized" | Delegation or scopes rejected by Google | Re-check domain-wide delegation: the service account's Client ID and all three `admin.directory.*.readonly` scopes must be authorized, and the delegation subject must be a valid admin |
+| Groups don't appear | Admin SDK API disabled, or delegation not propagated | Enable the **Admin SDK API**; delegation changes can take a few minutes to apply |
+| "Connection failed" | Invalid OAuth credentials | Verify the Client ID and Client Secret |
+
+---
+
+## Security best practices
+
+1. **Keep the consent screen Internal** so only your Workspace users can sign in
+2. **Grant read-only scopes only** — the directory scopes above are all `.readonly`
+3. **Rotate the service account key** periodically (paste a new JSON to rotate)
+4. **Enforce SSO-only mode** once all users are onboarded, keeping a
+   [Break the Glass](/platform/break-glass) account for outages
+5. **Verify every email domain** your organization uses
+6. **Monitor [audit logs](/platform/audit-logs)** for suspicious login patterns
+
+## Next steps
+
+- [Microsoft Entra ID SSO](/platform/sso) — Configure SSO with Microsoft Entra ID
+- [Generic OIDC SSO](/platform/generic-oidc-sso) — Okta, Auth0, and other providers
+- [Configure Break the Glass](/platform/break-glass) — Emergency access for IdP outages
+- [Configure SCIM Provisioning](/platform/scim) — Automate user account lifecycle
+- [Set Up Audit Logs](/platform/audit-logs) — Monitor SSO-related security events

--- a/platform/google-workspace-sso.mdx
+++ b/platform/google-workspace-sso.mdx
@@ -121,13 +121,20 @@ as when reading the directory.
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
 2. Open the sidebar gear → **Platform settings → SSO Configuration**
-3. Select **Google Workspace**
+3. Select the **Google Workspace** tab
+
+<Note>
+Only **one** identity provider can be active at a time. If Microsoft Entra ID or Generic
+OIDC is already configured, remove it before setting up Google Workspace. Note that
+[SCIM Provisioning](/platform/scim) is available **only with Microsoft Entra ID** — with
+Google Workspace, groups come from directory sync instead.
+</Note>
 
 ### Step 2: Enter your credentials
 
 | Field | Value |
 |-------|-------|
-| **Client ID** | The OAuth client ID from Part 1 |
+| **Client ID** | The OAuth client ID from Part 1 (ends with `.apps.googleusercontent.com`) |
 | **Client Secret** | The OAuth client secret from Part 1 (paste to set or rotate) |
 | **Service account JSON** | The full JSON key from Part 2, Step 2 |
 | **Delegation subject** | A Google Workspace **admin email** for domain-wide delegation |
@@ -170,39 +177,33 @@ again later.
 ## Part 5: Map Google groups to roles
 
 Role mapping assigns NeuralTrust roles automatically from Google Workspace group
-membership. It requires directory group sync (Part 2) to be configured.
+membership. It requires directory group sync (Part 2) to be configured, and it lives in the
+**Role Provisioning** section — the same place for every provider. See
+[Role Provisioning](/platform/role-provisioning) for the full guide. In short:
 
-### Step 1: Add group mappings
-
-1. Go to **Platform settings → SSO Configuration → Users & groups**
-2. Click **Add Group Mapping**
-3. Select a Google group and choose the NeuralTrust role to assign:
+1. Go to **Platform settings → Role Provisioning**
+2. Turn on **User provisioning & role mapping**
+3. Set a **Default Access** role for users who match no group
+4. Choose an **Enforcement** mode — *At sign-up only* or *At sign-up and login*
+5. Under **Role Mapping**, add a row per Google group and pick its platform role:
 
 | Role | Access Level |
 |------|--------------|
 | **Global Admin** | Full admin across products and platform settings; billing visibility |
 | **Admin** | Manage members, most settings |
-| **Editor** / **Viewer** | Product permission levels — see [User &amp; Roles](/platform/users) |
+| **Editor** / **Viewer** | Product permission levels — see [Users &amp; groups](/platform/users) |
 
-<Note>
-Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization;
-transfer ownership in [User &amp; Roles](/platform/users) instead.
-</Note>
+<Warning>
+A user in **several** mapped groups gets the **highest-privilege** role among them — not
+the first match. Do **not** map IdP groups to **Owner**; transfer ownership in
+[Users &amp; groups](/platform/users) instead.
+</Warning>
 
-4. For Editor / Viewer mappings, set **Product Access** — which products the group can use
-5. Enable **Auto Sync** to include the group in synchronization
-6. Click **Save**
+### Review synced groups
 
-### Step 2: Review synced groups
-
-The **Groups** tab under **Users & groups** lists every group in your unified directory
-with its **source** (SCIM, directory, or login) and **member count**, so you can confirm
+The **Groups** tab under **Users &amp; groups** lists every group in your unified directory
+with its **source** (SCIM, Directory, or Login) and **member count**, so you can confirm
 the sync is working before you rely on a mapping.
-
-<Note>
-Users are assigned the role from the **first matching group mapping**. If a user belongs
-to multiple mapped groups, the highest-priority mapping (by creation order) wins.
-</Note>
 
 ---
 
@@ -284,6 +285,7 @@ users on a verified domain, accounts are created automatically on first login.
 
 ## Next steps
 
+- [Role Provisioning](/platform/role-provisioning) — Map Google groups to roles and choose enforcement
 - [Microsoft Entra ID SSO](/platform/sso) — Configure SSO with Microsoft Entra ID
 - [Generic OIDC SSO](/platform/generic-oidc-sso) — Okta, Auth0, and other providers
 - [Configure Break the Glass](/platform/break-glass) — Emergency access for IdP outages

--- a/platform/role-provisioning.mdx
+++ b/platform/role-provisioning.mdx
@@ -1,0 +1,124 @@
+---
+title: Role Provisioning
+description: "Map identity provider groups to NeuralTrust platform roles, set a default role, and choose when provisioning applies. One place for group-to-role mapping across Entra ID and Google Workspace."
+---
+
+# Role Provisioning
+
+**Role Provisioning** maps your identity provider's groups to NeuralTrust platform roles
+and decides what access a user gets when they sign in. It is one unified section —
+it **replaces** the old separate *Role mapping*, *User provisioning*, *SCIM*, and *Trust
+identity provider* screens.
+
+<Note>
+Configure your identity provider first in [SSO Configuration](/platform/sso). Only **one**
+provider can be active at a time (Microsoft Entra ID, Generic OIDC, or Google Workspace),
+and group browsing needs directory access — Entra Graph permissions or the Google
+Workspace [service account](/platform/google-workspace-sso#part-2-enable-directory-group-sync-optional).
+</Note>
+
+## Where to find it
+
+1. Log in as Owner or Admin
+2. Open the sidebar gear → **Platform settings → Role Provisioning**
+
+## Prerequisites
+
+- An identity provider connected in [SSO Configuration](/platform/sso)
+- At least one **verified email domain**
+
+<Note>
+Until both are in place, provisioning can't be enabled. The section tells you which one is
+missing.
+</Note>
+
+## Turn provisioning on
+
+Use the **User provisioning & role mapping** toggle to enable the section.
+
+<Note>
+**Who it applies to.** Provisioning applies automatically to users from your **verified
+domains**. It never affects **guests**, organization **Owners**, **Global Admins**, or
+**break-glass** accounts — those keep their access regardless.
+</Note>
+
+<Warning>
+Turning provisioning **off** stops all admission and syncing from the provider. Existing
+users **keep the roles they have** — nothing is revoked. New users fall back to the
+**default role** at sign-in.
+</Warning>
+
+## Default Access
+
+**Default Access** is the role a user receives when they match **no** group mapping.
+
+- Pick any role, or choose **No NeuralTrust access** — the user can sign in but receives no
+  membership and no access to resources.
+- **Admin** and **Global Admin** cannot be used as the default role.
+
+## Enforcement — when provisioning applies
+
+Choose when the rules take effect:
+
+| Mode | Behavior |
+|------|----------|
+| **At sign-up only** | Roles are assigned on first sign-in and **never overwritten** by later IdP changes or manual edits. |
+| **At sign-up and login** | Roles are re-applied on **every** sign-in. A manual role change in [Users & groups](/platform/users) is overwritten on the user's next login. |
+| **Automatically via SCIM** | Your IdP creates, updates, and deactivates users through SCIM 2.0. See [SCIM Provisioning](/platform/scim). |
+
+## Role Mapping
+
+Add a row per group to map an IdP group to a platform role.
+
+1. Click **Add mapping**
+2. Search and select the **{provider} group**
+3. Choose the **Platform role**:
+
+| Role | Access Level |
+|------|--------------|
+| **Global Admin** | Full admin across products and platform settings; billing visibility |
+| **Admin** | Manage members, most settings |
+| **Editor** / **Viewer** | Product permission levels — see [Users & groups](/platform/users) |
+
+<Warning>
+A user who belongs to **several** mapped groups gets the **highest-privilege** role among
+them — not the first match. Map deliberately so a broad group can't over-grant.
+</Warning>
+
+<Note>
+Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization;
+transfer ownership in [Users & groups](/platform/users) instead.
+</Note>
+
+<Note>
+**No groups in the picker?** Directory access isn't configured or was rejected. For Entra,
+grant `Group.Read.All` (and consent); for Google Workspace, complete the
+[service account + domain-wide delegation](/platform/google-workspace-sso#part-2-enable-directory-group-sync-optional)
+setup.
+</Note>
+
+## How groups reach NeuralTrust
+
+The groups you map come from your **unified directory**, kept fresh from up to three
+sources so a mapping always reflects reality:
+
+- **SCIM push** — Entra/Okta push groups to `/api/scim/v2/Groups`
+- **Directory pull** — Google Workspace groups and members are pulled from the Admin SDK
+  Directory API (on login and on a schedule)
+- **Login claims** — the signing-in user's group claims
+
+Review what arrived under **Users & groups → Groups**, which shows each group's **source**
+(SCIM, Directory, or Login) and **member count**.
+
+<Note>
+The same resolved group set also drives **gateway and MCP access** in TrustGate — see
+[Roles](/trustgate/concepts/roles). Group-based access **fails closed**: an unknown or
+stale group never grants more than the directory says.
+</Note>
+
+## Next steps
+
+- [Microsoft Entra ID SSO](/platform/sso) — Connect Entra ID
+- [Google Workspace SSO](/platform/google-workspace-sso) — Connect Google Workspace
+- [SCIM Provisioning](/platform/scim) — Automatic lifecycle via SCIM 2.0
+- [Users & groups](/platform/users) — Members and the directory groups view

--- a/platform/scim.mdx
+++ b/platform/scim.mdx
@@ -6,7 +6,12 @@ description: "Set up SCIM automatic user provisioning with Microsoft Entra ID. A
 # SCIM Automatic User Provisioning
 
 <Note>
-SCIM is available for **Microsoft Entra ID** only. Generic OIDC SSO does not include SCIM — use invitations or [User sync](/platform/user-sync) where applicable. Prefer SCIM over manual invites when both are enabled to avoid duplicate or conflicting memberships.
+SCIM is available for **Microsoft Entra ID** only — and only one identity provider can be
+active at a time. Generic OIDC and Google Workspace do not include SCIM; use
+[Role Provisioning](/platform/role-provisioning) (group-to-role mapping) or
+[Manual User Sync](/platform/user-sync) instead. In Role Provisioning, choosing the
+**Automatically via SCIM** enforcement mode is what hands the user lifecycle to your IdP
+through SCIM 2.0.
 </Note>
 
 SCIM (System for Cross-domain Identity Management) automatically creates, updates, and removes NeuralTrust user accounts when changes happen in your Microsoft Entra ID directory. No manual user management needed.
@@ -188,9 +193,10 @@ Before enabling provisioning for your entire organization, test with a single us
 
 ### Verify User in NeuralTrust
 
-1. Open **Platform settings → User & Roles** in NeuralTrust
+1. Open **Platform settings → Users & groups** in NeuralTrust
 2. Confirm the provisioned user appears in the member list
-3. Verify their display name and email are correct
+3. Verify their display name and email are correct — groups pushed by SCIM appear under the
+   **Groups** tab with source **SCIM**
 
 ---
 

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -8,7 +8,7 @@ description: "Step-by-step guide to configure Microsoft Entra ID (Azure AD) Sing
 Single Sign-On (SSO) allows your organization members to sign in to NeuralTrust using their corporate Microsoft credentials instead of a separate password.
 
 <Note>
-**Using a different identity provider?** If you use Okta, Auth0, Google Workspace, or another OIDC-compliant provider, see [Generic OIDC SSO](/platform/generic-oidc-sso) instead.
+**Using a different identity provider?** For Google Workspace, see [Google Workspace SSO](/platform/google-workspace-sso) — it has a dedicated provider with directory group sync. For Okta, Auth0, or another OIDC-compliant provider, see [Generic OIDC SSO](/platform/generic-oidc-sso).
 </Note>
 
 ## Benefits
@@ -326,6 +326,7 @@ For new users whose email domain is verified, accounts are created automatically
 
 ## Next Steps
 
+- [Google Workspace SSO](/platform/google-workspace-sso) — Configure SSO with Google Workspace
 - [Generic OIDC SSO](/platform/generic-oidc-sso) — Configure SSO with Okta, Auth0, or other providers
 - [Configure Break the Glass](/platform/break-glass) — Set up emergency access for IdP outages
 - [Manual User Sync](/platform/user-sync) — Import users on-demand with role mappings

--- a/platform/sso.mdx
+++ b/platform/sso.mdx
@@ -95,6 +95,12 @@ Only required if you plan to use the Manual User Sync feature.
 
 1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
 2. Open the sidebar gear → **Platform settings → SSO Configuration**
+3. Select the **Microsoft Entra ID** tab
+
+<Note>
+Only **one** identity provider can be active at a time. If Generic OIDC or Google Workspace
+is already configured, remove it before setting up Microsoft Entra ID.
+</Note>
 
 ### Step 2: Enter Your Azure Credentials
 
@@ -203,56 +209,29 @@ Ensure your app registration has these **Application permissions** (not Delegate
 If permissions don't show "Granted", click **Grant admin consent for [Your Organization]** and confirm.
 </Warning>
 
-### Step 4: Configure Role Mappings in NeuralTrust
+### Step 4: Map groups to roles in Role Provisioning
 
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner
-2. Go to **Settings** → **SSO** → **Entra ID User Sync** tab
-3. Click **Add Group Mapping**
-4. Select an Azure AD group from the dropdown
-5. Choose the NeuralTrust role to assign:
+Group-to-role mapping lives in one place — the **Role Provisioning** section — for every
+provider. See [Role Provisioning](/platform/role-provisioning) for the full guide. In short:
+
+1. Log in as Owner or Admin → **Platform settings → Role Provisioning**
+2. Turn on **User provisioning & role mapping**
+3. Set a **Default Access** role for users who match no group
+4. Choose an **Enforcement** mode — *At sign-up only*, *At sign-up and login*, or
+   *Automatically via SCIM*
+5. Under **Role Mapping**, add a row per Azure AD group and pick its platform role:
 
 | Role | Access Level |
 |------|--------------|
 | **Global Admin** | Full admin across products and platform settings; billing visibility |
 | **Admin** | Manage members, most settings |
-| **Editor** / **Viewer** | Product permission levels — see [User & Roles](/platform/users) |
+| **Editor** / **Viewer** | Product permission levels — see [Users & groups](/platform/users) |
 
-<Note>
-Do **not** map IdP groups to **Owner**. There is exactly one Owner per organization; transfer ownership in User & Roles instead. Predefined role templates are Global Admin, Break the Glass, Admin, Editor, Viewer, and No access — see [User & Roles](/platform/users).
-</Note>
-
-6. Configure **Product Access** when mapping Editor / Viewer (and similar non–full-admin) roles:
-   - Select which products/features the group members can access
-   - Global Admin and Admin mappings have broad product Admin access
-
-7. Enable **Auto Sync** to include this group in synchronization
-8. Click **Save**
-
-### Step 5: Sync Users
-
-After creating mappings:
-
-1. Go to **Settings** → **SSO** → **Sync Users** tab
-2. Click **Preview Sync** to see which users will be imported
-3. Review the list of users and their assigned roles
-4. Click **Sync Now** to import users
-
-<Note>
-Users are assigned the role from the **first matching group mapping**. If a user belongs to multiple mapped groups, they receive the role from the highest-priority mapping (based on creation order).
-</Note>
-
-<Note>
-**Manual role edits and re-sync.** If you change a synced user's role by hand in **User & Roles**, that change persists until the next sync. Running **Sync Now** again re-applies the mapped role and overwrites a manual edit if it no longer matches the group mapping — sync is on-demand here, so this only happens when you trigger it.
-</Note>
-
-### Role Mapping Table Reference
-
-| Column | Description |
-|--------|-------------|
-| **Azure AD Group** | The source group in Microsoft Entra ID |
-| **NeuralTrust Role** | Role assigned to group members |
-| **Product Access** | Specific products accessible (Editor / Viewer and similar mappings) |
-| **Auto Sync** | Whether group is included in sync operations |
+<Warning>
+A user in **several** mapped groups gets the **highest-privilege** role among them — not
+the first match. Do **not** map IdP groups to **Owner**; transfer ownership in
+[Users & groups](/platform/users) instead.
+</Warning>
 
 ---
 
@@ -278,7 +257,7 @@ Exceptions:
   for that address.
 
 **Prerequisites:** Add at least one break-the-glass account under
-[User & Roles](/platform/users) and configure your **Email Domain** first.
+[Users & groups](/platform/users) and configure your **Email Domain** first.
 </Note>
 
 <Warning>
@@ -328,6 +307,7 @@ For new users whose email domain is verified, accounts are created automatically
 
 - [Google Workspace SSO](/platform/google-workspace-sso) — Configure SSO with Google Workspace
 - [Generic OIDC SSO](/platform/generic-oidc-sso) — Configure SSO with Okta, Auth0, or other providers
+- [Role Provisioning](/platform/role-provisioning) — Map groups to roles and choose enforcement
 - [Configure Break the Glass](/platform/break-glass) — Set up emergency access for IdP outages
 - [Manual User Sync](/platform/user-sync) — Import users on-demand with role mappings
 - [Configure SCIM Provisioning](/platform/scim) — Automate user account creation and removal

--- a/platform/user-sync.mdx
+++ b/platform/user-sync.mdx
@@ -1,150 +1,93 @@
 ---
 title: Manual User Sync
-description: "Synchronize users from Microsoft Entra ID groups on-demand. Import users with role assignments based on group mappings."
+description: "Provision users from Microsoft Entra ID groups without SCIM, using group-to-role mapping in Role Provisioning."
 ---
 
 # Manual User Sync
 
-Manual User Sync allows you to import users from Microsoft Entra ID groups with a single click. Unlike SCIM (which syncs automatically), Manual Sync gives you full control over when users are imported.
+Manual User Sync provisions users from **Microsoft Entra ID** groups **without** a separate
+SCIM Enterprise Application — it reuses your existing SSO app registration's Graph
+permissions. Users are admitted and assigned roles from your group mappings when they sign
+in, according to the **enforcement mode** you choose.
 
-## Benefits
+<Note>
+**Group-to-role mapping now lives in [Role Provisioning](/platform/role-provisioning).**
+That single section replaces the old *Role mapping*, *User provisioning*, *SCIM*, and
+*Trust identity provider* screens. This page covers the Entra-specific prerequisites and
+how manual (non-SCIM) provisioning behaves.
+</Note>
 
-- **On-demand import**: Sync users when you're ready
-- **Preview before sync**: Review which users will be imported
-- **Role-based access**: Users get roles based on group mappings
-- **No Azure Enterprise App needed**: Uses your existing SSO app registration
+## When to use it
+
+| Use Manual (non-SCIM) provisioning when… | Use [SCIM](/platform/scim) when… |
+|------------------------------------------|----------------------------------|
+| You don't want a separate Azure Enterprise App | You want a fully automated user lifecycle |
+| You handle offboarding yourself | Auto-deprovisioning is required |
+| Roles should apply at sign-up / login | Your IdP should create and deactivate users directly |
+
+<Warning>
+Manual provisioning and SCIM are **alternative approaches** for the same goal. SCIM is
+available **only with Microsoft Entra ID**, and only one identity provider can be active at
+a time. Don't run both against the same users.
+</Warning>
 
 ## Prerequisites
 
-Before using Manual User Sync:
-
-1. [SSO must be configured](/platform/sso) and working
-2. [Role mappings must be set up](/platform/sso#part-4-configure-role-mapping-optional)
-3. API permissions must be granted:
+1. [Microsoft Entra ID SSO is configured](/platform/sso) and working
+2. At least one **verified email domain**
+3. Your app registration has these **Application** Graph permissions, with admin consent:
    - `User.Read.All`
    - `GroupMember.Read.All`
    - `Group.Read.All`
 
+<Note>
+Without `Group.Read.All` (and consent), no groups appear in the Role Provisioning picker.
+</Note>
+
+## Configure it in Role Provisioning
+
+1. Log in as Owner or Admin → **Platform settings → Role Provisioning**
+2. Turn on **User provisioning & role mapping**
+3. Set a **Default Access** role for users who match no mapped group (or **No NeuralTrust
+   access**)
+4. Choose an **Enforcement** mode:
+
+| Mode | Behavior |
+|------|----------|
+| **At sign-up only** | Role assigned on first sign-in; never overwritten afterwards |
+| **At sign-up and login** | Role re-applied every sign-in; a manual edit in [Users & groups](/platform/users) is overwritten on next login |
+
+5. Under **Role Mapping**, add a row per Entra group and choose its platform role:
+
+| Role | Access Level |
+|------|--------------|
+| **Global Admin** | Full admin across products and platform settings; billing visibility |
+| **Admin** | Manage members, most settings |
+| **Editor** / **Viewer** | Product permission levels — see [Users & groups](/platform/users) |
+
 <Warning>
-Manual User Sync and SCIM Provisioning are **alternative approaches**. You can use either one, but using both simultaneously may cause conflicts. Choose the method that best fits your workflow.
+A user in **several** mapped groups gets the **highest-privilege** role among them — not
+the first match. Do **not** map IdP groups to **Owner**; transfer ownership in
+[Users & groups](/platform/users) instead.
 </Warning>
 
----
+## What manual provisioning does not do
 
-## Part 1: Set Up Group Mappings
+- It does **not** auto-deprovision. Removing a user from an Entra group does not remove them
+  from NeuralTrust — remove them in [Users & groups](/platform/users), or use
+  [SCIM](/platform/scim) for automatic offboarding.
 
-Before syncing users, you need to map Azure AD groups to NeuralTrust roles.
+## Verify
 
-### Step 1: Open User Sync Settings
+1. Open **Platform settings → Users & groups**
+2. Confirm the expected members appear with the correct roles
+3. The **Groups** tab shows each synced group with its **source** and **member count**
 
-1. Log in to <a href="https://app.neuraltrust.ai" target="_blank">NeuralTrust</a> as Owner or Admin
-2. Open the sidebar gear → **Platform settings → SSO Configuration**
-3. Click the **Entra ID User Sync** tab
+All provisioning actions are recorded in [Audit Logs](/platform/audit-logs).
 
-### Step 2: Add Group Mappings
+## Related documentation
 
-1. Click **Add Group Mapping**
-2. Select an Azure AD group from the dropdown
-3. Choose the role to assign (Owner, Admin, or Member)
-4. For Member role, optionally configure product access
-5. Enable **Auto Sync** to include in sync operations
-6. Click **Save**
-
-Repeat for each group you want to sync.
-
-<Note>
-If no groups appear in the dropdown, verify that your app registration has `Group.Read.All` permission with admin consent granted.
-</Note>
-
----
-
-## Part 2: Preview and Sync Users
-
-### Step 1: Preview Sync
-
-1. Go to **Settings** → **SSO** → **Sync Users** tab
-2. Click **Preview Sync**
-3. Review the list showing:
-   - User email and name
-   - Source Azure AD group(s)
-   - Role that will be assigned
-   - Action: **Create** (new user) or **Update** (existing user)
-
-### Step 2: Execute Sync
-
-1. Review the preview carefully
-2. Click **Sync Now**
-3. Wait for the sync to complete
-4. Check the **Synced Users** tab to verify imported users
-
-### What Happens During Sync
-
-| Scenario | Action |
-|----------|--------|
-| New user (not in NeuralTrust) | Account created with mapped role |
-| Existing user (already in team) | Role updated if different |
-| User removed from Azure group | **Not automatically removed** — use SCIM for auto-deprovisioning |
-| User in multiple mapped groups | Gets role from first matching mapping |
-
-<Note>
-A manual role change made in **User & Roles** stays in place until you run sync again. Because Manual Sync only runs when you click **Sync Now**, a manual edit is only overwritten by the mapped group role at that point — not automatically in between.
-</Note>
-
----
-
-## Part 3: View Imported Users
-
-### Step 1: Check Synced Users
-
-1. Go to **Settings** → **SSO** → **Synced Users** tab
-2. View all users imported via Manual Sync
-3. See their assigned roles and source groups
-
-### Step 2: Verify in Team Members
-
-1. Open **Platform settings → User & Roles**
-2. Confirm users appear with correct roles
-3. Verify they can sign in via SSO
-
----
-
-## Comparison: Manual Sync vs SCIM
-
-| Feature | Manual Sync | SCIM |
-|---------|-------------|------|
-| **Sync trigger** | Manual (on-demand) | Automatic (every 40 min) |
-| **User creation** | ✓ | ✓ |
-| **User updates** | ✓ | ✓ |
-| **User deprovisioning** | ✗ Manual removal | ✓ Automatic |
-| **Azure setup** | SSO app only | Separate Enterprise App |
-| **Best for** | Controlled onboarding | Fully automated lifecycle |
-
----
-
-## Troubleshooting
-
-| Issue | Cause | Solution |
-|-------|-------|----------|
-| No groups in dropdown | Missing API permissions | Add `Group.Read.All` and grant admin consent |
-| "No users to sync" | No users in mapped groups | Add users to Azure AD groups, or check group mappings |
-| User not synced | Not in any mapped group | Verify user is member of a group with Auto Sync enabled |
-| Wrong role assigned | Multiple group memberships | Check mapping order; first match wins |
-| Sync failed | Token expired or invalid | Re-test SSO connection, regenerate client secret if needed |
-
----
-
-## Security Best Practices
-
-1. **Review before syncing** — Always use Preview to verify which users will be imported
-2. **Use Azure AD groups** — Manage access through groups, not individual assignments
-3. **Regular audits** — Check imported users periodically in the Synced Users tab
-4. **Monitor audit logs** — All sync operations are logged in [Audit Logs](/platform/audit-logs)
-
----
-
-## Related Documentation
-
-- [Configure SSO](/platform/sso) — Set up SSO and role mappings
-- [Configure SCIM Provisioning](/platform/scim) — For fully automated user lifecycle
+- [Role Provisioning](/platform/role-provisioning) — Group-to-role mapping and enforcement
+- [Microsoft Entra ID SSO](/platform/sso) — Connect Entra ID
+- [SCIM Provisioning](/platform/scim) — Fully automated user lifecycle
 - [Audit Logs](/platform/audit-logs) — Monitor sync and access events
-- [Integrations](/platform/alert-integrations) — Forward alert findings to your security platform


### PR DESCRIPTION
## What

Adds a dedicated **Google Workspace SSO** guide and aligns the whole SSO docs cluster with the current **Beta** implementation.

## New pages

- **`platform/google-workspace-sso.mdx`** — dedicated provider guide: OAuth login client (consent screen *Internal*, redirect URI `.../callback/google-workspace`, `openid email profile`), directory group sync via a service account + domain-wide delegation (the three `admin.directory.*.readonly` scopes), the in-app fields (**Client ID**, **Client Secret**, **Service account JSON**, **Delegation subject**), sync freshness, enforcement, and troubleshooting.
- **`platform/role-provisioning.mdx`** — the canonical group-to-role page. Documents the unified **Role Provisioning** section that **replaces** the old *Role mapping / User provisioning / SCIM / Trust identity provider* screens: master toggle, scope (verified domains; excludes guests/owners/global-admins/break-glass), **Default Access**, **enforcement** modes (*At sign-up only / At sign-up and login / Automatically via SCIM*), and **Role Mapping** where a user in several groups gets the **highest-privilege** role.

## Alignment fixes (matching the shipped Beta)

- **One identity provider active at a time** — noted on Entra, Google, and OIDC.
- **Group mapping location** — moved from the outdated *Entra ID User Sync* / *Sync Users* tabs (and *Users & groups*) to **Role Provisioning**.
- **Multi-group rule** — corrected from *first match wins* to **highest-privilege role**.
- **SCIM** — clarified it is Entra-only and corresponds to the *Automatically via SCIM* enforcement mode.
- **Manual User Sync** — rewritten around Role Provisioning enforcement; keeps the Entra Graph prerequisites and the SCIM comparison.
- **Renamed** *User & Roles* → *Users & groups*; added Role Provisioning to the nav.

## Notes

Facts (callback path, scopes, field labels, section/tab names, enforcement modes, the highest-privilege rule) were taken from the current app implementation and message catalog, not invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)