### PR TITLE
docs: name the first column of every Coverage table, and say what ask does (RUN-1264)

### DIFF
--- a/platform/browser-extension.mdx
+++ b/platform/browser-extension.mdx
@@ -21,7 +21,7 @@ collector to create for it.
 
 ## What it covers
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | Prompt, before it is sent | ✅ | ✅ | ✅ |
 | Attachments, before upload | ✅ | ✅ | ➖ |

--- a/trustguard/integrations/akamai.mdx
+++ b/trustguard/integrations/akamai.mdx
@@ -7,11 +7,14 @@ Sub-requests only reach hosts on your Akamai property. Map TrustGuard under a pa
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ❌ | ❌ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the EdgeWorker returns 403 on `block` and forwards everything else, so
+an `ask` gate is **allowed**. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** you serve through Akamai and can map the TrustGuard endpoint
 behind your property in Property Manager. **Not when** you cannot: EdgeWorkers

--- a/trustguard/integrations/apigee.mdx
+++ b/trustguard/integrations/apigee.mdx
@@ -7,11 +7,14 @@ Call evaluate from a **Shared Flow** and raise a fault on block.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ✅ | ✅ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the Shared Flow maps the verdict onto a boolean, so an `ask` gate is
+**allowed** and recorded. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** Apigee is your API management layer and you can attach the Shared
 Flow with an environment flow hook, covering every proxy by default. **Not when**

--- a/trustguard/integrations/aws-cloudfront.mdx
+++ b/trustguard/integrations/aws-cloudfront.mdx
@@ -8,11 +8,14 @@ AWS WAF cannot call external services. Use Lambda@Edge on **viewer request** wit
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ❌ | ❌ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the function returns 403 on `block` and forwards everything else, so an
+`ask` gate is **allowed**. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** you serve AI endpoints through CloudFront and want the control
 alongside AWS WAF. **Not when** your prompts exceed the viewer-request body

--- a/trustguard/integrations/azure-apim.mdx
+++ b/trustguard/integrations/azure-apim.mdx
@@ -7,11 +7,14 @@ Use **`send-request`** on inbound (prompt) and outbound (completion).
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ✅ | ✅ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the policy maps the verdict onto a boolean, so an `ask` gate is
+**allowed** and recorded. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** you publish AI APIs through APIM and want the control alongside
 your other policies. **Not when** you will only deploy the inbound policy and

--- a/trustguard/integrations/claude-code.mdx
+++ b/trustguard/integrations/claude-code.mdx
@@ -30,12 +30,15 @@ Under the hood the plugin registers Claude Code **lifecycle hooks** that call
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ✅ | ❌ |
+
+**Ask** — honoured natively, through Claude Code's own permission dialog, on
+prompts and on tool calls.
 
 **Use it when** you want to stop a specific shell command or MCP call on
 developer machines. **Not when** you expect to see or block the model's

--- a/trustguard/integrations/claude-enterprise.mdx
+++ b/trustguard/integrations/claude-enterprise.mdx
@@ -35,13 +35,17 @@ stamp different `source.application` values, so they gate independently.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
 | Tool listing | ✅ | ⚠️ | ➖ |
 | Tool call | ✅ | ⚠️ | ❌ |
 | Tool result | ✅ | ⚠️ | ❌ |
+
+**Ask** — the Claude dialect answers allow or deny only and there is no IDE
+prompt on this path, so an `ask` gate resolves to **allowed**. Use the
+[Claude Code plugin](/trustguard/integrations/claude-code) where you need a dialog.
 
 **Use it when** you need org-wide coverage no user can disable, with nothing
 installed on laptops. **Not when** you need per-tool control or masking — pair it

--- a/trustguard/integrations/cloudflare.mdx
+++ b/trustguard/integrations/cloudflare.mdx
@@ -6,11 +6,14 @@ description: "TrustGuard Worker on AI routes."
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ❌ | ❌ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the Worker returns 403 on `block` and forwards everything else, so an
+`ask` gate is **allowed**. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** you already terminate traffic at Cloudflare and want flagged
 content blocked before it reaches your origin, with no application changes.

