### PR TITLE
docs(trustguard): lead IDE pages with value and add GitHub Copilot page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -297,7 +297,8 @@
                   "trustguard/integrations/ide/claude-enterprise",
                   "trustguard/integrations/ide/claude-code",
                   "trustguard/integrations/ide/cursor",
-                  "trustguard/integrations/ide/codex"
+                  "trustguard/integrations/ide/codex",
+                  "trustguard/integrations/ide/copilot"
                 ]
               },
               {

--- a/trustguard/integrations/ide/claude-code.mdx
+++ b/trustguard/integrations/ide/claude-code.mdx
@@ -3,24 +3,11 @@ title: "Claude Code"
 description: "Block or Ask on prompts, shell commands, and MCP tool calls in Claude Code with local TrustGuard lifecycle hooks. TrustGate MCP stays on org Connectors."
 ---
 
-The [TrustGuard Claude Code plugin](https://github.com/NeuralTrust/trustguard-claude-code-plugin)
-adds **lifecycle hooks** on the developer machine. It calls
-[`POST /v1/evaluate`](/trustguard/api/evaluate) with a collector `tgk_…` key.
-
-This is **not** [Claude Enterprise Inference Hooks](/trustguard/integrations/ide/claude-enterprise)
-(`POST /v1/evaluate/claude`, `source.application = claude-code`). The plugin stamps
-`source.application = claude-code-plugin`. Gate the two paths separately.
-
-**TrustGate MCP is not this plugin.** Org-wide MCP (claude.ai, Desktop, Cowork,
-Claude Code) is an [organization connector](/trustgate/mcp/claude). Do not put
-the collector `tgk_…` on the connector, and do not put the MCP URL in the
-plugin (`pluginConfigs` / `mcpServers`).
-
-## What this gives you
-
 Claude Code is an agent that **acts** — it runs shell commands, edits files,
-and calls MCP tools. The plugin puts a policy check at each of those moments,
-on the machine, before the action happens:
+and calls MCP tools. The
+[TrustGuard Claude Code plugin](https://github.com/NeuralTrust/trustguard-claude-code-plugin)
+puts your org's policy check at each of those moments, on the developer
+machine, **before the action happens**:
 
 | Moment | What you can stop | Enforcement |
 |---|---|---|
@@ -36,6 +23,19 @@ This complements [Inference Hooks](/trustguard/integrations/ide/claude-enterpris
 the hook screens the model request org-wide with zero endpoint install
 (allow/deny only); the plugin is per-machine and controls **actions**, with Ask.
 Most orgs run both.
+
+Under the hood the plugin registers Claude Code **lifecycle hooks** that call
+[`POST /v1/evaluate`](/trustguard/api/evaluate) with a collector `tgk_…` key.
+
+## What this is not
+
+- **Not [Claude Enterprise Inference Hooks](/trustguard/integrations/ide/claude-enterprise)**
+  (`POST /v1/evaluate/claude`, `source.application = claude-code`). The plugin
+  stamps `source.application = claude-code-plugin`. Gate the two paths separately.
+- **Not TrustGate MCP.** Org-wide MCP (claude.ai, Desktop, Cowork, Claude Code)
+  is an [organization connector](/trustgate/mcp/claude). Do not put the
+  collector `tgk_…` on the connector, and do not put the MCP URL in the plugin
+  (`pluginConfigs` / `mcpServers`).
 
 ## Three pieces
 

--- a/trustguard/integrations/ide/claude-enterprise.mdx
+++ b/trustguard/integrations/ide/claude-enterprise.mdx
@@ -3,21 +3,11 @@ title: "Claude Enterprise"
 description: "Screen every Claude chat, Claude Code, and Cowork model request org-wide with Anthropic Inference Hooks — nothing installed on laptops."
 ---
 
-One Anthropic organization endpoint maps to **one** TrustGuard collector. Claude chat,
-Claude Code, and Claude Cowork share that hook; TrustGuard stamps
-`source.application` so policies can target a surface without separate collectors.
-
-This path does **not** install Claude Code lifecycle hooks. For laptop hooks
-(`source.application = claude-code-plugin`), see
-[Claude Code](/trustguard/integrations/ide/claude-code). Do not put this
-collector's `tgk_…` on a TrustGate MCP connector.
-
-## What this gives you
-
-Inference Hooks put TrustGuard in front of **every model request** the
-organization's Claude surfaces make — server-side, with **nothing installed on
-laptops**. Anthropic calls TrustGuard before the model answers; TrustGuard
-returns allow or deny. Typical uses:
+Anthropic **Inference Hooks** put TrustGuard in front of **every model request**
+your organization makes through Claude — Claude chat, Claude Code, and Claude
+Cowork — server-side, with **nothing installed on laptops**. Anthropic calls
+TrustGuard before the model answers; TrustGuard returns allow or deny. Typical
+uses:
 
 - **Stop jailbreaks and prompt injection org-wide** — a
   [Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)
@@ -40,6 +30,18 @@ sees the model request, not the shell command Claude Code is about to run. For
 action-level control on developer machines, pair it with the
 [Claude Code plugin](/trustguard/integrations/ide/claude-code); the two paths
 stamp different `source.application` values, so they gate independently.
+
+## How it maps
+
+One Anthropic organization endpoint maps to **one** TrustGuard collector.
+Claude chat, Claude Code, and Claude Cowork share that hook; TrustGuard stamps
+`source.application` so policies can target a surface without separate
+collectors.
+
+This path does **not** install Claude Code lifecycle hooks — that is the
+[Claude Code plugin](/trustguard/integrations/ide/claude-code)
+(`source.application = claude-code-plugin`). Do not put this collector's
+`tgk_…` on a TrustGate MCP connector.
 
 ## Setup
 

--- a/trustguard/integrations/ide/codex.mdx
+++ b/trustguard/integrations/ide/codex.mdx
@@ -3,18 +3,10 @@ title: "Codex"
 description: "Block prompts, deny commands, and replace poisoned tool results in OpenAI Codex with TrustGuard lifecycle hooks — one org API key."
 ---
 
-The [TrustGuard Codex plugin](https://github.com/NeuralTrust/trustguard-codex-plugin)
-uses Codex **lifecycle hooks** (not Codex External guardrails / Prisma AIRS) and
-[`POST /v1/evaluate`](/trustguard/api/evaluate). One org collector API key is shared
-across the company.
-
-Codex has **no** “import plugin from GitHub” marketplace flow like Cursor. You install
-from the repo (local) or IT deploys hooks + config (enterprise).
-
-## What this gives you
-
 Codex runs shell commands, applies patches, and calls MCP tools on the
-developer machine. The hooks put a policy check at each of those moments:
+developer machine. The
+[TrustGuard Codex plugin](https://github.com/NeuralTrust/trustguard-codex-plugin)
+puts your org's policy check at each of those moments:
 
 | Moment | What you can stop | Enforcement |
 |---|---|---|
@@ -26,6 +18,13 @@ Every decision lands in **Activity** with `consumer_id` prefixed `codex:`, so
 you also get a per-developer audit trail; start in **Report** policy mode to
 observe before enforcing. With `allow_managed_hooks_only`, developers cannot
 switch the hooks off.
+
+Under the hood the plugin uses Codex **lifecycle hooks** (not Codex External
+guardrails / Prisma AIRS) calling
+[`POST /v1/evaluate`](/trustguard/api/evaluate). One org collector API key is
+shared across the company. Codex has **no** “import plugin from GitHub”
+marketplace flow like Cursor: you install from the repo (local) or IT deploys
+hooks + config (enterprise).
 
 ## Console setup
 

--- a/trustguard/integrations/ide/copilot.mdx
+++ b/trustguard/integrations/ide/copilot.mdx
@@ -1,0 +1,139 @@
+---
+title: "GitHub Copilot"
+description: "Ask or deny tool calls and flag poisoned tool results in Copilot CLI and VS Code Agent mode with TrustGuard lifecycle hooks."
+---
+
+Copilot's agent surfaces — **Copilot CLI** and **VS Code Agent mode** — run
+shell commands and call MCP tools on the developer machine. The
+[TrustGuard Copilot plugin](https://github.com/NeuralTrust/trustguard-copilot-plugin)
+puts your org's policy check at each of those moments:
+
+| Moment | What you can stop | Enforcement |
+|---|---|---|
+| Prompt, before submit | Visibility into jailbreaks ([Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)) and secrets or PII pasted into the agent ([DLP](/trustguard/detectors/data-loss-prevention)) | **Audit only** — Copilot discards command-hook output at this event, so findings are recorded but the prompt is not blocked |
+| Tool call, before it runs (shell, MCP) | Dangerous or out-of-policy commands; risky MCP tool calls | **Deny** or **Ask** (Copilot approval prompt) |
+| Tool result, after it runs | [Indirect prompt injection](/trustguard/detectors/agent-mcp-security) in MCP / tool output | **Flag** — the result is marked as untrusted context for the model; `postToolUse` cannot undo the call |
+
+Every decision lands in **Activity** with
+`source.application = copilot-plugin`, so you also get an audit trail; start in
+**Report** policy mode to observe before enforcing.
+
+Coverage limits: **inline completions (ghost text) expose no hooks** and are
+out of scope. Copilot **cloud** coding-agent jobs load only hooks committed
+under `.github/hooks/*.json` — see [Cloud coding agent](#cloud-coding-agent).
+
+## Console setup
+
+1. Create a **GitHub Copilot** collector (Catalog → IDE & coding agents).
+2. Mint a `tgk_…` API key on the **Auth** tab (shown once — store it).
+3. Assign a default [policy](/trustguard/concepts/policies) on the **Policies** tab.
+
+## Local / pilot
+
+Copilot CLI has a plugin marketplace flow:
+
+```bash
+copilot plugin marketplace add NeuralTrust/trustguard-copilot-plugin
+copilot plugin install trustguard@neuraltrust
+```
+
+Then write the API key config:
+
+```json
+// ~/.trustguard/copilot.json  (chmod 600)
+{
+  "data_url": "https://<your-trustguard-host>",
+  "api_key": "tgk_…",
+  "fail_mode": "open"
+}
+```
+
+Environment variables (`TRUSTGUARD_DATA_URL`, `TRUSTGUARD_API_KEY`,
+`TRUSTGUARD_FAIL_MODE`, `TRUSTGUARD_TIMEOUT_MS`, `TRUSTGUARD_TRANSFORM_ACTION`,
+`TRUSTGUARD_CONSUMER_ID`) override the user file.
+
+If a personal install is incomplete, the marketplace bootstrap emits `{}` and
+exits 0 on purpose — Copilot's `preToolUse` command hooks fail **closed** on
+non-zero exits, and a half-installed plugin must not brick Copilot.
+
+## Enterprise
+
+IT deploys **policy hooks**, which Copilot CLI loads machine-wide **before**
+user, repository, and plugin hooks — developers cannot disable them
+(`disableAllHooks` does not apply). Kandji scripts live under
+[`mdm/kandji/`](https://github.com/NeuralTrust/trustguard-copilot-plugin/tree/main/mdm/kandji);
+they install four pieces:
+
+| Piece | Path (macOS) |
+|---|---|
+| Collector binary | `/Library/Application Support/TrustGuard/bin/trustguard-copilot` |
+| Managed config (`tgk_…`) | `/Library/Application Support/TrustGuard/copilot.json` |
+| Wrapper | `/usr/local/bin/trustguard-policy-hook` |
+| Policy hook file | `/etc/github-copilot/policy.d/10-trustguard.json` |
+
+| OS | Collector | Managed config | Policy hooks dir |
+|---|---|---|---|
+| macOS | `…/TrustGuard/bin/trustguard-copilot` | `…/TrustGuard/copilot.json` | `/etc/github-copilot/policy.d/` |
+| Linux | `/opt/trustguard/bin/` or `/usr/local/bin/` | `/etc/trustguard/copilot.json` | `/etc/github-copilot/policy.d/` |
+| Windows | `%ProgramData%\TrustGuard\bin\trustguard-copilot.exe` | `%ProgramData%\TrustGuard\copilot.json` | `C:\ProgramData\GitHub\Copilot\policy.d\` |
+
+The policy hook file calls the **wrapper**, not the collector directly, so one
+file works across platforms (`TRUSTGUARD_COPILOT_BIN` overrides the lookup).
+The wrapper distinguishes two failures on purpose: collector **not installed**
+→ allow (a machine mid-provisioning is not bricked); collector **installed but
+failing** → `preToolUse` is denied and `postToolUse` output marked untrusted.
+Normal data-plane errors follow the configured `fail_mode`.
+
+**VS Code Agent mode:** install the plugin from the organization marketplace.
+Agent hooks are currently a VS Code **preview** feature — ensure enterprise
+policy permits hooks and controls marketplace sources.
+
+### Cloud coding agent
+
+Cloud jobs receive no local plugins, user hooks, MDM files, or policy hooks. To
+cover them:
+
+1. Commit a Copilot hook file under `.github/hooks/`.
+2. Make the collector binary available in the job image (or use an HTTP hook
+   endpoint that accepts Copilot's event payload).
+3. Add the TrustGuard host to the cloud-agent firewall allowlist.
+4. Provide credentials through the approved GitHub environment mechanism.
+
+In cloud, **ask is treated as deny** (no user present) and `userPromptSubmitted`
+remains audit-only.
+
+## Verify
+
+1. Run Copilot CLI and send a test prompt, then trigger a shell tool call.
+2. Confirm the events in TrustGuard **Activity**
+   (`source.application = copilot-plugin`).
+
+Smoke-test the binary (optional):
+
+```bash
+echo '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo hi"},"session_id":"pilot"}' \
+  | trustguard-copilot hook
+```
+
+## What is evaluated
+
+| Copilot event | TrustGuard protocol | Direction | Notes |
+|---|---|---|---|
+| `userPromptSubmitted` | `llm` | input | Audit-only — Copilot discards command-hook output |
+| `preToolUse` (shell) | `all` | input | `allow`, `ask`, or `deny` |
+| `preToolUse` (MCP / other tools) | `mcp` tools/call | input | Same verdicts |
+| `postToolUse` | `mcp` result | output | Blocked / sensitive output marked as untrusted context |
+
+## Attributes
+
+- `attributes.source.application = "copilot-plugin"`
+- `attributes.copilot.*` — the full hook stdin JSON is preserved
+- `consumer_id` sent only when configured explicitly
+  (`TRUSTGUARD_CONSUMER_ID` / `consumer_id` in `copilot.json`)
+
+## Related
+
+- [Plugin README](https://github.com/NeuralTrust/trustguard-copilot-plugin)
+- [Enterprise deployment guide](https://github.com/NeuralTrust/trustguard-copilot-plugin/blob/main/docs/enterprise.md)
+- [Policies — Gates](/trustguard/concepts/policies#gates)
+- [Evaluate API](/trustguard/api/evaluate)

--- a/trustguard/integrations/ide/cursor.mdx
+++ b/trustguard/integrations/ide/cursor.mdx
@@ -4,20 +4,9 @@ description: "Screen prompts, tool calls, and tool results in Cursor — TrustGu
 ---
 
 The [NeuralTrust Cursor plugin](https://github.com/NeuralTrust/trustguard-cursor-plugin)
-(`trustguard` package) runs on each developer machine and ships **two** surfaces:
-
-| Surface | Role | Credential |
-| --- | --- | --- |
-| **TrustGuard hooks** | Prompts, tool calls, tool results → [`POST /v1/evaluate`](/trustguard/api/evaluate) | Org Cursor collector `tgk_…` (MDM / `cursor.json`) |
-| **TrustGate MCP** | Aggregated MCP tools for the agent | Plugin variables: MCP URL (+ API key if not OAuth) |
-
-Developers do not need NeuralTrust accounts for the firewall path. Do **not** reuse
-the `tgk_…` collector key as an MCP credential.
-
-## What this gives you
-
-One plugin covers the two risks of agentic coding in Cursor — what the agent
-is told, and what the agent does:
+covers the two risks of agentic coding in Cursor — what the agent is **told**,
+and what the agent **does**. It runs on each developer machine and puts your
+org's policy check at each moment:
 
 | Moment | What you can stop | Enforcement |
 |---|---|---|
@@ -32,6 +21,18 @@ observe before enforcing.
 The **TrustGate MCP** half is governance for the tools themselves: instead of
 developers wiring arbitrary MCP servers, the agent gets one org-curated
 endpoint whose tool calls still pass through the firewall hooks above.
+
+## Two surfaces, two credentials
+
+The plugin (`trustguard` package) ships both surfaces:
+
+| Surface | Role | Credential |
+| --- | --- | --- |
+| **TrustGuard hooks** | Prompts, tool calls, tool results → [`POST /v1/evaluate`](/trustguard/api/evaluate) | Org Cursor collector `tgk_…` (MDM / `cursor.json`) |
+| **TrustGate MCP** | Aggregated MCP tools for the agent | Plugin variables: MCP URL (+ API key if not OAuth) |
+
+Developers do not need NeuralTrust accounts for the firewall path. Do **not** reuse
+the `tgk_…` collector key as an MCP credential.
 
 ## What IT deploys vs what developers install
 

--- a/trustguard/integrations/overview.mdx
+++ b/trustguard/integrations/overview.mdx
@@ -32,6 +32,7 @@ both, at action level.
 | [Claude Code](/trustguard/integrations/ide/claude-code) | Dev machine (plugin + MDM) | Prompts · tool calls (shell, MCP) · tool results | Block · **Ask** · report |
 | [Cursor](/trustguard/integrations/ide/cursor) | Dev machine (plugin + MDM) | Prompts · tool calls · tool results | Block · **Ask** (tools) · warn on results · report |
 | [Codex](/trustguard/integrations/ide/codex) | Dev machine (hooks + MDM) | Prompts · tool calls · tool results | Block / deny · replace tool result · report |
+| [GitHub Copilot](/trustguard/integrations/ide/copilot) | Dev machine (plugin / policy hooks) | Prompts (audit) · tool calls · tool results | Deny · **Ask** · flag result untrusted · report |
 
 ## Application
 


### PR DESCRIPTION
Move plugin mechanics and disambiguation notes (Inference Hooks vs plugin, TrustGate MCP credential warnings) below the value section so every IDE page opens with what it protects. Add the GitHub Copilot integration page (CLI + VS Code Agent mode, policy hooks for enterprise, cloud coding agent coverage) to the nav and the overview comparison table.