### PR TITLE
docs(trustguard): explain what each IDE integration protects, not just setup

### DIFF
--- a/trustguard/integrations/ide/claude-code.mdx
+++ b/trustguard/integrations/ide/claude-code.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code"
-description: "Local TrustGuard lifecycle hooks on Claude Code — plugin, binary, and collector key. TrustGate MCP stays on org Connectors."
+description: "Block or Ask on prompts, shell commands, and MCP tool calls in Claude Code with local TrustGuard lifecycle hooks. TrustGate MCP stays on org Connectors."
 ---
 
 The [TrustGuard Claude Code plugin](https://github.com/NeuralTrust/trustguard-claude-code-plugin)
@@ -15,6 +15,27 @@ This is **not** [Claude Enterprise Inference Hooks](/trustguard/integrations/ide
 Claude Code) is an [organization connector](/trustgate/mcp/claude). Do not put
 the collector `tgk_…` on the connector, and do not put the MCP URL in the
 plugin (`pluginConfigs` / `mcpServers`).
+
+## What this gives you
+
+Claude Code is an agent that **acts** — it runs shell commands, edits files,
+and calls MCP tools. The plugin puts a policy check at each of those moments,
+on the machine, before the action happens:
+
+| Moment | What you can stop | Enforcement |
+|---|---|---|
+| Prompt, before submit | Jailbreaks ([Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)); secrets and PII pasted into the agent ([DLP](/trustguard/detectors/data-loss-prevention)) | **Block** |
+| Tool call, before it runs (shell, MCP, everything else) | Dangerous or out-of-policy commands; risky MCP tool calls — the full command line is evaluated as `tool.command` | **Block** or **Ask** (native Claude Code permission dialog) |
+| Tool result, after it runs | [Indirect prompt injection](/trustguard/detectors/agent-mcp-security) riding back in MCP / tool output before the model consumes it; sensitive data in results | **Block** |
+
+Every decision also lands in **Activity** with a per-developer `consumer_id`,
+so you get an audit trail of what the org's coding agents actually did — in
+**Report** policy mode you can run all of this observe-only before enforcing.
+
+This complements [Inference Hooks](/trustguard/integrations/ide/claude-enterprise):
+the hook screens the model request org-wide with zero endpoint install
+(allow/deny only); the plugin is per-machine and controls **actions**, with Ask.
+Most orgs run both.
 
 ## Three pieces
 

--- a/trustguard/integrations/ide/claude-enterprise.mdx
+++ b/trustguard/integrations/ide/claude-enterprise.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Enterprise"
-description: "Connect Claude chat, Claude Code, and Claude Cowork to TrustGuard via Anthropic Inference Hooks."
+description: "Screen every Claude chat, Claude Code, and Cowork model request org-wide with Anthropic Inference Hooks — nothing installed on laptops."
 ---
 
 One Anthropic organization endpoint maps to **one** TrustGuard collector. Claude chat,
@@ -11,6 +11,35 @@ This path does **not** install Claude Code lifecycle hooks. For laptop hooks
 (`source.application = claude-code-plugin`), see
 [Claude Code](/trustguard/integrations/ide/claude-code). Do not put this
 collector's `tgk_…` on a TrustGate MCP connector.
+
+## What this gives you
+
+Inference Hooks put TrustGuard in front of **every model request** the
+organization's Claude surfaces make — server-side, with **nothing installed on
+laptops**. Anthropic calls TrustGuard before the model answers; TrustGuard
+returns allow or deny. Typical uses:
+
+- **Stop jailbreaks and prompt injection org-wide** — a
+  [Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)
+  detector screens every prompt from chat, Claude Code, and Cowork before it
+  reaches the model.
+- **Catch secrets and PII leaving the org** —
+  [Data Loss Prevention](/trustguard/detectors/data-loss-prevention) flags API
+  keys, tokens, and customer data pasted into Claude. On this path the verdict
+  is binary, so DLP **blocks or reports**; it cannot mask in flight.
+- **Audit who uses Claude for what** — every request lands in **Activity**
+  with `consumer.id` (the actor's email) and the surface in
+  `source.application`, without touching endpoints.
+- **Apply different rules per surface** — one collector, one policy, and
+  [gates](/trustguard/concepts/policies#gates) on
+  `source.application`: e.g. Report on Claude chat, Block on Claude Code.
+
+What it can **not** do: no **Ask** dialog (there is no IDE prompt on this path),
+no Transform/masking, and no visibility into individual tool executions — it
+sees the model request, not the shell command Claude Code is about to run. For
+action-level control on developer machines, pair it with the
+[Claude Code plugin](/trustguard/integrations/ide/claude-code); the two paths
+stamp different `source.application` values, so they gate independently.
 
 ## Setup
 

--- a/trustguard/integrations/ide/codex.mdx
+++ b/trustguard/integrations/ide/codex.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Codex"
-description: "Install TrustGuard for OpenAI Codex from GitHub — lifecycle hooks to POST /v1/evaluate with one org API key."
+description: "Block prompts, deny commands, and replace poisoned tool results in OpenAI Codex with TrustGuard lifecycle hooks — one org API key."
 ---
 
 The [TrustGuard Codex plugin](https://github.com/NeuralTrust/trustguard-codex-plugin)
@@ -10,6 +10,22 @@ across the company.
 
 Codex has **no** “import plugin from GitHub” marketplace flow like Cursor. You install
 from the repo (local) or IT deploys hooks + config (enterprise).
+
+## What this gives you
+
+Codex runs shell commands, applies patches, and calls MCP tools on the
+developer machine. The hooks put a policy check at each of those moments:
+
+| Moment | What you can stop | Enforcement |
+|---|---|---|
+| Prompt, before submit | Jailbreaks ([Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)); secrets and PII pasted into the agent ([DLP](/trustguard/detectors/data-loss-prevention)) | **Block** |
+| Tool call, before it runs (`Bash`, `apply_patch`, MCP) | Dangerous or out-of-policy commands and patches; risky MCP tool calls | **Deny** (Codex does not honour Ask — an Ask gate becomes allow + a warning the agent sees) |
+| Tool result, after it runs | [Indirect prompt injection](/trustguard/detectors/agent-mcp-security) in MCP / tool output | **Block** — the tool result is replaced before the model consumes it |
+
+Every decision lands in **Activity** with `consumer_id` prefixed `codex:`, so
+you also get a per-developer audit trail; start in **Report** policy mode to
+observe before enforcing. With `allow_managed_hooks_only`, developers cannot
+switch the hooks off.
 
 ## Console setup
 

--- a/trustguard/integrations/ide/cursor.mdx
+++ b/trustguard/integrations/ide/cursor.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cursor"
-description: "Install the NeuralTrust Cursor plugin — TrustGuard firewall hooks plus TrustGate MCP Gateway — with org credentials."
+description: "Screen prompts, tool calls, and tool results in Cursor — TrustGuard firewall hooks plus the TrustGate MCP Gateway in one plugin."
 ---
 
 The [NeuralTrust Cursor plugin](https://github.com/NeuralTrust/trustguard-cursor-plugin)
@@ -13,6 +13,25 @@ The [NeuralTrust Cursor plugin](https://github.com/NeuralTrust/trustguard-cursor
 
 Developers do not need NeuralTrust accounts for the firewall path. Do **not** reuse
 the `tgk_…` collector key as an MCP credential.
+
+## What this gives you
+
+One plugin covers the two risks of agentic coding in Cursor — what the agent
+is told, and what the agent does:
+
+| Moment | What you can stop | Enforcement |
+|---|---|---|
+| Prompt, before submit | Jailbreaks ([Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)); secrets and PII pasted into the agent ([DLP](/trustguard/detectors/data-loss-prevention)) | **Block** (Cursor has no Ask dialog at this event) |
+| Tool call, before it runs (Shell, MCP, everything else) | Dangerous or out-of-policy shell commands; risky MCP tool calls | **Block** or **Ask** (Cursor approval prompt) |
+| Tool result, after it runs | [Indirect prompt injection](/trustguard/detectors/agent-mcp-security) in MCP / tool output | **Warn** — Cursor's `postToolUse` cannot block, so findings are injected as an untrusted-content warning the agent sees |
+
+Every decision lands in **Activity** with `consumer_id` = `cursor:<email>`, so
+you also get a per-developer audit trail; start in **Report** policy mode to
+observe before enforcing.
+
+The **TrustGate MCP** half is governance for the tools themselves: instead of
+developers wiring arbitrary MCP servers, the agent gets one org-curated
+endpoint whose tool calls still pass through the firewall hooks above.
 
 ## What IT deploys vs what developers install
 

--- a/trustguard/integrations/overview.mdx
+++ b/trustguard/integrations/overview.mdx
@@ -20,12 +20,18 @@ collector side panel has the steps and snippet for the integration you pick.
 
 ## IDE & coding agents
 
-| | |
-| --- | --- |
-| [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise) | Inference Hooks → `/v1/evaluate/claude` |
-| [Claude Code](/trustguard/integrations/ide/claude-code) | Plugin + MDM binary/`tgk_…` → `/v1/evaluate` |
-| [Cursor](/trustguard/integrations/ide/cursor) | Plugin from GitHub · MDM config → `/v1/evaluate` |
-| [Codex](/trustguard/integrations/ide/codex) | Plugin from GitHub · MDM hooks + config → `/v1/evaluate` |
+Coding agents create two exposures: what developers **tell** them (secrets and
+PII in prompts, jailbreaks) and what the agents **do** (shell commands, patches,
+MCP tool calls, and the untrusted content those tools return). Inference Hooks
+cover the first org-wide with nothing on laptops; the per-machine plugins cover
+both, at action level.
+
+| | Runs | Sees | Can enforce |
+| --- | --- | --- | --- |
+| [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise) | Anthropic org (server-side, no install) | Every model request from Claude chat, Claude Code, Cowork | Allow / deny |
+| [Claude Code](/trustguard/integrations/ide/claude-code) | Dev machine (plugin + MDM) | Prompts · tool calls (shell, MCP) · tool results | Block · **Ask** · report |
+| [Cursor](/trustguard/integrations/ide/cursor) | Dev machine (plugin + MDM) | Prompts · tool calls · tool results | Block · **Ask** (tools) · warn on results · report |
+| [Codex](/trustguard/integrations/ide/codex) | Dev machine (hooks + MDM) | Prompts · tool calls · tool results | Block / deny · replace tool result · report |
 
 ## Application
 


### PR DESCRIPTION
## What

The IDE & coding agents pages (Claude Enterprise, Claude Code, Cursor, Codex) documented **how** to configure each integration but not **why** — a reader landing on them couldn't tell what each surface can see, what threats it can stop, or which enforcement actions are available. They also opened with disambiguation details (`source.application` values, credential warnings) that mean nothing on first read.

## Changes

- **Every IDE page now opens with the value**: a one-paragraph framing plus a table of *interception moment → what you can stop → enforcement action* (prompt before submit, tool call before it runs, tool result after), linking the relevant detectors (Prompt Guard for jailbreaks, DLP for secrets/PII, Indirect Prompt Injection for tool results), plus the per-developer Activity audit trail and Report mode. Plugin mechanics and the "this is not Inference Hooks / not TrustGate MCP" disambiguation moved below the fold.
- **New page: GitHub Copilot** (`trustguard/integrations/ide/copilot`), written from the plugin repo — Copilot CLI + VS Code Agent mode, marketplace install, enterprise policy hooks (machine-wide, load first, cannot be disabled), per-OS paths, wrapper fail semantics, cloud coding-agent coverage, and its real limits (prompt event is audit-only, inline completions expose no hooks, `postToolUse` can only flag). Added to nav and the overview table.
- **Per-surface accuracy**, verified against the plugin sources:
  - Claude Enterprise: allow/deny only, no Ask, no tool-call visibility — pair with the Claude Code plugin for action-level control.
  - Claude Code: Block or **Ask** via the native permission dialog.
  - Cursor: `postToolUse` cannot block — findings surface as an untrusted-content warning.
  - Codex: Ask collapses to allow + context; blocked tool results are **replaced** before the model consumes them.
  - Copilot: `userPromptSubmitted` is audit-only; `preToolUse` allow/ask/deny; cloud treats ask as deny.
- **Integrations overview**: the IDE section now frames the two exposures (what developers *tell* agents vs what agents *do*) and the table compares surfaces by *Runs / Sees / Can enforce* instead of install mechanism.
- **Frontmatter descriptions** rewritten in value terms (shown in nav and search).
- Fixed a stale anchor (`#gates-match-before-you-detect` → `#gates`) in claude-enterprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)