### PR TITLE
ci: run on develop PRs, and check the navigation resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
-# CI pipeline for PRs targeting main
-# Runs: AI code review → Lint & Tests (Python) → SAST → auto-approve
+# CI pipeline for pull requests
+# Runs: navigation check → SAST
 
 name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +20,14 @@ permissions:
   id-token: write
 
 jobs:
+  navigation:
+    name: Navigation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: docs.json is valid and every page it lists exists
+        run: python3 scripts/check-navigation.py
+
   security:
     uses: NeuralTrust/workflows/.github/workflows/sast.yml@main
     with:

--- a/scripts/check-navigation.py
+++ b/scripts/check-navigation.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Check that docs.json is valid and every page it lists exists.
+
+A page entry is any string inside a "pages" array. Group and tab names are not
+paths, so they are not checked — that distinction matters, because a group can
+legitimately be called "Edge / WAF" and would look like a path to a looser rule.
+
+Run it before opening a PR:
+
+    python3 scripts/check-navigation.py
+"""
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOCS_JSON = ROOT / "docs.json"
+
+
+def page_entries(node):
+    """Yield every string that sits inside a "pages" array."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "pages" and isinstance(value, list):
+                for item in value:
+                    if isinstance(item, str):
+                        yield item
+                    else:
+                        yield from page_entries(item)
+            else:
+                yield from page_entries(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from page_entries(item)
+
+
+def resolves(page):
+    if page.startswith(("http://", "https://")):
+        return True
+    return (ROOT / f"{page}.mdx").is_file() or (ROOT / page / "index.mdx").is_file()
+
+
+def main():
+    try:
+        docs = json.loads(DOCS_JSON.read_text())
+    except json.JSONDecodeError as exc:
+        print(f"docs.json is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    pages = list(page_entries(docs))
+    if not pages:
+        print("no page entries found in docs.json — has the schema changed?", file=sys.stderr)
+        return 1
+
+    missing = sorted({p for p in pages if not resolves(p)})
+    if missing:
+        noun = "entry points" if len(missing) == 1 else "entries point"
+        print(f"{len(missing)} navigation {noun} at a page that does not exist:", file=sys.stderr)
+        for page in missing:
+            print(f"  {page}  (expected {page}.mdx)", file=sys.stderr)
+        print(
+            "\nEach one is a 404 in the published navigation.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"docs.json is valid; {len(pages)} navigation entries all resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two problems with one cause: this repo had no CI worth running.

## Nothing ran on develop PRs

The trigger was `branches: [main]`. But `develop` is the default base — `main`
only receives release PRs from it. So **every docs PR merged with zero checks**.
#204 did, earlier today.

## The one job that existed does not apply here

```yaml
security:
  uses: NeuralTrust/workflows/.github/workflows/sast.yml@main
  with:
    bandit_enabled: true
```

Bandit is a Python security scanner. This repo has **189 `.mdx` files and zero
`.py` files**. Widening the trigger on its own would just add a green tick that
validates nothing about the documentation, which is worse than no check —
it looks like coverage.

## So this adds the check the repo needs

`scripts/check-navigation.py` verifies `docs.json` parses and that every page it
lists exists.

It caught a real one: `docs.json` pointed at
`trusttest/getting-started/tutorials/llm-as-a-judge` while the file is
`llm-as-judge.mdx` — a 404 in the published navigation. `mintlify dev` warns
about it on every boot and nobody reads the boot log. Fixed in #204; this stops
the next one.

**Only strings inside a `pages` array are treated as paths.** Group and tab
names are not paths, and that distinction is load-bearing: a looser rule that
guessed from the string shape flagged the group `"Edge / WAF"` as a missing
page. Precision here is what keeps the check from crying wolf.

It is a script rather than an inline workflow step so it can be run before
pushing:

```
python3 scripts/check-navigation.py
```

No dependencies — standard library only, no `pip install` step.

## Verification

Both directions:

```
$ python3 scripts/check-navigation.py
docs.json is valid; 168 navigation entries all resolve.

# with the llm-as-a-judge typo put back
$ python3 scripts/check-navigation.py; echo $?
1 navigation entry points at a page that does not exist:
  trusttest/getting-started/tutorials/llm-as-a-judge  (expected …/llm-as-a-judge.mdx)

Each one is a 404 in the published navigation.
1
```

## Worth deciding separately

Whether `bandit_enabled: true` should stay at all. It scans a language this repo
does not contain. I left it rather than quietly removing someone else's job, but
it is not earning its run time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)