--- a/trustguard/integrations/codex.mdx
+++ b/trustguard/integrations/codex.mdx
@@ -28,12 +28,15 @@ hooks + config (enterprise).
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ✅ | ❌ |
+
+**Ask** — Codex has no dialog: an `ask` gate is **allowed**, plus a warning
+injected as context the agent sees. Treat it as advisory here.
 
 **Use it when** your developers use Codex and you can deploy the hook scripts by
 MDM alongside the config. **Not when** your policy leans on `ask` gates — Codex

--- a/trustguard/integrations/copilot.mdx
+++ b/trustguard/integrations/copilot.mdx
@@ -24,12 +24,15 @@ under `.github/hooks/*.json` — see [Cloud coding agent](#cloud-coding-agent).
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ❌ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ⚠️ | ❌ |
+
+**Ask** — honoured on tool calls, through Copilot's approval prompt. In Copilot
+cloud there is no user present, so `ask` becomes deny.
 
 **Use it when** your developers use Copilot CLI or Agent mode and you want its
 tool calls governed. **Not when** you need to stop a prompt: Copilot discards

--- a/trustguard/integrations/coverage.mdx
+++ b/trustguard/integrations/coverage.mdx
@@ -45,7 +45,8 @@ difference matters:
 | [n8n](/trustguard/integrations/n8n) | **Blocked** — a workflow cannot prompt anyone mid-run. `trustguard.status` stays `ask` so you can branch off it; from 0.2.0 the node no longer fails on it. |
 | [LangChain](/trustguard/integrations/langchain) | **Blocked** — the middleware has no case for `ask`, and an unknown verdict fails closed. |
 | [Claude Enterprise](/trustguard/integrations/claude-enterprise) | **Allowed** — the Claude dialect answers allow or deny only, and there is no IDE prompt on this path. |
-| Gateways and Edge / WAF | **Allowed**, and recorded. There is no user to prompt and the verdict is not `block`, so the request passes through. |
+| [TrustGate](/trustguard/integrations/trustgate) | **Blocked** — a gateway has nobody to prompt, so it applies the most restrictive verdict it can express. In observe mode it is recorded instead. |
+| The other gateways, Edge / WAF | **Allowed**, and recorded. Each maps the verdict onto a boolean, and `ask` is not `block`, so the request passes through. |
 | Application collectors | **Yours to implement.** `status` is advisory; nothing prompts anyone unless your code does. |
 
 Legend for the matrices: ✅ supported · ⚠️ conditional · ❌ not supported · ➖ the
@@ -248,6 +249,8 @@ closest to the developer. Route MCP through
 5xx it **fails open** unless the policy sets fail-closed; auth and entitlement
 failures always block. In observe mode a `transform` is logged, not applied. A
 `transform` that cannot be applied safely blocks rather than forwarding unmasked.
+An `ask` is enforced like a block, since there is nobody at a gateway to prompt;
+the other gateways forward it instead.
 
 **Portkey** — the native plugin holds the request body, so it consumes
 `transformed_payload` on chat completions, text completions and Anthropic
@@ -317,7 +320,7 @@ applications, not employee use of third-party AI.
 | --- | --- |
 | Masking sensitive data in flight | [TrustGate](/trustguard/integrations/trustgate) — the only collector that rewrites payloads on every surface, including streams. [LiteLLM](/trustguard/integrations/litellm) and [Portkey](/trustguard/integrations/portkey) rewrite non-streaming completions once their native guardrails ship |
 | Coverage of streaming completions | [TrustGate](/trustguard/integrations/trustgate) |
-| A confirmation dialog in front of the developer | [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor) or [GitHub Copilot](/trustguard/integrations/copilot) — the only collectors that honour `ask` |
+| A confirmation dialog in front of the developer | [Claude Code](/trustguard/integrations/claude-code), [Cursor](/trustguard/integrations/cursor) or [GitHub Copilot](/trustguard/integrations/copilot) — the only collectors that can prompt anyone. Everywhere else `ask` collapses, and not the same way |
 | Inspection of tool declarations, for tool poisoning | [TrustGate](/trustgate/mcp/overview) on MCP, or [LangChain](/trustguard/integrations/langchain) inside the agent |
 | Enforcement as a visible step in a low-code workflow | [n8n](/trustguard/integrations/n8n) — the verdict becomes a branch on the canvas, enforced by how you wire it |
 | Org-wide Claude coverage nobody can disable | [Claude Enterprise](/trustguard/integrations/claude-enterprise) |

--- a/trustguard/integrations/cursor.mdx
+++ b/trustguard/integrations/cursor.mdx
@@ -60,7 +60,7 @@ the `tgk_…` collector key as an MCP credential.
 
 ## What IT deploys vs what developers install
 
-| | Who | What |
+| Component | Who | What |
 | --- | --- | --- |
 | **Plugin** | Each developer (or Team Marketplace / standard rollout) | Import from GitHub — see below |
 | **Firewall config** | IT / MDM | `cursor.json` with the org `tgk_…` key |

--- a/trustguard/integrations/cursor.mdx
+++ b/trustguard/integrations/cursor.mdx
@@ -24,12 +24,15 @@ endpoint whose tool calls still pass through the firewall hooks above.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ➖ | ➖ | ➖ |
 | Tool call | ✅ | ✅ | ❌ |
 | Tool result | ✅ | ✅ | ❌ |
+
+**Ask** — honoured on tool calls, through Cursor's approval prompt. There is no
+dialog at the prompt event, so an `ask` on a prompt is enforced as a block.
 
 **Use it when** your developers work with the Cursor agent and you want its tool
 calls governed from one org key. **Not when** you rely on `ask` stopping a

--- a/trustguard/integrations/fastly.mdx
+++ b/trustguard/integrations/fastly.mdx
@@ -6,11 +6,14 @@ description: "TrustGuard from a Fastly Compute service."
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ❌ | ❌ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the service returns 403 on `block` and forwards everything else, so an
+`ask` gate is **allowed**. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** you already serve through Fastly Compute and can declare backends
 for TrustGuard and for your origin. **Not when** you cannot manage the service's

--- a/trustguard/integrations/kong.mdx
+++ b/trustguard/integrations/kong.mdx
@@ -8,11 +8,14 @@ evaluate.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ❌ |
 | LLM output | ✅ | ✅ | ❌ |
 | Tool-level | ➖ | ➖ | ➖ |
+
+**Ask** — the plugin maps the verdict onto a boolean, so an `ask` gate is
+**allowed** and recorded. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** Kong AI Proxy is already configured on the routes you protect.
 **Not when** you do not use AI Proxy — `ai-custom-guardrail` does not work on its

--- a/trustguard/integrations/langchain.mdx
+++ b/trustguard/integrations/langchain.mdx
@@ -114,6 +114,7 @@ The middleware never changes the meaning of a verdict, only how it is applied to
 | `report` | Continues and fires `on_violation`. On the hook stages it also records the findings on the message's `additional_kwargs["trustguard"]`; on the `check_tool_calls` stage there is no message to write to, so `on_violation` is the only place a tool-call report surfaces. |
 | `block` | Applies `exit_behavior`, below. |
 | `transform` | Rewrites the matching messages **preserving `message.id`**, so LangChain replaces them instead of appending a second copy. |
+| `ask` | **Blocks.** The middleware has no case for it, and an unknown verdict fails closed — see below. An agent has nobody to prompt, so this is the safe collapse rather than an oversight, but write the rule as **Block** if that is what you mean. |
 
 Preserving the id is what makes `transform` usable in an agent: a redacted message must occupy the
 same slot in the thread, or the model sees both the original and the redaction.

--- a/trustguard/integrations/litellm.mdx
+++ b/trustguard/integrations/litellm.mdx
@@ -18,11 +18,14 @@ This page covers only the LiteLLM connection. Other gateways: [TrustGate](/trust
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ⚠️ |
 | LLM output | ✅ | ✅ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — the guardrail maps the verdict onto a boolean, so an `ask` gate is
+**allowed** and recorded. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** you run a LiteLLM proxy and want every client behind it covered without
 touching application code.

--- a/trustguard/integrations/n8n.mdx
+++ b/trustguard/integrations/n8n.mdx
@@ -17,11 +17,15 @@ reconciles with **Activity**, and `transform` rewrites the payload in flight.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ⚠️ | ⚠️ |
 | LLM output | ✅ | ⚠️ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — a workflow cannot prompt anyone mid-run, so the node applies **Block**
+and leaves `trustguard.status` as `ask` for you to branch on. From 0.2.0 it no
+longer fails on it.
 
 **Use it when** you already build AI workflows in n8n and want enforcement to be an explicit edge
 in the graph. **Not when** the guarantee has to hold for traffic you do not control — the gate

--- a/trustguard/integrations/node-middleware.mdx
+++ b/trustguard/integrations/node-middleware.mdx
@@ -8,11 +8,14 @@ Middleware for **input**. Call `guard` again with `direction: "output"` after th
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ⚠️ | ⚠️ |
 | LLM output | ✅ | ⚠️ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — `status` is advisory: nothing prompts anyone unless your code does.
+A middleware has no user to prompt on the HTTP path either.
 
 **Use it when** you want every new AI route covered by configuration rather than
 by each developer's discipline. **Not as your only defence when** traffic reaches

--- a/trustguard/integrations/node-sdk.mdx
+++ b/trustguard/integrations/node-sdk.mdx
@@ -8,11 +8,13 @@ the model, `output` after). Defaults to `input` if omitted.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ⚠️ | ⚠️ |
 | LLM output | ✅ | ⚠️ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — `status` is advisory: nothing prompts anyone unless your code does.
 
 **Use it when** the model call lives in your JavaScript or TypeScript code and
 the policy decision needs application context. **Not as your only defence when**

--- a/trustguard/integrations/overview.mdx
+++ b/trustguard/integrations/overview.mdx
@@ -13,7 +13,7 @@ does not cover, see **[Coverage](/trustguard/integrations/coverage)**.
 
 ## Gateway
 
-| | |
+| Collector | How it connects |
 | --- | --- |
 | [TrustGate](/trustguard/integrations/trustgate) | Native — no collector API key |
 | [Portkey](/trustguard/integrations/portkey) | BYOG webhook; native `neuraltrust` plugin pending |
@@ -47,7 +47,7 @@ return).
   distinct — `claude-code` matches Claude Enterprise, `claude-code-plugin`
   matches the plugin — so a rule written for one never fires for the other.
 
