### PR TITLE
docs: correct the collectors overview after review

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -363,7 +363,7 @@
                   "trusttest/getting-started/tutorials/local-llm",
                   "trusttest/getting-started/tutorials/http-model",
                   "trusttest/getting-started/tutorials/basic-red-teaming",
-                  "trusttest/getting-started/tutorials/llm-as-a-judge",
+                  "trusttest/getting-started/tutorials/llm-as-judge",
                   "trusttest/getting-started/tutorials/prompt-dataset",
                   "trusttest/getting-started/tutorials/rag",
                   "trusttest/getting-started/tutorials/iterate",

--- a/trustguard/concepts/collectors.mdx
+++ b/trustguard/concepts/collectors.mdx
@@ -38,17 +38,30 @@ Each collector owns:
 Collectors are created from a catalog grouped by integration type. The
 integration determines the setup snippet you get and where enforcement happens.
 
-| Group | Examples | Where it runs |
-|---|---|---|
-| **Gateway** | [TrustGate](/trustguard/integrations/trustgate), [Portkey](/trustguard/integrations/portkey), [LiteLLM](/trustguard/integrations/litellm), [Kong](/trustguard/integrations/kong), [Apigee](/trustguard/integrations/apigee), [Azure APIM](/trustguard/integrations/azure-apim) | AI gateway path |
-| **IDE & coding agents** | [Claude Enterprise](/trustguard/integrations/claude-enterprise), [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor), [Codex](/trustguard/integrations/codex), [GitHub Copilot](/trustguard/integrations/copilot) | Org Inference Hooks / developer-machine plugins |
-| **Agent frameworks** | [LangChain](/trustguard/integrations/langchain), [n8n](/trustguard/integrations/n8n) | Inside the agent loop or workflow |
-| **Application** | [Python](/trustguard/integrations/python-sdk), [Node](/trustguard/integrations/node-sdk), [REST](/trustguard/integrations/rest), [Python middleware](/trustguard/integrations/python-middleware), [Node middleware](/trustguard/integrations/node-middleware) | Around model calls |
-| **WAF / Edge** | [Cloudflare](/trustguard/integrations/cloudflare), [CloudFront](/trustguard/integrations/aws-cloudfront), [Fastly](/trustguard/integrations/fastly), [Akamai](/trustguard/integrations/akamai) | CDN edge |
+| Category | Where it runs | What it can see | Collectors |
+|---|---|---|:--:|
+| **Gateway** | The AI gateway path | Every request the gateway proxies, LLM and MCP | 6 |
+| **Agent frameworks** | Inside your agent loop or workflow | Prompts, responses and tool calls in the graph | 2 |
+| **IDE & coding agents** | The Anthropic organisation server-side, or developer machines | Prompts, and agent actions — shell, patches, MCP calls | 5 |
+| **Application** | Your own code, around model calls or on the request path | Whatever you pass it | 5 |
+| **Edge / WAF** | The CDN edge, in front of your application | Inbound requests to your own AI endpoints | 4 |
+
+Twenty-two collectors across five categories.
+[Integrations](/trustguard/integrations/overview) lists every one with its setup
+path; [Coverage](/trustguard/integrations/coverage) is the per-collector table of
+what each one can actually enforce.
 
 Employee use of AI services you do **not** operate is covered by the
 [browser extension](/platform/browser-extension), which is configured through
 managed browser policy rather than as a collector.
+
+<Note>
+**A model provider is not a collector.** The
+[provider catalog](/trustgate/endpoints/models) answers *who you call* — OpenAI,
+Anthropic, Moonshot, Databricks. A collector answers *where we plug in to see the
+call*. Adding a provider does not add a collector: traffic to a new provider is
+already covered by whichever collector sits on that path.
+</Note>
 
 See [Claude Enterprise](/trustguard/integrations/claude-enterprise) (`POST /v1/evaluate/claude`),
 and [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor),

--- a/trustguard/concepts/policies.mdx
+++ b/trustguard/concepts/policies.mdx
@@ -84,8 +84,8 @@ body is rejected (`400`).
 
 | Value | Path |
 |---|---|
-| `claude-ai` | [Inference Hooks](/trustguard/integrations/claude-enterprise) — claude.ai chat |
-| `claude-code` | Inference Hooks — Claude Code (org hook, not the laptop plugin) |
+| `claude-ai` | [Claude Enterprise](/trustguard/integrations/claude-enterprise) — claude.ai chat |
+| `claude-code` | Claude Enterprise — Claude Code seen server-side, not the laptop plugin |
 | `claude-code-plugin` | [Claude Code plugin](/trustguard/integrations/claude-code) — local lifecycle hooks |
 | `cursor-plugin` | [Cursor plugin](/trustguard/integrations/cursor) |
 | `config-test` | Anthropic **Test connection** |

--- a/trustguard/integrations/claude-code.mdx
+++ b/trustguard/integrations/claude-code.mdx
@@ -19,7 +19,7 @@ Every decision also lands in **Activity** with a per-developer `consumer_id`,
 so you get an audit trail of what the org's coding agents actually did — in
 **Report** policy mode you can run all of this observe-only before enforcing.
 
-This complements [Inference Hooks](/trustguard/integrations/claude-enterprise):
+This complements [Claude Enterprise](/trustguard/integrations/claude-enterprise):
 the hook screens the model request org-wide with zero endpoint install
 (allow/deny only); the plugin is per-machine and controls **actions**, with Ask.
 Most orgs run both — they stamp different `source.application` values
@@ -34,7 +34,6 @@ Under the hood the plugin registers Claude Code **lifecycle hooks** that call
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
-| Tool listing | ❌ | ❌ | ❌ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ✅ | ❌ |
 
@@ -168,12 +167,12 @@ reload.
 Remote SSH / WSL: hooks run on the **remote** host. A Kandji binary on the Mac
 does not cover that session.
 
-claude.ai / Desktop: no lifecycle hooks. Use Inference Hooks and/or org
+claude.ai / Desktop: no lifecycle hooks. Use Claude Enterprise and/or org
 Connectors, not this plugin.
 
 ## Related
 
