### PR TITLE
docs(trustguard): align console UI paths with renamed catalog category

### DIFF
--- a/trustguard/concepts/collectors.mdx
+++ b/trustguard/concepts/collectors.mdx
@@ -15,7 +15,7 @@ tabs:
 | Tab | What it is |
 |---|---|
 | **Collectors** | Installed taps and their policy counts. |
-| **Catalog** | Providers grouped as Gateway, Application, **IDE & coding agents**, Browser, WAF. **Add collector** opens the create flow. |
+| **Catalog** | Providers grouped as Gateway, Application, **AI assistants & coding agents**, Browser, WAF. **Add collector** opens the create flow. |
 
 Opening a collector is a side panel with:
 
@@ -41,7 +41,7 @@ integration determines the setup snippet you get and where enforcement happens.
 | Group | Examples | Where it runs |
 |---|---|---|
 | **Gateway** | [TrustGate](/trustguard/integrations/gateway/trustgate), [Portkey](/trustguard/integrations/gateway/portkey), [LiteLLM](/trustguard/integrations/gateway/litellm), [Kong](/trustguard/integrations/gateway/kong), [Apigee](/trustguard/integrations/gateway/apigee), [Azure APIM](/trustguard/integrations/gateway/azure-apim) | AI gateway path |
-| **IDE & coding agents** | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise), [Claude Code](/trustguard/integrations/ide/claude-code), [Cursor](/trustguard/integrations/ide/cursor), [Codex](/trustguard/integrations/ide/codex), [GitHub Copilot](/trustguard/integrations/ide/copilot) | Org Inference Hooks / developer-machine plugins |
+| **AI assistants & coding agents** | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise), [Claude Code](/trustguard/integrations/ide/claude-code), [Cursor](/trustguard/integrations/ide/cursor), [Codex](/trustguard/integrations/ide/codex), [GitHub Copilot](/trustguard/integrations/ide/copilot) | Org Inference Hooks / developer-machine plugins |
 | **Application** | [Python](/trustguard/integrations/application/python-sdk), [Node](/trustguard/integrations/application/node-sdk), [REST](/trustguard/integrations/application/rest), [Python middleware](/trustguard/integrations/application/python-middleware), [Node middleware](/trustguard/integrations/application/node-middleware) | Around model calls |
 | **Browser** | [Chrome](/trustguard/integrations/browser/chrome), [Edge](/trustguard/integrations/browser/edge), [Firefox](/trustguard/integrations/browser/firefox) | AI web apps |
 | **WAF / Edge** | [Cloudflare](/trustguard/integrations/edge-waf/cloudflare), [CloudFront](/trustguard/integrations/edge-waf/aws-cloudfront), [Fastly](/trustguard/integrations/edge-waf/fastly), [Akamai](/trustguard/integrations/edge-waf/akamai) | CDN edge |

--- a/trustguard/integrations/ide/claude-code.mdx
+++ b/trustguard/integrations/ide/claude-code.mdx
@@ -43,7 +43,7 @@ must be enabled.** `Scope: managed` only means the marketplace installed it.
 
 ## Console setup
 
-1. **Runtime → Collectors → Catalog → IDE & coding agents → Claude Code** (or the Claude Code collector type your workspace lists).
+1. **Runtime → Collectors → Catalog → AI assistants & coding agents → Claude Code** (or the Claude Code collector type your workspace lists).
 2. **Auth** — mint a `tgk_…` key (shown once).
 3. **Policies** — assign a default [policy](/trustguard/concepts/policies). Gate **Ask** / **Block** on `source.application` **eq** `claude-code-plugin` if this collector also receives other traffic.
 

--- a/trustguard/integrations/ide/claude-enterprise.mdx
+++ b/trustguard/integrations/ide/claude-enterprise.mdx
@@ -45,7 +45,7 @@ This path does **not** install Claude Code lifecycle hooks — that is the
 
 ## Setup
 