-| | Runs | Sees | Can enforce |
+| Collector | Runs | Sees | Can enforce |
 | --- | --- | --- | --- |
 | [Claude Enterprise](/trustguard/integrations/claude-enterprise) | Anthropic org (server-side, no install) | Every model request from Claude chat, Claude Code, Cowork | Allow / deny |
 | [Claude Code](/trustguard/integrations/claude-code) | Dev machine (plugin + MDM) | Prompts · tool calls (shell, MCP) · tool results | Block · **Ask** · report |
@@ -61,14 +61,14 @@ Guards that run inside your agent or workflow rather than on the HTTP path. Lang
 agent loop, so a pending tool call can be gated before it executes; the n8n node is a step in
 the graph, so it gates what you route through it.
 
-| | Package | Gates |
+| Collector | Package | Gates |
 | --- | --- | --- |
 | [LangChain](/trustguard/integrations/langchain) | `langchain-neuraltrust` | Prompts · responses · tool calls, before they execute |
 | [n8n](/trustguard/integrations/n8n) | `@neuraltrust/n8n-nodes-trustguard` | Prompts · responses, as a branch in the workflow |
 
 ## Application
 
-| | Package |
+| Collector | Package |
 | --- | --- |
 | [Python SDK](/trustguard/integrations/python-sdk) | `trustguard-sdk` |
 | [Node.js SDK](/trustguard/integrations/node-sdk) | `@neuraltrust/trustguard-sdk` |