-- [Claude Enterprise (Inference Hooks)](/trustguard/integrations/claude-enterprise)
+- [Claude Enterprise](/trustguard/integrations/claude-enterprise)
 - [Policies — Gates](/trustguard/concepts/policies#gates)
 - [Evaluate API](/trustguard/api/evaluate)
 - [Plugin repo](https://github.com/NeuralTrust/trustguard-claude-code-plugin)

--- a/trustguard/integrations/claude-enterprise.mdx
+++ b/trustguard/integrations/claude-enterprise.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Claude Enterprise"
-description: "Screen every Claude chat, Claude Code, and Cowork model request org-wide with Anthropic Inference Hooks — nothing installed on laptops."
+description: "Screen every Claude chat, Claude Code, and Cowork model request org-wide, server-side — nothing installed on laptops."
 ---
 
-Anthropic **Inference Hooks** put TrustGuard in front of **every model request**
-your organization makes through Claude — Claude chat, Claude Code, and Claude
-Cowork — server-side, with **nothing installed on laptops**. Anthropic calls
-TrustGuard before the model answers; TrustGuard returns allow or deny. Typical
-uses:
+**Claude Enterprise** puts TrustGuard in front of **every model request** your
+organization makes through Claude — Claude chat, Claude Code, and Claude Cowork —
+server-side, with **nothing installed on laptops**. Anthropic calls TrustGuard
+before the model answers, through the org-level hook it calls Inference Hooks;
+TrustGuard returns allow or deny. Typical uses:
 
 - **Stop jailbreaks and prompt injection org-wide** — a
   [Prompt Guard](/trustguard/detectors/content-security#prompt-guard--prompt_guard)
@@ -24,7 +24,9 @@ uses:
   [gates](/trustguard/concepts/policies#gates) on
   `source.application`: e.g. Report on Claude chat, Block on Claude Code.
 
-What it can **not** do: no **Ask** dialog (there is no IDE prompt on this path),
+What it can **not** do: no **Ask** dialog — there is no IDE prompt on this
+path, so an `ask` gate resolves to **allowed** here rather than stopping
+anything —
 no Transform/masking, and no visibility into individual tool executions — it
 sees the model request, not the shell command Claude Code is about to run. For
 action-level control on developer machines, pair it with the

--- a/trustguard/integrations/codex.mdx
+++ b/trustguard/integrations/codex.mdx
@@ -32,7 +32,6 @@ hooks + config (enterprise).
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
-| Tool listing | ❌ | ❌ | ❌ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ✅ | ❌ |
 

--- a/trustguard/integrations/codex.mdx
+++ b/trustguard/integrations/codex.mdx
@@ -20,7 +20,7 @@ observe before enforcing. With `allow_managed_hooks_only`, developers cannot
 switch the hooks off.
 
 Under the hood the plugin uses Codex **lifecycle hooks** (not Codex External
-guardrails / Prisma AIRS) calling
+guardrails, which is a different extension point) calling
 [`POST /v1/evaluate`](/trustguard/api/evaluate). One org collector API key is
 shared across the company. Codex has **no** “import plugin from GitHub”
 marketplace flow like Cursor: you install from the repo (local) or IT deploys

--- a/trustguard/integrations/copilot.mdx
+++ b/trustguard/integrations/copilot.mdx
@@ -28,7 +28,6 @@ under `.github/hooks/*.json` — see [Cloud coding agent](#cloud-coding-agent).
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ❌ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
-| Tool listing | ❌ | ❌ | ❌ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ⚠️ | ❌ |
 

--- a/trustguard/integrations/coverage.mdx
+++ b/trustguard/integrations/coverage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Coverage"
-description: "What each collector monitors, blocks, and redacts — for LLM traffic and for tool-level traffic — and what it does not cover."
+description: "What each collector monitors, asks about, blocks, and redacts — for LLM traffic and for tool-level traffic — and what it does not cover."
 ---
 
 Every collector calls the same [evaluate API](/trustguard/api/evaluate), but they
@@ -11,39 +11,77 @@ masked payload; a provider hook whose response schema is `allow` / `deny` cannot
 This page is the comparison. Each integration page repeats its own row, with the
 detail, so you do not have to come back here mid-setup.
 
-## The three capabilities
+## What a collector can apply
 
-TrustGuard resolves every evaluation into a
-[policy](/trustguard/concepts/policies) status. Three of them decide coverage:
+TrustGuard resolves every evaluation into one
+[policy](/trustguard/concepts/policies) status. Four of them ask something of the
+collector, listed most restrictive first — the order the reducer itself uses,
+`block` > `ask` > `transform` > `report` > `allow`:
 
-| Capability | Status | What it means |
+| Action | Status | What it means |
 | --- | --- | --- |
-| **Monitor** | `report` | The interaction is recorded with findings and continues. |
 | **Block** | `block` | The interaction is stopped before it reaches the model, the tool, or the user. |
-| **Redact** | `transform` | The content is **rewritten** and continues masked. [Data-loss](/trustguard/detectors/data-loss-prevention) outcomes only. |
+| **Ask** | `ask` | The user is asked to confirm. **Input only** — on output the gate does not match. Needs a human in the loop, so most collectors cannot honour it. |
+| **Redact** | `transform` | The content is **rewritten** and continues masked. [DLP](/trustguard/detectors/data-loss-prevention) (`data_loss_prevention`) outcomes only. |
+| **Monitor** | `report` | The interaction is recorded with findings and continues. |
 
 **Redaction is the scarce one.** To honour `transform`, the host has to own the
 payload *and* be able to write it back. Most integration contracts return a
 boolean verdict, so `transform` collapses to allow or deny there.
 
-Legend: ✅ supported · ⚠️ conditional · ❌ not supported · ➖ the surface does not
-exist for this collector.
+**Ask is the one that collapses.** It needs a person at a keyboard, which only
+the developer-machine plugins have. It is not a column in the matrices below,
+because it does not vary by surface the way the other three do — it varies by
+whether the collector can prompt anyone at all, and it never applies on output.
+Where there is nobody to ask, each integration resolves it differently, and the
+difference matters:
 
-## Deployment scope
+| Collector | What an `ask` gate actually does |
+| --- | --- |
+| [Claude Code](/trustguard/integrations/claude-code) | **Honoured** — the native permission dialog, on prompts and on tool calls. |
+| [Cursor](/trustguard/integrations/cursor) | **Honoured on tool calls** — Cursor's approval prompt. There is no dialog at the prompt event, so an `ask` on a prompt is enforced as a block. |
+| [GitHub Copilot](/trustguard/integrations/copilot) | **Honoured on tool calls** — Copilot's approval prompt. In Copilot cloud there is no user present, so `ask` becomes deny. |
+| [Codex](/trustguard/integrations/codex) | **Allowed**, plus a warning injected as context the agent sees. Codex has no dialog, so treat `ask` as advisory here. |
+| [n8n](/trustguard/integrations/n8n) | **Blocked** — a workflow cannot prompt anyone mid-run. `trustguard.status` stays `ask` so you can branch off it; from 0.2.0 the node no longer fails on it. |
+| [LangChain](/trustguard/integrations/langchain) | **Blocked** — the middleware has no case for `ask`, and an unknown verdict fails closed. |
+| [Claude Enterprise](/trustguard/integrations/claude-enterprise) | **Allowed** — the Claude dialect answers allow or deny only, and there is no IDE prompt on this path. |
+| Gateways and Edge / WAF | **Allowed**, and recorded. There is no user to prompt and the verdict is not `block`, so the request passes through. |
+| Application collectors | **Yours to implement.** `status` is advisory; nothing prompts anyone unless your code does. |
 
-| Group | Collectors | Runs on | Protects | Deployed by |
+Legend for the matrices: ✅ supported · ⚠️ conditional · ❌ not supported · ➖ the
+surface does not exist for this collector.
+
+## Every collector
+
+One row per collector, in the same order in all three tables on this page.
+**Category** is the group it sits under in these docs.
+
+| Collector | Category | Runs on | Protects | Deployed by |
 | --- | --- | --- | --- | --- |
-| Gateway | [TrustGate](/trustguard/integrations/trustgate) | Your gateway (self-hosted or SaaS) | LLM and MCP traffic on guarded routes | Platform team, in the gateway |
-| Gateway | [Portkey](/trustguard/integrations/portkey), [LiteLLM](/trustguard/integrations/litellm), [Kong](/trustguard/integrations/kong), [Apigee](/trustguard/integrations/apigee), [Azure APIM](/trustguard/integrations/azure-apim) | Gateway infrastructure | LLM API traffic | Platform team, in the gateway config |
-| Agent frameworks | [LangChain](/trustguard/integrations/langchain) | Your agent process | Prompts, responses and tool calls in the agent loop | Application developers |
-| Agent frameworks | [n8n](/trustguard/integrations/n8n) | Your n8n instance | The workflows you place the node in | Whoever builds the workflow |
-| IDE & coding agents | [Claude Enterprise](/trustguard/integrations/claude-enterprise) | Anthropic, server-side | Every model request from Claude chat, Claude Code and Cowork | Anthropic org admin (`organization:manage`) |
-| IDE & coding agents | [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor), [Codex](/trustguard/integrations/codex), [GitHub Copilot](/trustguard/integrations/copilot) | Developer machines | Prompts, tool calls and tool results | IT, by MDM — developers need no NeuralTrust account |
-| Application | [Python](/trustguard/integrations/python-sdk), [Node](/trustguard/integrations/node-sdk), [REST](/trustguard/integrations/rest) | Your code | Any model provider your code calls | Application developers |
-| Application | [Python middleware](/trustguard/integrations/python-middleware), [Node middleware](/trustguard/integrations/node-middleware) | Your service | Every AI route it wraps | Application developers |
-| Edge / WAF | [Cloudflare](/trustguard/integrations/cloudflare), [CloudFront](/trustguard/integrations/aws-cloudfront), [Fastly](/trustguard/integrations/fastly), [Akamai](/trustguard/integrations/akamai) | CDN edge | Requests to your own AI endpoints | Platform team, in the CDN |
+| [TrustGate](/trustguard/integrations/trustgate) | Gateway | Your gateway, self-hosted or SaaS | LLM and MCP traffic on guarded routes | Platform team, in the gateway |
+| [Portkey](/trustguard/integrations/portkey) | Gateway | Portkey Cloud or self-hosted | LLM API traffic through Portkey | Platform team, in the gateway config |
+| [LiteLLM](/trustguard/integrations/litellm) | Gateway | Your LiteLLM proxy | LLM API traffic through the proxy | Platform team, in the gateway config |
+| [Kong](/trustguard/integrations/kong) | Gateway | Kong Gateway, on routes running AI Proxy | LLM API traffic on those routes | Platform team, in the gateway config |
+| [Apigee](/trustguard/integrations/apigee) | Gateway | Apigee, per proxy or per environment | LLM API traffic on the attached proxies | Platform team, in the gateway config |
+| [Azure APIM](/trustguard/integrations/azure-apim) | Gateway | Azure API Management | LLM API traffic on the API | Platform team, in the gateway config |
+| [LangChain](/trustguard/integrations/langchain) | Agent frameworks | Your agent process | Prompts, responses and tool calls in the agent loop | Application developers |
+| [n8n](/trustguard/integrations/n8n) | Agent frameworks | Your n8n instance | The workflows you place the node in | Whoever builds the workflow |
+| [Claude Enterprise](/trustguard/integrations/claude-enterprise) | IDE & coding agents | Anthropic, server-side — nothing installed | Every model request from Claude chat, Claude Code and Cowork | Anthropic org admin (`organization:manage`) |
+| [Claude Code](/trustguard/integrations/claude-code) | IDE & coding agents | Developer machines | Prompts, tool calls and tool results | IT, by MDM — developers need no NeuralTrust account |
+| [Cursor](/trustguard/integrations/cursor) | IDE & coding agents | Developer machines | Prompts, tool calls and tool results | IT, by MDM |
+| [Codex](/trustguard/integrations/codex) | IDE & coding agents | Developer machines | Prompts, tool calls and tool results | IT, by MDM |
+| [GitHub Copilot](/trustguard/integrations/copilot) | IDE & coding agents | Developer machines, and Copilot cloud | Tool calls and tool results; prompts are audit-only | IT, by MDM or org policy |
+| [Python SDK](/trustguard/integrations/python-sdk) | Application | Your code | Any model provider your code calls | Application developers |
+| [Node.js SDK](/trustguard/integrations/node-sdk) | Application | Your code | Any model provider your code calls | Application developers |
+| [REST](/trustguard/integrations/rest) | Application | Your code, any language or runtime | Any model provider your code calls | Application developers |
+| [Python middleware](/trustguard/integrations/python-middleware) | Application | Your FastAPI, Django or Flask service | Every AI route it wraps | Application developers |
+| [Node.js middleware](/trustguard/integrations/node-middleware) | Application | Your Express or Next.js service | Every AI route it wraps | Application developers |
+| [Cloudflare](/trustguard/integrations/cloudflare) | Edge / WAF | A Cloudflare Worker on your AI routes | Requests to your own AI endpoints | Platform team, in the CDN |
+| [CloudFront](/trustguard/integrations/aws-cloudfront) | Edge / WAF | Lambda@Edge on viewer request | Requests to your own AI endpoints | Platform team, in the CDN |
+| [Fastly](/trustguard/integrations/fastly) | Edge / WAF | A Fastly Compute service | Requests to your own AI endpoints | Platform team, in the CDN |
+| [Akamai](/trustguard/integrations/akamai) | Edge / WAF | Akamai EdgeWorkers, `responseProvider` | Requests to your own AI endpoints | Platform team, in the CDN |
 
-Groups are not exclusive, and most deployments need more than one. A gateway
+Categories are not exclusive, and most deployments need more than one. A gateway
 collector covers your own AI products; an IDE collector covers what developers
 and their agents do; neither sees the other.
 
@@ -55,29 +93,42 @@ tool call arguments and tool results. **Output** is the model's response.
 | Collector | In · monitor | In · block | In · redact | Out · monitor | Out · block | Out · redact |
 | --- | :--: | :--: | :--: | :--: | :--: | :--: |
 | TrustGate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Kong, Apigee, Azure APIM | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
 | Portkey | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
 | LiteLLM | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
-| Claude Enterprise | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
-| Claude Code, Cursor, Codex | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
-| GitHub Copilot | ✅ | ❌ | ❌ | ➖ | ➖ | ➖ |
+| Kong | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Apigee | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Azure APIM | ✅ | ✅ | ❌ | ⚠️ | ⚠️ | ❌ |
 | LangChain | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | n8n | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Application (SDK, REST, middleware) | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Edge / WAF (all) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Claude Enterprise | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
+| Claude Code | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
+| Cursor | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
+| Codex | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
+| GitHub Copilot | ✅ | ❌ | ❌ | ➖ | ➖ | ➖ |
+| Python SDK | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
+| Node.js SDK | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
+| REST | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
+| Python middleware | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
+| Node.js middleware | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
+| Cloudflare | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| CloudFront | ⚠️ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Fastly | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Akamai | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 **TrustGate is the only collector that inspects streaming responses.** Its
 `post_response` stage buffers the stream and inspects it after the client drain.
 On the other gateways, output coverage is over non-streaming completions.
 
-**LiteLLM redaction is version-gated.** It needs the native `neuraltrust`
-guardrail, which is contributed but not yet in a LiteLLM release. The custom
-guardrail file that works today enforces `block` and does not apply `transform`.
+**LiteLLM and Portkey redaction is version-gated.** Both need their native
+`neuraltrust` guardrail, contributed but not yet in a release. What ships today —
+LiteLLM's custom guardrail file, Portkey's BYOG webhook — enforces `block` and
+does not apply `transform`.
 
-**Portkey redaction is version-gated too.** It needs the native `neuraltrust`
-plugin, which is contributed but not yet in a Portkey release. The BYOG webhook
-that works on Portkey Cloud today returns a boolean, so `transform` becomes allow
-or deny there.
+**Azure APIM is input-only** until you add the outbound policy, which is why its
+output column is conditional rather than supported.
+
+**CloudFront truncates** an oversized viewer-request body silently, so a long
+prompt is evaluated only in part — monitoring is partial, not absent.
 
 **Copilot prompts are audit-only.** Copilot discards command-hook output at
 `userPromptSubmitted`, so a prompt is recorded but cannot be stopped there.
@@ -86,34 +137,50 @@ Enforcement happens at the tool events.
 ## Tool-level interactions
 
 These collectors apply policy between an agent and its tools — MCP servers,
-shell, patches. **Tool listing** means the tool *declarations*: descriptions and
-parameter schemas, which is where
-[tool poisoning](/trustguard/detectors/agent-mcp-security) hides.
+shell, patches.
 
-| Collector | Listing · monitor | Listing · block | Call · monitor | Call · block | Call · redact | Result · monitor | Result · block | Result · redact |
-| --- | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |
-| TrustGate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Claude Enterprise | ✅ | ⚠️ | ✅ | ⚠️ | ❌ | ✅ | ⚠️ | ❌ |
-| Claude Code, Cursor, Codex | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| GitHub Copilot | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ⚠️ | ❌ |
-| LangChain | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
-| n8n | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Application (SDK, REST) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Kong, Apigee, Azure APIM | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Portkey | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| LiteLLM | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Edge / WAF | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Collector | Call · monitor | Call · block | Call · redact | Result · monitor | Result · block | Result · redact |
+| --- | :--: | :--: | :--: | :--: | :--: | :--: |
+| TrustGate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Portkey | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| LiteLLM | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| Kong | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Apigee | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Azure APIM | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| LangChain | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
+| n8n | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| Claude Enterprise | ✅ | ⚠️ | ❌ | ✅ | ⚠️ | ❌ |
+| Claude Code | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Cursor | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Codex | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| GitHub Copilot | ✅ | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| Python SDK | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| Node.js SDK | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| REST | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
+| Python middleware | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Node.js middleware | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Cloudflare | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| CloudFront | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Fastly | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| Akamai | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
 
-Tool declarations are scored by
-[indirect prompt injection](/trustguard/detectors/agent-mcp-security) over LLM
-`tools[]` and MCP `tools/list` — but only where the integration actually sends
-them. The developer-machine plugins send tool *calls* and *results*, not the tool
-list, so tool-poisoning detection does not apply on the surface closest to the
-developer. Route MCP through [TrustGate](/trustgate/mcp/overview) to cover it.
+The middleware collectors see HTTP routes, not model or tool calls, which is why
+they have no tool surface at all while the SDKs do.
 
-On Claude Enterprise, tool content is visible in the transcript and can be
-blocked, but only by denying the whole inference at the single pre-inference
-decision point. There is no per-tool verdict.
+<Note>
+**Tool declarations are a TrustGate and MCP concern.** Tool *listings* —
+descriptions and parameter schemas, where
+[tool poisoning](/trustguard/detectors/agent-mcp-security) hides — are scored by
+indirect prompt injection over LLM `tools[]` and MCP `tools/list`, but only where
+the integration actually sends them: [TrustGate](/trustgate/mcp/overview),
+[LangChain](/trustguard/integrations/langchain) over the agent's bound tools, and
+[Claude Enterprise](/trustguard/integrations/claude-enterprise), where the
+declarations are visible in the transcript but can only be stopped by denying the
+whole inference. The developer-machine plugins send tool *calls* and *results*,
+not the tool list, so tool-poisoning detection does not apply on the surface
+closest to the developer. Route MCP through
+[TrustGate](/trustgate/mcp/overview) to cover it.
+</Note>
 
 ## Considerations
 
@@ -121,11 +188,6 @@ decision point. There is no per-tool verdict.
 5xx it **fails open** unless the policy sets fail-closed; auth and entitlement
 failures always block. In observe mode a `transform` is logged, not applied. A
 `transform` that cannot be applied safely blocks rather than forwarding unmasked.
-
-**Other gateways** — Kong, Apigee and Azure APIM map the verdict onto a boolean,
-so redaction cannot travel. Kong needs AI Proxy on the route. Apigee coverage is
-per proxy unless you attach the Shared Flow with an environment flow hook. Azure
-APIM is input-only until you add the outbound policy.
 
 **Portkey** — the native plugin holds the request body, so it consumes
 `transformed_payload` on chat completions, text completions and Anthropic
@@ -145,29 +207,39 @@ payload where LiteLLM populates them and a transformed tool call is written back
 but every verdict is request-level, so a tool-level finding blocks the whole
 request. Auth and entitlement failures stay fail-closed even under `fail_open`.
 
+**Kong** — needs AI Proxy on the route. The verdict maps onto a boolean, so
+redaction cannot travel.
+
+**Apigee** — coverage is per proxy unless you attach the Shared Flow with an
+environment flow hook. The verdict maps onto a boolean, so redaction cannot
+travel.
+
+**Azure APIM** — input-only until you add the outbound policy. The verdict maps
+onto a boolean, so redaction cannot travel.
+
 **Claude Enterprise** — allow or deny on a whole inference, and nothing else. No
-redaction, no `ask`, no output coverage. Attachments arrive as metadata and
-extracted text, never raw bytes.
+redaction, no `ask`, no output coverage. Tool content is visible in the
+transcript and can be blocked, but only by denying the whole inference at the
+single pre-inference decision point: there is no per-tool verdict. Attachments
+arrive as metadata and extracted text, never raw bytes.
 
 **Claude Code, Cursor, Codex, Copilot** — none of them sees the model's response,
 system prompts, token usage or extended thinking: they capture what passes
 through hook events. None supports redaction — `transform` becomes a permission
-decision, so a masking policy warns or blocks instead of masking. Codex does not
-honour `ask`, and Cursor has no confirmation dialog for prompts. The n8n node
-does not honour it either — it denies instead.
+decision, so a masking policy warns or blocks instead of masking. They differ on
+`ask`, which is where the choice between them usually lands — see the table
+above.
 
-**Agent frameworks** — both run inside your agent or workflow rather than on
-the network, so they see only what they are installed in. **LangChain** applies
-`transform` by rewriting messages in place, and `check_tool_calls` is the one
-hook anywhere that stops a tool call *before* it executes; output redaction is
-conditional because a streamed response has already reached the client. **n8n**
-routes the verdict to a named output instead of enforcing it, so every
-capability past monitoring depends on how the workflow is wired — a **Block**
-branch reconnected to the agent is monitoring. It has no hook inside an AI
-Agent node's loop, so tool coverage is only what the graph makes explicit. An
-`ask` lands on Block with `trustguard.status` preserved: from 0.2.0 the node no
-longer fails on it, but a workflow cannot prompt anyone, so it is degraded to a
-deny rather than honoured.
+**LangChain** — runs inside your agent rather than on the network, so it sees
+only what it is installed in. It applies `transform` by rewriting messages in
+place, and `check_tool_calls` is the one hook anywhere that stops a tool call
+*before* it executes; output redaction is conditional because a streamed response
+has already reached the client.
+
+**n8n** — routes the verdict to a named output instead of enforcing it, so every
+capability past monitoring depends on how the workflow is wired: a **Block**
+branch reconnected to the agent is monitoring. It has no hook inside an AI Agent
+node's loop, so tool coverage is only what the graph makes explicit.
 
 **Application** — every capability is reachable because you hold the payload, and
 none is automatic. Code that logs a `block` and calls the model anyway is
@@ -177,9 +249,7 @@ queue consumers bypass them.
 
 **Edge / WAF** — the documented integrations inspect the request body and return
 403 on `block`; the response path is not inspected. They protect your own
-applications, not employee use of third-party AI. Watch the runtime limits:
-CloudFront **truncates** an oversized viewer-request body silently, so a long
-prompt is evaluated only in part.
+applications, not employee use of third-party AI.
 
 ## Choosing
 
@@ -187,10 +257,12 @@ prompt is evaluated only in part.
 | --- | --- |
 | Masking sensitive data in flight | [TrustGate](/trustguard/integrations/trustgate) — the only collector that rewrites payloads on every surface, including streams. [LiteLLM](/trustguard/integrations/litellm) and [Portkey](/trustguard/integrations/portkey) rewrite non-streaming completions once their native guardrails ship |
 | Coverage of streaming completions | [TrustGate](/trustguard/integrations/trustgate) |
+| A confirmation dialog in front of the developer | [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor) or [GitHub Copilot](/trustguard/integrations/copilot) — the only collectors that honour `ask` |
+| Inspection of tool declarations, for tool poisoning | [TrustGate](/trustgate/mcp/overview) on MCP, or [LangChain](/trustguard/integrations/langchain) inside the agent |
 | Enforcement as a visible step in a low-code workflow | [n8n](/trustguard/integrations/n8n) — the verdict becomes a branch on the canvas, enforced by how you wire it |
 | Org-wide Claude coverage nobody can disable | [Claude Enterprise](/trustguard/integrations/claude-enterprise) |
 | Stopping a specific shell command or MCP call | [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor), [Codex](/trustguard/integrations/codex), [Copilot](/trustguard/integrations/copilot) |
-| A policy decision that needs application context | [Application](/trustguard/integrations/python-sdk) collectors |
+| A policy decision that needs application context | The [SDK](/trustguard/integrations/python-sdk) or [REST](/trustguard/integrations/rest) collectors |
 | Coverage without touching application code | A [gateway](/trustguard/integrations/trustgate) or [edge](/trustguard/integrations/cloudflare) collector |
 
 <Note>

--- a/trustguard/integrations/coverage.mdx
+++ b/trustguard/integrations/coverage.mdx
@@ -88,32 +88,62 @@ and their agents do; neither sees the other.
 ## LLM interactions
 
 **Input** is the request sent to the model provider — prompts, tool definitions,
-tool call arguments and tool results. **Output** is the model's response.
+tool call arguments and tool results. **Output** is the model's response. One
+table each, so neither needs scrolling sideways to read.
 
-| Collector | In · monitor | In · block | In · redact | Out · monitor | Out · block | Out · redact |
-| --- | :--: | :--: | :--: | :--: | :--: | :--: |
-| TrustGate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Portkey | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
-| LiteLLM | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
-| Kong | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| Apigee | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| Azure APIM | ✅ | ✅ | ❌ | ⚠️ | ⚠️ | ❌ |
-| LangChain | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
-| n8n | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Claude Enterprise | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
-| Claude Code | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
-| Cursor | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
-| Codex | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ |
-| GitHub Copilot | ✅ | ❌ | ❌ | ➖ | ➖ | ➖ |
-| Python SDK | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Node.js SDK | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| REST | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Python middleware | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Node.js middleware | ✅ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| Cloudflare | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| CloudFront | ⚠️ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Fastly | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Akamai | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+### Input
+
+| Collector | Monitor | Block | Redact |
+| --- | :--: | :--: | :--: |
+| TrustGate | ✅ | ✅ | ✅ |
+| Portkey | ✅ | ✅ | ⚠️ |
+| LiteLLM | ✅ | ✅ | ⚠️ |
+| Kong | ✅ | ✅ | ❌ |
+| Apigee | ✅ | ✅ | ❌ |
+| Azure APIM | ✅ | ✅ | ❌ |
+| LangChain | ✅ | ✅ | ✅ |
+| n8n | ✅ | ⚠️ | ⚠️ |
+| Claude Enterprise | ✅ | ✅ | ❌ |
+| Claude Code | ✅ | ✅ | ❌ |
+| Cursor | ✅ | ✅ | ❌ |
+| Codex | ✅ | ✅ | ❌ |
+| GitHub Copilot | ✅ | ❌ | ❌ |
+| Python SDK | ✅ | ⚠️ | ⚠️ |
+| Node.js SDK | ✅ | ⚠️ | ⚠️ |
+| REST | ✅ | ⚠️ | ⚠️ |
+| Python middleware | ✅ | ⚠️ | ⚠️ |
+| Node.js middleware | ✅ | ⚠️ | ⚠️ |
+| Cloudflare | ✅ | ✅ | ❌ |
+| CloudFront | ⚠️ | ✅ | ❌ |
+| Fastly | ✅ | ✅ | ❌ |
+| Akamai | ✅ | ✅ | ❌ |
+
+### Output
+
+| Collector | Monitor | Block | Redact |
+| --- | :--: | :--: | :--: |
+| TrustGate | ✅ | ✅ | ✅ |
+| Portkey | ✅ | ✅ | ⚠️ |
+| LiteLLM | ✅ | ✅ | ⚠️ |
+| Kong | ✅ | ✅ | ❌ |
+| Apigee | ✅ | ✅ | ❌ |
+| Azure APIM | ⚠️ | ⚠️ | ❌ |
+| LangChain | ✅ | ✅ | ⚠️ |
+| n8n | ✅ | ⚠️ | ⚠️ |
+| Claude Enterprise | ➖ | ➖ | ➖ |
+| Claude Code | ➖ | ➖ | ➖ |
+| Cursor | ➖ | ➖ | ➖ |
+| Codex | ➖ | ➖ | ➖ |
+| GitHub Copilot | ➖ | ➖ | ➖ |
+| Python SDK | ✅ | ⚠️ | ⚠️ |
+| Node.js SDK | ✅ | ⚠️ | ⚠️ |
+| REST | ✅ | ⚠️ | ⚠️ |
+| Python middleware | ✅ | ⚠️ | ⚠️ |
+| Node.js middleware | ✅ | ⚠️ | ⚠️ |
+| Cloudflare | ❌ | ❌ | ❌ |
+| CloudFront | ❌ | ❌ | ❌ |
+| Fastly | ❌ | ❌ | ❌ |
+| Akamai | ❌ | ❌ | ❌ |
 
 **TrustGate is the only collector that inspects streaming responses.** Its
 `post_response` stage buffers the stream and inspects it after the client drain.
@@ -137,32 +167,62 @@ Enforcement happens at the tool events.
 ## Tool-level interactions
 
 These collectors apply policy between an agent and its tools — MCP servers,
-shell, patches.
+shell, patches. The **call** is what the agent is about to do; the **result** is
+what the tool sends back.
 
-| Collector | Call · monitor | Call · block | Call · redact | Result · monitor | Result · block | Result · redact |
-| --- | :--: | :--: | :--: | :--: | :--: | :--: |
-| TrustGate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Portkey | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| LiteLLM | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Kong | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Apigee | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Azure APIM | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| LangChain | ✅ | ✅ | ⚠️ | ✅ | ✅ | ⚠️ |
-| n8n | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Claude Enterprise | ✅ | ⚠️ | ❌ | ✅ | ⚠️ | ❌ |
-| Claude Code | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| Cursor | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| Codex | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| GitHub Copilot | ✅ | ✅ | ❌ | ✅ | ⚠️ | ❌ |
-| Python SDK | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Node.js SDK | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| REST | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| Python middleware | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Node.js middleware | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Cloudflare | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| CloudFront | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Fastly | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Akamai | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+### Tool call
+
+| Collector | Monitor | Block | Redact |
+| --- | :--: | :--: | :--: |
+| TrustGate | ✅ | ✅ | ✅ |
+| Portkey | ⚠️ | ⚠️ | ⚠️ |
+| LiteLLM | ⚠️ | ⚠️ | ⚠️ |
+| Kong | ➖ | ➖ | ➖ |
+| Apigee | ➖ | ➖ | ➖ |
+| Azure APIM | ➖ | ➖ | ➖ |
+| LangChain | ✅ | ✅ | ⚠️ |
+| n8n | ⚠️ | ⚠️ | ⚠️ |
+| Claude Enterprise | ✅ | ⚠️ | ❌ |
+| Claude Code | ✅ | ✅ | ❌ |
+| Cursor | ✅ | ✅ | ❌ |
+| Codex | ✅ | ✅ | ❌ |
+| GitHub Copilot | ✅ | ✅ | ❌ |
+| Python SDK | ⚠️ | ⚠️ | ⚠️ |
+| Node.js SDK | ⚠️ | ⚠️ | ⚠️ |
+| REST | ⚠️ | ⚠️ | ⚠️ |
+| Python middleware | ➖ | ➖ | ➖ |
+| Node.js middleware | ➖ | ➖ | ➖ |
+| Cloudflare | ➖ | ➖ | ➖ |
+| CloudFront | ➖ | ➖ | ➖ |
+| Fastly | ➖ | ➖ | ➖ |
+| Akamai | ➖ | ➖ | ➖ |
+
+### Tool result
+
+| Collector | Monitor | Block | Redact |
+| --- | :--: | :--: | :--: |
+| TrustGate | ✅ | ✅ | ✅ |
+| Portkey | ⚠️ | ⚠️ | ⚠️ |
+| LiteLLM | ⚠️ | ⚠️ | ⚠️ |
+| Kong | ➖ | ➖ | ➖ |
+| Apigee | ➖ | ➖ | ➖ |
+| Azure APIM | ➖ | ➖ | ➖ |
+| LangChain | ✅ | ✅ | ⚠️ |
+| n8n | ⚠️ | ⚠️ | ⚠️ |
+| Claude Enterprise | ✅ | ⚠️ | ❌ |
+| Claude Code | ✅ | ✅ | ❌ |
+| Cursor | ✅ | ✅ | ❌ |
+| Codex | ✅ | ✅ | ❌ |
+| GitHub Copilot | ✅ | ⚠️ | ❌ |
+| Python SDK | ⚠️ | ⚠️ | ⚠️ |
+| Node.js SDK | ⚠️ | ⚠️ | ⚠️ |
+| REST | ⚠️ | ⚠️ | ⚠️ |
+| Python middleware | ➖ | ➖ | ➖ |
+| Node.js middleware | ➖ | ➖ | ➖ |
+| Cloudflare | ➖ | ➖ | ➖ |
+| CloudFront | ➖ | ➖ | ➖ |
+| Fastly | ➖ | ➖ | ➖ |
+| Akamai | ➖ | ➖ | ➖ |
 
 The middleware collectors see HTTP routes, not model or tool calls, which is why
 they have no tool surface at all while the SDKs do.

--- a/trustguard/integrations/cursor.mdx
+++ b/trustguard/integrations/cursor.mdx
@@ -28,7 +28,6 @@ endpoint whose tool calls still pass through the firewall hooks above.
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
-| Tool listing | ❌ | ❌ | ❌ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ✅ | ❌ |
 

--- a/trustguard/integrations/overview.mdx
+++ b/trustguard/integrations/overview.mdx
@@ -27,8 +27,25 @@ does not cover, see **[Coverage](/trustguard/integrations/coverage)**.
 AI assistants and coding agents create two exposures: what employees **tell**
 them (secrets and PII in prompts, jailbreaks) and what the agents **do** (shell
 commands, patches, MCP tool calls, and the untrusted content those tools
-return). Inference Hooks cover the first org-wide with nothing on laptops; the
-per-machine plugins cover both, at action level.
+return).
+
+**Which one you need:**
+
+- **[Claude Enterprise](/trustguard/integrations/claude-enterprise)** — org-wide
+  control of the *prompt* in Claude, enforced server-side by Anthropic. Nothing
+  is installed on any laptop and no developer can turn it off. Allow or deny
+  only: no redaction, no dialog, no output coverage.
+- **[Claude Code](/trustguard/integrations/claude-code),
+  [Cursor](/trustguard/integrations/cursor),
+  [Codex](/trustguard/integrations/codex) and
+  [GitHub Copilot](/trustguard/integrations/copilot)** — local hooks on the
+  developer's machine, covering *prompts and tool use* (shell, patches, MCP),
+  with a confirmation dialog wherever the client honours `ask`.
+- **Both, if you run Claude.** They are not alternatives and they do not
+  overlap: the org hook cannot see a shell command, and the laptop plugin cannot
+  cover a developer who uninstalls it or moves to claude.ai. Their gates are
+  distinct — `claude-code` matches Claude Enterprise, `claude-code-plugin`
+  matches the plugin — so a rule written for one never fires for the other.
 
 | | Runs | Sees | Can enforce |
 | --- | --- | --- | --- |

--- a/trustguard/overview.mdx
+++ b/trustguard/overview.mdx
@@ -56,13 +56,13 @@ results), not only chat.
 
 | Collector | Path | `source.application` | Enforcement |
 |---|---|---|---|
-| [Claude Enterprise](/trustguard/integrations/claude-enterprise) | Org Inference Hooks (`/v1/evaluate/claude`) | `claude-ai`, `claude-code` | Allow or deny. **Ask** is not a dialog here. |
+| [Claude Enterprise](/trustguard/integrations/claude-enterprise) | Anthropic org, server-side (`/v1/evaluate/claude`) | `claude-ai`, `claude-code` | Allow or deny only. An `ask` gate is **allowed** here — there is no dialog. |
 | [Claude Code](/trustguard/integrations/claude-code) | Laptop plugin + binary + `tgk_…` | `claude-code-plugin` | Block / Ask on input (prompt, PreToolUse) |
 | [Cursor](/trustguard/integrations/cursor) | Plugin + MDM `cursor.json` | `cursor-plugin` | Same; Ask is Cursor’s permission dialog |
 | [Codex](/trustguard/integrations/codex) | Plugin / managed hooks + `codex.json` | `codex-plugin` | Block to stop. Ask is extra context only (no dialog) |
 | [GitHub Copilot](/trustguard/integrations/copilot) | Plugin / policy hooks + `copilot.json` | `copilot-plugin` | Deny / Ask on tool use; prompt event is audit-only |
 
-A gate on `claude-code` (Inference Hooks) does **not** match the laptop plugin
+A gate on `claude-code` (Claude Enterprise, server-side) does **not** match the laptop plugin
 (`claude-code-plugin`). TrustGate MCP is an [org Connector](/trustgate/integrations/claude), not
 these plugins — do not put a `tgk_…` key on the connector.
 


### PR DESCRIPTION
Applies the review feedback on the collectors overview. Everything here is the
overview tier; the child pages (TrustGate, Cursor, Claude Enterprise, Portkey)
are the next pass, and no new collector is documented until then.

## What the review asked for, and what changed

| Feedback | Change |
| --- | --- |
| A table is governed by its first column: unambiguous, parallel entities, no repeated categories. One table per collector: `Collector \| Category \| Runs on \| Protects \| Deployed by` | All tables are keyed on the collector, 22 rows, same order throughout. Category became an attribute column. The old table keyed on the category and repeated each one twice |
| Avoid the "deployment scope" heading unless one clear sentence explains it | Heading dropped. The section is "Every collector" and opens by saying what the table holds |
| Same rule in the LLM matrix: do not put Portkey/LiteLLM/Kong/Apigee/Azure in one row when their Considerations differ | Every grouped row split. Kong, Apigee and Azure APIM each carry a different caveat, so each gets a row and its own bullet in Considerations. Also splits `Claude Code, Cursor, Codex` and `Edge / WAF (all)`, which the same rule breaks |
| Separate Application into SDK/API and Middleware | Split all the way to one row each. This surfaced something the grouped row hid: the middleware collectors have **no tool surface at all**, because they see HTTP routes rather than model or tool calls |
| Ask is missing from the model, or say how it collapses where there is no UI | Added as a fourth action, with a table of how it resolves on every collector that cannot prompt anyone. Verified per integration, and for the gateways against `guardOutcomeDecision` in the TrustGate plugin |
| Redact = DLP / `data_loss_prevention`, not "data loss" in general | Named after the detector that produces it |
| Inference Hooks is not a category or a multi-vendor standard: rename to Claude Enterprise, and add the choose-rule | Renamed everywhere. The term now appears once in the whole repo, in prose on its own page, as the org-level hook Anthropic calls Inference Hooks. Choose-rule added to `integrations/overview`, including the case for running both |
| Take tool listing out, or reduce it to a note under TrustGate/MCP | The two listing columns are gone — near-empty across 22 rows — replaced by a note scoped to TrustGate and MCP. The row also came off the four agent-plugin pages, where it read ❌ ❌ ❌ |
| `claude.aiy` → `claude.ai` | Not a typo in the docs. The source reads `` `claude.ai` y Cowork``; the page it was reviewed on printed the backtick literally |
| Copilot is in the live docs: include it or say why it is out | Already included: rows in both matrices, its own page, and the note that its prompt event is audit-only. It was missing from the copy under review, which was a stale duplicate — retired separately in NeuralTrust/TrustGuard |

## Two things found while doing it

**The matrices did not fit the page.** Keying them on the collector made them
seven columns wide, and Mintlify caps the prose column: on a 1440px viewport
only four columns were visible, with the whole Output half outside the scroll
area. `mode: "wide"` does not help — it removes the right-hand table of
contents and leaves the text column the same width. Each matrix is now two
tables of four columns, under Input/Output and Tool call/Tool result
subheadings. Same rows, same order, same values.

**A competitor product name was in the published docs.** The Codex page named
Prisma AIRS, a Palo Alto Networks product, to disambiguate which Codex
extension point the plugin uses. "Codex External guardrails" is already the
name of that feature, so the brand added nothing. Pre-existing, from 8f92fff.

**A navigation entry pointed at a missing page.** `docs.json` referenced
`trusttest/getting-started/tutorials/llm-as-a-judge`; the file is
`llm-as-judge.mdx`. It was a 404 in the published navigation and `mintlify dev`
warned about it on every boot.

## Verification

Rendered locally with `mintlify dev` and checked in the browser, not only in the
markdown — which is how the two layout problems above surfaced.

- 200 internal links across the changed files, none broken
- Every navigation entry resolves to a file that exists
- No malformed tables; row counts 22 / 22 / 22 / 22 on the four matrices
- No competitor brand anywhere in the repo

## Out of scope

- Child pages: TrustGate, Cursor, Claude Enterprise, Portkey. Their per-page
  coverage tables still use the three-capability framing without an Ask row.
- The console catalog and these docs disagree on two category names: the console
  says "AI assistants & coding agents" and "WAF", the docs say "IDE & coding
  agents" and "Edge / WAF". The Category column deliberately claims to name the
  docs grouping, not the catalog. Worth settling, but renaming the navigation
  was not part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)