-1. In TrustGuard, create a **Claude Enterprise** collector (Catalog → IDE & coding agents).
+1. In TrustGuard, create a **Claude Enterprise** collector (Catalog → AI assistants & coding agents).
 2. Mint a `tgk_…` API key on the collector **Auth** tab.
 3. In the Anthropic admin console (Data and Privacy → Inference hooks), set:
    - **Hook URL:** `{TRUSTGUARD_URL}/v1/evaluate/claude`

--- a/trustguard/integrations/ide/codex.mdx
+++ b/trustguard/integrations/ide/codex.mdx
@@ -28,7 +28,7 @@ hooks + config (enterprise).
 
 ## Console setup
 
-1. Create a **Codex** collector (Catalog → IDE & coding agents).
+1. Create a **Codex** collector (Catalog → AI assistants & coding agents).
 2. Mint a `tgk_…` API key on the **Auth** tab (shown once — store it).
 3. Assign a default [policy](/trustguard/concepts/policies) on the **Policies** tab.
 

--- a/trustguard/integrations/ide/copilot.mdx
+++ b/trustguard/integrations/ide/copilot.mdx
@@ -24,7 +24,7 @@ under `.github/hooks/*.json` — see [Cloud coding agent](#cloud-coding-agent).
 
 ## Console setup
 
-1. Create a **GitHub Copilot** collector (Catalog → IDE & coding agents).
+1. Create a **GitHub Copilot** collector (Catalog → AI assistants & coding agents).
 2. Mint a `tgk_…` API key on the **Auth** tab (shown once — store it).
 3. Assign a default [policy](/trustguard/concepts/policies) on the **Policies** tab.
 

--- a/trustguard/integrations/ide/cursor.mdx
+++ b/trustguard/integrations/ide/cursor.mdx
@@ -48,7 +48,7 @@ the managed firewall config file. The plugin’s bootstrap downloads the platfor
 
 ## Console setup
 
-1. Create a **Cursor** collector (Catalog → IDE & coding agents).
+1. Create a **Cursor** collector (Catalog → AI assistants & coding agents).
 2. Mint a `tgk_…` API key on the **Auth** tab (shown once — store it).
 3. Assign a default [policy](/trustguard/concepts/policies) on the **Policies** tab.
 

--- a/trustguard/overview.mdx
+++ b/trustguard/overview.mdx
@@ -33,7 +33,7 @@ Create a collector under **Runtime → Collectors → Catalog**.
 | Group | Examples |
 |---|---|
 | **Gateway** | [TrustGate](/trustguard/integrations/gateway/trustgate) (native — no `tgk_…` key), Portkey, LiteLLM, Kong, Apigee, Azure APIM |
-| **IDE & coding agents** | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise), [Claude Code](/trustguard/integrations/ide/claude-code), [Cursor](/trustguard/integrations/ide/cursor), [Codex](/trustguard/integrations/ide/codex), [GitHub Copilot](/trustguard/integrations/ide/copilot) |
+| **AI assistants & coding agents** | [Claude Enterprise](/trustguard/integrations/ide/claude-enterprise), [Claude Code](/trustguard/integrations/ide/claude-code), [Cursor](/trustguard/integrations/ide/cursor), [Codex](/trustguard/integrations/ide/codex), [GitHub Copilot](/trustguard/integrations/ide/copilot) |
 | **Application** | [Python](/trustguard/integrations/application/python-sdk) / [Node](/trustguard/integrations/application/node-sdk) SDK, REST, middleware |
 | **Browser / WAF** | Chrome, Edge, Firefox; Cloudflare, CloudFront, Fastly, Akamai |
 
@@ -49,7 +49,7 @@ overrides if you need them) before you rely on it.
 
 ## AI assistants & coding agents
 
-The **IDE & coding agents** catalog group covers AI assistants and developer
+The **AI assistants & coding agents** catalog group covers AI assistants and developer
 tools. TrustGuard sees **prompts and tool use** (shell, MCP `tools/call`, tool
 results), not only chat.
 


### PR DESCRIPTION
The console catalog group is being renamed to 'AI assistants & coding agents' (NeuralTrust/app#3445); update the Catalog → … steps and tables to match.