--- a/trustguard/integrations/portkey.mdx
+++ b/trustguard/integrations/portkey.mdx
@@ -18,11 +18,14 @@ This page covers only the Portkey connection. Other gateways: [TrustGate](/trust
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ⚠️ |
 | LLM output | ✅ | ✅ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — the integration maps the verdict onto a boolean, so an `ask` gate is
+**allowed** and recorded. Write the rule as **Block** if you need a hard stop.
 
 **Use it when** your apps already reach models through a Portkey config and you want one policy
 for all of them.

--- a/trustguard/integrations/python-middleware.mdx
+++ b/trustguard/integrations/python-middleware.mdx
@@ -8,11 +8,14 @@ Middleware covers **input**. Guard completions in the route with `direction="out
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ⚠️ | ⚠️ |
 | LLM output | ✅ | ⚠️ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — `status` is advisory: nothing prompts anyone unless your code does.
+A middleware has no user to prompt on the HTTP path either.
 
 **Use it when** you want every new AI route covered by configuration rather than
 by someone remembering to add the check. **Not as your only defence when**

--- a/trustguard/integrations/python-sdk.mdx
+++ b/trustguard/integrations/python-sdk.mdx
@@ -8,11 +8,13 @@ the model, `output` after). Defaults to `input` if omitted.
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ⚠️ | ⚠️ |
 | LLM output | ✅ | ⚠️ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — `status` is advisory: nothing prompts anyone unless your code does.
 
 **Use it when** the model call lives in your Python code and the policy decision
 needs context only the application has — the authenticated user, the tenant, the

--- a/trustguard/integrations/rest.mdx
+++ b/trustguard/integrations/rest.mdx
@@ -11,11 +11,13 @@ Create an API key on the collector first. Set `direction` on every call (`input`
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ⚠️ | ⚠️ |
 | LLM output | ✅ | ⚠️ | ⚠️ |
 | Tool-level | ⚠️ | ⚠️ | ⚠️ |
+
+**Ask** — `status` is advisory: nothing prompts anyone unless your code does.
 
 **Use it when** your runtime has no published SDK, or adding a dependency is not
 an option. **Not when** you are on Python, Node or Go: the SDKs already handle

--- a/trustguard/integrations/trustgate.mdx
+++ b/trustguard/integrations/trustgate.mdx
@@ -13,13 +13,16 @@ to TrustGuard. Other gateways (Portkey, LiteLLM, Kong, …) still use a collecto
 
 ## Coverage
 
-| | Monitor | Block | Redact |
+| Surface | Monitor | Block | Redact |
 | --- | :--: | :--: | :--: |
 | LLM input | ✅ | ✅ | ✅ |
 | LLM output | ✅ | ✅ | ✅ |
 | Tool listing | ✅ | ✅ | ➖ |
 | Tool call | ✅ | ✅ | ✅ |
 | Tool result | ✅ | ✅ | ✅ |
+
+**Ask** — a gateway has nobody to prompt, so an `ask` gate is enforced like a
+block: denied in enforce mode, recorded in observe.
 
 **Use it when** you already route through TrustGate, or when you need any of the
 three things no other collector gives you: real in-flight masking, inspection of

--- a/trustguard/integrations/trustgate.mdx
+++ b/trustguard/integrations/trustgate.mdx
@@ -34,6 +34,26 @@ not want one in the data path — see the
 **Limits.** Redaction applies to [data-loss](/trustguard/detectors/data-loss-prevention)
 outcomes only. In observe mode a `transform` is logged, not applied.
 
+### Tool declarations
+
+The **Tool listing** row is the one surface almost nothing else covers, and it is
+the reason to route MCP through the gateway.
+
+A tool *declaration* is the tool's description and parameter schema — not a call,
+not a result. It is what an agent reads before deciding to act, which makes it
+where [tool poisoning](/trustguard/detectors/agent-mcp-security) hides: a server
+that describes a benign-looking tool in language crafted to steer the agent.
+Declarations are scored by indirect prompt injection over LLM `tools[]` and MCP
+[`tools/list`](/trustgate/mcp/overview).
+
+TrustGate sees them because the declarations pass through it. The
+developer-machine plugins — Claude Code, Cursor, Codex, Copilot — send tool
+*calls* and *results* and never the list, so tool-poisoning detection does not
+apply on the surface closest to the developer. That is the gap this closes.
+
+Redaction is `➖` rather than `❌`: a declaration is not a payload to mask. A
+poisoned one is blocked, not rewritten.
+
 Full comparison: [Coverage](/trustguard/integrations/coverage).
 
 ## Setup


### PR DESCRIPTION
RUN-1264. https://linear.app/neuraltrust/issue/RUN-1264

Second half of Joan's review of the collectors documentation. The overview
landed in #204; these are the child pages, which is the step he put next and
what unblocks NeuralTrust/TrustGuard#548.

## First, a correctness fix I owed

`coverage.mdx` said an `ask` gate on a gateway is **allowed**. That stopped
being true when NeuralTrust/TrustGate#628 merged — it now enforces `ask` like a
block, denied in enforce mode, recorded in observe.

The row grouped TrustGate with every other gateway and the edge collectors, and
that group no longer agrees: the others map the verdict onto a boolean in their
own plugin code, which nothing changed, so they still forward it. Split by the
same rule the rest of the page follows.

**My own code change made the merged documentation wrong.** Worth noting as a
pattern: a behaviour change in TrustGate or TrustGuard can invalidate a
statement in the docs repo, and nothing links the two.

## Then the two defects across the whole set

**21 Coverage tables had an unnamed first column.**

```
| | Monitor | Block | Redact |
| --- | :--: | :--: | :--: |
| LLM input | ✅ | ✅ | ❌ |
```

The rows are surfaces — LLM input, LLM output, Tool call, Tool result — which is
unambiguous and parallel, so the *entries* were always fine. Nothing said so. A
table is governed by its first column, and an unnamed one makes the reader infer
what the rows even are. It is now `Surface`.

**No page reflected the `ask` action.** All 21 were Monitor / Block / Redact,
while the overview now documents four actions and a table of how `ask` collapses
per collector. The pages contradicted it by omission — and `ask` is precisely
the axis that decides between Claude Code, Cursor, Codex and Copilot.

Each page now states what an `ask` gate does there, taken from the reviewed
table in `coverage.mdx`.

## Why prose and not a fourth column

The same reason the overview keeps `ask` out of its matrices: it does not vary
by surface the way Monitor, Block and Redact do. On 17 of the 21 collectors the
column would hold one value repeated down every row.

And where it *does* vary, prose is more precise than a glyph could be. Cursor
honours it on tool calls but has no dialog at the prompt event, so an `ask` on a
prompt is enforced as a block. Copilot honours it on tool calls but loses the
user in cloud, where it becomes deny. Neither fits in a cell.

## LangChain

The one integration page with no Coverage section — it has its own verdict
table, which listed `allow`, `report`, `block` and `transform` and simply had no
`ask`. So the page said nothing about the verdict that hits its fail-closed
path. Added there, where it belongs on that page.

## Verification

Rendered locally with `mintlify dev` and looked at, not only checked in the
markdown — that is how the overview's unreadable matrices and a 404 in the
navigation were both found.

- No `| | Monitor | Block | Redact |` left in the repo
- All 21 pages carry an Ask note, each matching its row in `coverage.mdx`
- 118 internal links across the 22 changed files, none broken
- No malformed tables
- `scripts/check-navigation.py` passes, and `mintlify dev` now boots with no
  warnings at all — the `llm-as-a-judge` one is gone since #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)